### PR TITLE
Fix Debian 8 matching

### DIFF
--- a/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
@@ -3,7 +3,7 @@ grep:
 
     local_only_mta:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/exim4/update-exim4.conf':
               tag: 'CIS-6.15'
               pattern: "^dc_local_interfaces = '127.0.0.1'"
@@ -11,7 +11,7 @@ grep:
 
     fstab_tmp_partition:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.1'
               pattern: '/tmp'
@@ -19,7 +19,7 @@ grep:
 
     fstab_tmp_partition_nodev:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.2'
               pattern: '/tmp'
@@ -28,7 +28,7 @@ grep:
 
     fstab_tmp_partition_nosuid:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.3'
               pattern: '/tmp'
@@ -37,7 +37,7 @@ grep:
 
     fstab_tmp_partition_noexec:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.4'
               pattern: '/tmp'
@@ -46,7 +46,7 @@ grep:
 
     fstab_var_partition:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.5'
               pattern: '/var'
@@ -54,7 +54,7 @@ grep:
 
     fstab_var_tmp_bind_mount:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.6'
               pattern: '/var'
@@ -63,7 +63,7 @@ grep:
 
     fstab_var_log_partition:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.7'
               pattern: '/var/log'
@@ -71,7 +71,7 @@ grep:
 
     fstab_var_log_audit_partition:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.8'
               pattern: '/var/log/audit'
@@ -79,7 +79,7 @@ grep:
 
     fstab_home_partition:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.9'
               pattern: '/home'
@@ -87,7 +87,7 @@ grep:
 
     fstab_home_partition_nodev:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.10'
               pattern: '/home'
@@ -96,7 +96,7 @@ grep:
 
     fstab_dev_shm_partition_nodev:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.14'
               pattern: '/dev/shm'
@@ -105,7 +105,7 @@ grep:
 
     fstab_dev_shm_partition_nosuid:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.15'
               pattern: '/dev/shm'
@@ -114,7 +114,7 @@ grep:
 
     fstab_dev_shm_partition_noexec:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.16'
               pattern: '/dev/shm'
@@ -123,7 +123,7 @@ grep:
 
     configure_ntp:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ntp.conf':
               tag: 'CIS-6.5'
               pattern: 'restrict default'
@@ -131,7 +131,7 @@ grep:
 
     keep_all_auditing_information:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/audit/auditd.conf':
               tag: 'CIS-8.1.1.3'
               pattern: 'max_log_file_action'
@@ -140,7 +140,7 @@ grep:
 
     rsyslog_remote_logging:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/rsyslog.conf':
               tag: 'CIS-8.2.5'
               pattern: "^*.*[^I][^I]*@"
@@ -148,7 +148,7 @@ grep:
 
     passwd_limit_reuse:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/pam.d/common-password':
               tag: 'CIS-9.2.3'
               pattern: "remember"
@@ -157,7 +157,7 @@ grep:
 
     sshd_protocol_2:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.1'
               pattern: "^Protocol"
@@ -166,7 +166,7 @@ grep:
 
     sshd_loglevel_info:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.2'
               pattern: "^LogLevel"
@@ -175,7 +175,7 @@ grep:
 
     sshd_x11_forwarding:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.4'
               pattern: "^X11Forwarding"
@@ -184,7 +184,7 @@ grep:
 
     sshd_max_auth_retries:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.5'
               pattern: "^MaxAuthTries"
@@ -193,7 +193,7 @@ grep:
 
     sshd_ignore_rhosts:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.6'
               pattern: "^IgnoreRhosts"
@@ -202,7 +202,7 @@ grep:
 
     sshd_hostbased_auth:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.7'
               pattern: "^HostbasedAuthentication"
@@ -211,7 +211,7 @@ grep:
 
     sshd_disable_root_login:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.8'
               pattern: "^PermitRootLogin"
