### PR TITLE
added windows 2106 to the top.nova file

### DIFF
--- a/hubblestack_nova_profiles/top.nova
+++ b/hubblestack_nova_profiles/top.nova
@@ -31,6 +31,8 @@ nova:
     - cis.windows-2008r2-level-1-scored-v3-0-0
   'G@osfullname:Microsoft*Windows*Server*2012*':
     - cis.windows-2012r2-level-1-scored-v2-0-0
+  'G@osfullname:Microsoft*Windows*Server*2016*':
+    - cis.windows-2016-level-1-scored-v1-0-0
   'G@osfinger:Amazon*Linux*2014*':
     - cis.amazon-201409-level-1-scored-v1-0-0
   'G@osfinger:Amazon*Linux*2015*':


### PR DESCRIPTION
Added 2 lines to the top.nova file so server 2016 can work as seamlessly as 2008 and 2012