@@ -220,7 +220,7 @@ grep:
 
     sshd_permit_empty_passwords:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.9'
               pattern: "^PermitEmptyPasswords"
@@ -229,7 +229,7 @@ grep:
 
     sshd_permit_user_environment:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.10'
               pattern: "^PermitUserEnvironment"
@@ -238,7 +238,7 @@ grep:
 
     sshd_approved_cipher:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.11'
               pattern: "Ciphers"
@@ -247,7 +247,7 @@ grep:
 
     sshd_idle_timeout:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveInterval"
@@ -260,7 +260,7 @@ grep:
 
     sshd_limit_access:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.13'
               pattern: "^AllowUsers"
@@ -277,7 +277,7 @@ grep:
 
     sshd_banner:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.14'
               pattern: "^Banner"
@@ -285,7 +285,7 @@ grep:
 
     restrict_access_su:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/pam.d/su':
               tag: 'CIS-9.5'
               pattern: "pam_wheel.so"
@@ -293,7 +293,7 @@ grep:
 
     passwd_expiration_days:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/login.defs':
               tag: 'CIS-10.1.1'
               pattern: "PASS_MAX_DAYS"
@@ -302,7 +302,7 @@ grep:
 
     passwd_change_min_days:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/login.defs':
               tag: 'CIS-10.1.2'
               pattern: "PASS_MIN_DAYS"
@@ -311,7 +311,7 @@ grep:
 
     passwd_expiry_warning:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/login.defs':
               tag: 'CIS-10.1.3'
               pattern: "PASS_WARN_AGE"
@@ -320,7 +320,7 @@ grep:
 
     default_umask:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/bash.bashrc':
               tag: 'CIS-10.4'
               pattern: "^umask 077"
@@ -332,7 +332,7 @@ grep:
 stat:
   grub_conf_own:
     data:
-      Debian-8:
+      Debian*8:
         - '/boot/grub/grub.cfg':
             tag: 'CIS-3.1'
             user: 'root'
@@ -341,7 +341,7 @@ stat:
 
   grub_conf_perm:
     data:
-      Debian-8:
+      Debian*8:
         - '/boot/grub/grub.cfg':
             tag: 'CIS-3.2'
             mode: 600
@@ -349,7 +349,7 @@ stat:
 
     boot_loader_passwd:
       data:
-        Debian-8:
+        Debian*8:
           - '/boot/grub/grub.cfg':
               tag: 'CIS-3.3'
               pattern: "^password"
@@ -357,7 +357,7 @@ stat:
 
     restrict_core_dumps:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/security/limits.conf':
               tag: 'CIS-4.1'
               pattern: 'hard core'
@@ -365,7 +365,7 @@ stat:
 
   cron_hourly:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/cron.hourly':
             tag: 'CIS-9.1.3'
             mode: 700
@@ -375,7 +375,7 @@ stat:
 
   cron_daily:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/cron.daily':
             tag: 'CIS-9.1.4'
             mode: 700
@@ -385,7 +385,7 @@ stat:
 
   cron_weekly:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/cron.weekly':
             tag: 'CIS-9.1.5'
             mode: 700
@@ -395,7 +395,7 @@ stat:
 
   cron_monthly:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/cron.monthly':
             tag: 'CIS-9.1.6'
             mode: 700
@@ -405,7 +405,7 @@ stat:
 
   cron_d:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/cron.d':
             tag: 'CIS-9.1.7'
             mode: 700
@@ -415,7 +415,7 @@ stat:
 
   sshd_config:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/ssh/sshd_config':
             tag: 'CIS-9.3.3'
             mode: 600
@@ -425,7 +425,7 @@ stat:
 
   passwd_perm:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/passwd':
             tag: 'CIS-12.1'
             mode: 644
@@ -437,7 +437,7 @@ stat:
 
   shadow_perm:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/shadow':
             tag: 'CIS-12.2'
             mode: 640
@@ -449,7 +449,7 @@ stat:
 
   group_perm:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/group':
             tag: 'CIS-12.3'
             mode: 644
@@ -462,7 +462,7 @@ stat:
   blacklist:
     single_user_auth:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/shadow':
               tag: 'CIS-3.4'
               pattern: "^root:[*\\!]:"
@@ -470,7 +470,7 @@ stat:
 
   hosts_allow:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/hosts.allow':
             tag: 'CIS-7.4.3'
             mode: 644
@@ -478,7 +478,7 @@ stat:
 
   hosts_deny:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/hosts.deny':
             tag: 'CIS-7.4.5'
             mode: 644
@@ -486,7 +486,7 @@ stat:
 
     legacy_passwd_entries:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/passwd':
               tag: 'CIS-13.2'
               pattern: "^+:"
@@ -494,7 +494,7 @@ stat:
 
     legacy_shadow_entries:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/shadow':
               tag: 'CIS-13.3'
               pattern: "^+:"
@@ -502,7 +502,7 @@ stat:
 
     legacy_group_entries:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/group':
               tag: 'CIS-13.4'
               pattern: "^+:"
@@ -511,7 +511,7 @@ stat:
 sysctl:
   randomize_va_space:
     data:
-      Debian-8:
+      Debian*8:
         - 'kernel.randomize_va_space':
             tag: 'CIS-4.3'
             match_output: '2'
@@ -519,7 +519,7 @@ sysctl:
 
   ip_forwarding:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.ip_forward':
             tag: 'CIS-7.1.1'
             match_output: '0'
@@ -527,7 +527,7 @@ sysctl:
 
   send_packet_redirect:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.conf.all.send_redirects':
             tag: 'CIS-7.1.2'
             match_output: '0'
@@ -538,7 +538,7 @@ sysctl:
 
   source_routed_packet_acceptance:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.conf.all.accept_source_route':
             tag: 'CIS-7.2.1'
             match_output: '0'
@@ -549,7 +549,7 @@ sysctl:
 
   icmp_redirect_acceptance:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.conf.all.accept_redirects':
             tag: 'CIS-7.2.2'
             match_output: '0'
@@ -560,7 +560,7 @@ sysctl:
 
   icmp_redirect_acceptance:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.conf.all.secure_redirects':
             tag: 'CIS-7.2.3'
             match_output: '0'
@@ -571,7 +571,7 @@ sysctl:
 
   log_suspicious_packets:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.conf.all.log_martian':
             tag: 'CIS-7.2.4'
             match_output: '1'
@@ -582,7 +582,7 @@ sysctl:
 
   ignore_broadcast_requests:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.icmp_echo_ignore_broadcasts':
             tag: 'CIS-7.2.5'
             match_output: '1'
@@ -590,7 +590,7 @@ sysctl:
 
   bad_error_message_protection:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.icmp_ignore_bogus_error_responses':
             tag: 'CIS-7.2.6'
             match_output: '1'
@@ -598,7 +598,7 @@ sysctl:
 
   source_route_validation:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.conf.all.rp_filter':
             tag: 'CIS-7.2.7'
             match_output: '1'
@@ -609,7 +609,7 @@ sysctl:
 
   tcp_syn_cookies:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.tcp_syncookies':
             tag: 'CIS-7.2.8'
             match_output: '1'
@@ -620,75 +620,75 @@ pkg:
 
     prelink:
       data:
-        Debian-8:
+        Debian*8:
           - 'prelink': 'CIS-4.4'
       description: Disable Prelink
 
     nis:
       data:
-        Debian-8:
+        Debian*8:
           - 'nis': 'CIS-5.1.1'
       description: Ensure NIS is not installed
 
     rsh-clients:
       data:
-        Debian-8:
+        Debian*8:
         - 'rsh-client': CIS-5.1.3
         - 'rsh-redone-client': CIS-5.1.3
       description: Ensure rsh client is not installed
     rsh-server:
       data:
-        Debian-8:
+        Debian*8:
         - 'rsh-server': CIS-5.1.2
       description: Ensure rsh server is not enabled
 
     talk:
       data:
-        Debian-8:
+        Debian*8:
           - 'talk': 'CIS-5.1.5'
       description: Ensure talk client is not installed
 
     telnet:
       data:
-        Debian-8:
+        Debian*8:
           - 'telnet': 'CIS-5.1.6'
           - 'telnet-server': 'CIS-5.1.6'
       description: Ensure telnet server is not enabled
 
     tftp:
       data:
-        Debian-8:
+        Debian*8:
           - 'tftp': 'CIS-5.1.7'
           - 'atftp': 'CIS-5.1.7'
       description: Ensure tftp-server is not enabled
 
     xinetd:
       data:
-        Debian-8:
+        Debian*8:
           - 'xinetd': 'CIS-5.1.8'
       description: Ensure xinetd is not enabled
 
     xorg-server:
       data:
-        Debian-8:
+        Debian*8:
           - 'xserver-xorg-core': 'CIS-6.1'
       description: Ensure the X Window system is not installed
 
     avahi-daemon:
       data:
-        Debian-8:
+        Debian*8:
           - 'avahi-daemon': 'CIS-6.2'
       description: Ensure Avahi Server is not enabled
 
     dhcp:
       data:
-        Debian-8:
+        Debian*8:
           - 'isc-dhcp-server': 'CIS-6.4'
       description: Ensure DHCP Server is not enabled
 
     slapd:
       data:
-        Debian-8:
+        Debian*8:
           - 'slapd': 'CIS-6.6'
       description: Ensure LDAP is not enabled
 
@@ -696,7 +696,7 @@ pkg:
 
     apparmor:
       data:
-        Debian-8:
+        Debian*8:
           - 'apparmor': 'CIS-4.5'
           - 'apparmor-utils': 'CIS-4.5'
           - 'apparmor-profiles': 'CIS-4.5'
@@ -704,43 +704,43 @@ pkg:
 
     tcp_wrappers:
       data:
-        Debian-8:
+        Debian*8:
           - 'tcpd': 'CIS-7.4.1'
       description: Install TCP Wrappers
 
     iptables:
       data:
-        Debian-8:
+        Debian*8:
           - 'iptables': 'CIS-7.7'
           - 'iptables-persistent': 'CIS-7.7'
       description: Ensure Firewall is active
 
     auditd:
       data:
-        Debian-8:
+        Debian*8:
           - 'auditd': 'CIS-8.1.2'
       description: 'Install and Enable auditd Service (Scored)'
 
     rsyslog:
       data:
-        Debian-8:
+        Debian*8:
           - 'rsyslog': 'CIS-8.2.1'
       description: Install the rsyslog package
 
     aide:
       data:
-        Debian-8:
+        Debian*8:
           - 'aide': 'CIS-8.3.1'
       description: Install AIDE (Scored) Lvl2
 
     cracklib:
       data:
-        Debian-8:
+        Debian*8:
           - 'libpam-cracklib': 'CIS-9.2.1'
       description: Set Password Creation Requirement Parameters Using pam_cracklib
 
     openssh_server:
       data:
-        Debian-8:
+        Debian*8:
           - 'openssh-server': 'CIS-9.3'
       description: Configure SSH

--- a/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1.yaml
+++ b/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1.yaml
@@ -3,7 +3,7 @@ grep:
 
     local_only_mta:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/exim4/update-exim4.conf':
               tag: 'CIS-6.15'
               pattern: "^dc_local_interfaces = '127.0.0.1'"
@@ -11,7 +11,7 @@ grep:
 
     fstab_tmp_partition:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.1'
               pattern: '/tmp'
@@ -19,7 +19,7 @@ grep:
 
     fstab_tmp_partition_nodev:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.2'
               pattern: '/tmp'
@@ -28,7 +28,7 @@ grep:
 
     fstab_tmp_partition_nosuid:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.3'
               pattern: '/tmp'
@@ -37,7 +37,7 @@ grep:
 
     fstab_tmp_partition_noexec:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.4'
               pattern: '/tmp'
@@ -46,7 +46,7 @@ grep:
 
     fstab_var_partition:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.5'
               pattern: '/var'
@@ -54,7 +54,7 @@ grep:
 
     fstab_var_tmp_bind_mount:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.6'
               pattern: '/var'
@@ -63,7 +63,7 @@ grep:
 
     fstab_var_log_partition:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.7'
               pattern: '/var/log'
@@ -71,7 +71,7 @@ grep:
 
     fstab_var_log_audit_partition:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.8'
               pattern: '/var/log/audit'
@@ -79,7 +79,7 @@ grep:
 
     fstab_home_partition:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.9'
               pattern: '/home'
@@ -87,7 +87,7 @@ grep:
 
     fstab_home_partition_nodev:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.10'
               pattern: '/home'
@@ -96,7 +96,7 @@ grep:
 
     fstab_dev_shm_partition_nodev:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.14'
               pattern: '/dev/shm'
@@ -105,7 +105,7 @@ grep:
 
     fstab_dev_shm_partition_nosuid:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.15'
               pattern: '/dev/shm'
@@ -114,7 +114,7 @@ grep:
 
     fstab_dev_shm_partition_noexec:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/fstab':
               tag: 'CIS-2.16'
               pattern: '/dev/shm'
@@ -123,7 +123,7 @@ grep:
 
     configure_ntp:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ntp.conf':
               tag: 'CIS-6.5'
               pattern: 'restrict default'
@@ -131,7 +131,7 @@ grep:
 
     keep_all_auditing_information:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/audit/auditd.conf':
               tag: 'CIS-8.1.1.3'
               pattern: 'max_log_file_action'
@@ -140,7 +140,7 @@ grep:
 
     rsyslog_remote_logging:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/rsyslog.conf':
               tag: 'CIS-8.2.5'
               pattern: "^*.*[^I][^I]*@"
@@ -148,7 +148,7 @@ grep:
 
     passwd_limit_reuse:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/pam.d/common-password':
               tag: 'CIS-9.2.3'
               pattern: "remember"
@@ -157,7 +157,7 @@ grep:
 
     sshd_protocol_2:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.1'
               pattern: "^Protocol"
@@ -166,7 +166,7 @@ grep:
 
     sshd_loglevel_info:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.2'
               pattern: "^LogLevel"
@@ -175,7 +175,7 @@ grep:
 
     sshd_x11_forwarding:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.4'
               pattern: "^X11Forwarding"
@@ -184,7 +184,7 @@ grep:
 
     sshd_max_auth_retries:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.5'
               pattern: "^MaxAuthTries"
@@ -193,7 +193,7 @@ grep:
 
     sshd_ignore_rhosts:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.6'
               pattern: "^IgnoreRhosts"
@@ -202,7 +202,7 @@ grep:
 
     sshd_hostbased_auth:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.7'
               pattern: "^HostbasedAuthentication"
@@ -211,7 +211,7 @@ grep:
 
     sshd_disable_root_login:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.8'
               pattern: "^PermitRootLogin"
@@ -220,7 +220,7 @@ grep:
 
     sshd_permit_empty_passwords:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.9'
               pattern: "^PermitEmptyPasswords"
@@ -229,7 +229,7 @@ grep:
 
     sshd_permit_user_environment:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.10'
               pattern: "^PermitUserEnvironment"
@@ -238,7 +238,7 @@ grep:
 
     sshd_approved_cipher:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.11'
               pattern: "Ciphers"
@@ -247,7 +247,7 @@ grep:
 
     sshd_idle_timeout:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveInterval"
@@ -260,7 +260,7 @@ grep:
 
     sshd_limit_access:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.13'
               pattern: "^AllowUsers"
@@ -277,7 +277,7 @@ grep:
 
     sshd_banner:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.14'
               pattern: "^Banner"
@@ -285,7 +285,7 @@ grep:
 
     restrict_access_su:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/pam.d/su':
               tag: 'CIS-9.5'
               pattern: "pam_wheel.so"
@@ -293,7 +293,7 @@ grep:
 
     passwd_expiration_days:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/login.defs':
               tag: 'CIS-10.1.1'
               pattern: "PASS_MAX_DAYS"
@@ -302,7 +302,7 @@ grep:
 
     passwd_change_min_days:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/login.defs':
               tag: 'CIS-10.1.2'
               pattern: "PASS_MIN_DAYS"
@@ -311,7 +311,7 @@ grep:
 
     passwd_expiry_warning:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/login.defs':
               tag: 'CIS-10.1.3'
               pattern: "PASS_WARN_AGE"
@@ -320,7 +320,7 @@ grep:
 
     default_umask:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/bash.bashrc':
               tag: 'CIS-10.4'
               pattern: "^umask 077"
@@ -332,7 +332,7 @@ grep:
 stat:
   grub_conf_own:
     data:
-      Debian-8:
+      Debian*8:
         - '/boot/grub/grub.cfg':
             tag: 'CIS-3.1'
             user: 'root'
@@ -341,7 +341,7 @@ stat:
 
   grub_conf_perm:
     data:
-      Debian-8:
+      Debian*8:
         - '/boot/grub/grub.cfg':
             tag: 'CIS-3.2'
             mode: 600
@@ -349,7 +349,7 @@ stat:
 
     boot_loader_passwd:
       data:
-        Debian-8:
+        Debian*8:
           - '/boot/grub/grub.cfg':
               tag: 'CIS-3.3'
               pattern: "^password"
@@ -357,7 +357,7 @@ stat:
 
     restrict_core_dumps:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/security/limits.conf':
               tag: 'CIS-4.1'
               pattern: 'hard core'
@@ -365,7 +365,7 @@ stat:
 
   cron_hourly:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/cron.hourly':
             tag: 'CIS-9.1.3'
             mode: 700
@@ -375,7 +375,7 @@ stat:
 
   cron_daily:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/cron.daily':
             tag: 'CIS-9.1.4'
             mode: 700
@@ -385,7 +385,7 @@ stat:
 
   cron_weekly:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/cron.weekly':
             tag: 'CIS-9.1.5'
             mode: 700
@@ -395,7 +395,7 @@ stat:
 
   cron_monthly:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/cron.monthly':
             tag: 'CIS-9.1.6'
             mode: 700
@@ -405,7 +405,7 @@ stat:
 
   cron_d:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/cron.d':
             tag: 'CIS-9.1.7'
             mode: 700
@@ -415,7 +415,7 @@ stat:
 
   sshd_config:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/ssh/sshd_config':
             tag: 'CIS-9.3.3'
             mode: 600
@@ -425,7 +425,7 @@ stat:
 
   passwd_perm:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/passwd':
             tag: 'CIS-12.1'
             mode: 644
@@ -437,7 +437,7 @@ stat:
 
   shadow_perm:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/shadow':
             tag: 'CIS-12.2'
             mode: 640
@@ -449,7 +449,7 @@ stat:
 
   group_perm:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/group':
             tag: 'CIS-12.3'
             mode: 644
@@ -462,7 +462,7 @@ stat:
   blacklist:
     single_user_auth:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/shadow':
               tag: 'CIS-3.4'
               pattern: "^root:[*\\!]:"
@@ -470,7 +470,7 @@ stat:
 
   hosts_allow:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/hosts.allow':
             tag: 'CIS-7.4.3'
             mode: 644
@@ -478,7 +478,7 @@ stat:
 
   hosts_deny:
     data:
-      Debian-8:
+      Debian*8:
         - '/etc/hosts.deny':
             tag: 'CIS-7.4.5'
             mode: 644
@@ -486,7 +486,7 @@ stat:
 
     legacy_passwd_entries:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/passwd':
               tag: 'CIS-13.2'
               pattern: "^+:"
@@ -494,7 +494,7 @@ stat:
 
     legacy_shadow_entries:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/shadow':
               tag: 'CIS-13.3'
               pattern: "^+:"
@@ -502,7 +502,7 @@ stat:
 
     legacy_group_entries:
       data:
-        Debian-8:
+        Debian*8:
           - '/etc/group':
               tag: 'CIS-13.4'
               pattern: "^+:"
@@ -511,7 +511,7 @@ stat:
 sysctl:
   randomize_va_space:
     data:
-      Debian-8:
+      Debian*8:
         - 'kernel.randomize_va_space':
             tag: 'CIS-4.3'
             match_output: '2'
@@ -519,7 +519,7 @@ sysctl:
 
   ip_forwarding:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.ip_forward':
             tag: 'CIS-7.1.1'
             match_output: '0'
@@ -527,7 +527,7 @@ sysctl:
 
   send_packet_redirect:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.conf.all.send_redirects':
             tag: 'CIS-7.1.2'
             match_output: '0'
@@ -538,7 +538,7 @@ sysctl:
 
   source_routed_packet_acceptance:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.conf.all.accept_source_route':
             tag: 'CIS-7.2.1'
             match_output: '0'
@@ -549,7 +549,7 @@ sysctl:
 
   icmp_redirect_acceptance:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.conf.all.accept_redirects':
             tag: 'CIS-7.2.2'
             match_output: '0'
@@ -560,7 +560,7 @@ sysctl:
 
   icmp_redirect_acceptance:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.conf.all.secure_redirects':
             tag: 'CIS-7.2.3'
             match_output: '0'
@@ -571,7 +571,7 @@ sysctl:
 
   log_suspicious_packets:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.conf.all.log_martian':
             tag: 'CIS-7.2.4'
             match_output: '1'
@@ -582,7 +582,7 @@ sysctl:
 
   ignore_broadcast_requests:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.icmp_echo_ignore_broadcasts':
             tag: 'CIS-7.2.5'
             match_output: '1'
@@ -590,7 +590,7 @@ sysctl:
 
   bad_error_message_protection:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.icmp_ignore_bogus_error_responses':
             tag: 'CIS-7.2.6'
             match_output: '1'
@@ -598,7 +598,7 @@ sysctl:
 
   source_route_validation:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.conf.all.rp_filter':
             tag: 'CIS-7.2.7'
             match_output: '1'
@@ -608,7 +608,7 @@ sysctl:
 
   tcp_syn_cookies:
     data:
-      Debian-8:
+      Debian*8:
         - 'net.ipv4.tcp_syncookies':
             tag: 'CIS-7.2.8'
             match_output: '1'
@@ -619,19 +619,19 @@ pkg:
 
     prelink:
       data:
-        Debian-8:
+        Debian*8:
           - 'prelink': 'CIS-4.4'
       description: 'Disable Prelink (Scored)'
 
     nis:
       data:
-        Debian-8:
+        Debian*8:
           - 'nis': 'CIS-5.1.1'
       description: 'Remove nis client and nis server (Scored)'
 
     rsh:
       data:
-        Debian-8:
+        Debian*8:
           - 'rsh-server': 'CIS-5.1.2'
           - 'rsh-client': 'CIS-5.1.3'
           - 'rsh-redone-client': 'CIS-5.1.3'
@@ -639,51 +639,51 @@ pkg:
 
     talk:
       data:
-        Debian-8:
+        Debian*8:
           - 'talk': 'CIS-5.1.5'
       description: 'Remove talk and talk-server (Scored)'
 
     telnet:
       data:
-        Debian-8:
+        Debian*8:
           - 'telnet': 'CIS-5.1.6'
           - 'telnet-server': 'CIS-5.1.6'
       description: 'Remove telnet and telnet-server (Scored)'
 
     tftp:
       data:
-        Debian-8:
+        Debian*8:
           - 'tftp': 'CIS-5.1.7'
           - 'atftp': 'CIS-5.1.7'
       description: 'Remove tftp and tftp-server (Scored)'
 
     xinetd:
       data:
-        Debian-8:
+        Debian*8:
           - 'xinetd': 'CIS-5.1.8'
       description: 'Remove xinetd (Scored)'
 
     xorg-server:
       data:
-        Debian-8:
+        Debian*8:
           - 'xserver-xorg-core': 'CIS-6.1'
       description: 'Remove the X Window System (Scored)'
 
     avahi-daemon:
       data:
-        Debian-8:
+        Debian*8:
           - 'avahi-daemon': 'CIS-6.2'
       description: 'Disable Avahi Server (Scored)'
 
     dhcp:
       data:
-        Debian-8:
+        Debian*8:
           - 'isc-dhcp-server': 'CIS-6.4'
       description: 'Remove DHCP server (Scored)'
 
     slapd:
       data:
-        Debian-8:
+        Debian*8:
           - 'slapd': 'CIS-6.6'
       description: 'Ensure LDAP is not enabled (Scored)'
 
@@ -691,7 +691,7 @@ pkg:
 
     apparmor:
       data:
-        Debian-8:
+        Debian*8:
           - 'apparmor': 'CIS-4.5'
           - 'apparmor-utils': 'CIS-4.5'
           - 'apparmor-profiles': 'CIS-4.5'
@@ -699,43 +699,43 @@ pkg:
 
     tcp_wrappers:
       data:
-        Debian-8:
+        Debian*8:
           - 'tcpd': 'CIS-7.4.1'
       description: 'Install TCP Wrappers (Scored)'
 
     iptables:
       data:
-        Debian-8:
+        Debian*8:
           - 'iptables': 'CIS-7.7'
           - 'iptables-persistent': 'CIS-7.7'
       description: 'Ensure firewall is active (Scored)'
 
     auditd:
       data:
-        Debian-8:
+        Debian*8:
           - 'auditd': 'CIS-8.1.2'
       description: 'Install and Enable auditd Service (Scored)'
 
     rsyslog:
       data:
-        Debian-8:
+        Debian*8:
           - 'rsyslog': 'CIS-8.2.1'
       description: 'Install rsyslog package (Scored)'
 
     aide:
       data:
-        Debian-8:
+        Debian*8:
           - 'aide': 'CIS-8.3.1'
       description: 'Install AIDE (Scored)'
 
     cracklib:
       data:
-        Debian-8:
+        Debian*8:
           - 'libpam-cracklib': 'CIS-9.2.1'
       description: 'Set password creation requirement parameters using pam_cracklib (Scored)'
 
     openssh_server:
       data:
-        Debian-8:
+        Debian*8:
           - 'openssh-server': 'CIS-9.3'
       description: 'Configure SSH'

--- a/hubblestack_nova_profiles/top.nova
+++ b/hubblestack_nova_profiles/top.nova
@@ -9,7 +9,7 @@ nova:
     - cis.centos-6-level-1-scored-v2-0-1
   'G@osfinger:CentOS*Linux-7':
     - cis.centos-7-level-1-scored-v2-1-0
-  'G@osfinger:Debian-8':
+  'G@osfinger:Debian*8':
     - cis.debian-8-level-1-scored-v1-0-0
   'G@osfinger:Red*Hat*Enterprise*Linux*Server-6':
     - cis.rhels-6-level-1-scored-v2-0-1


### PR DESCRIPTION
We are seeing some debian hosts reporting "Debian GNU/Linux-8" for
osfinger