### PR TITLE
Issue #82: Fix MaxAuthRetries false positives and false positives

### DIFF
--- a/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
@@ -637,7 +637,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: 'Set SSH MaxAuthTries to 4 or Less (Scored)'
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
@@ -562,7 +562,8 @@ grep:
       data:
         'Amazon Linux*':
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
+            match_output_regex: True
             pattern: ^MaxAuthTries
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
@@ -675,7 +675,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: 'Set SSH MaxAuthTries to 4 or Less'
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -591,7 +591,8 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: '^MaxAuthTries +[1-4]$'
+            match_output_regex: True
             pattern: ^MaxAuthTries
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less

--- a/hubblestack_nova_profiles/cis/coreos-level-1.yaml
+++ b/hubblestack_nova_profiles/cis/coreos-level-1.yaml
@@ -1,81 +1,466 @@
 grep:
   blacklist:
-    banner_os_info_motd:
+    legacy_passwd_entries_group:
       data:
         '*CoreOS*':
-        - /etc/motd:
-            pattern: '\\\\v'
-            tag: CIS-1.7.1.1
-        - /etc/motd:
-            pattern: '\\\\r'
-            tag: CIS-1.7.1.1
-        - /etc/motd:
-            pattern: '\\\\m'
-            tag: CIS-1.7.1.1
-        - /etc/motd:
-            pattern: '\\\\s'
-            tag: CIS-1.7.1.1
-      description: Ensure message of the day is configured properly
-    ensure_local_login_warning:
+        - /etc/group:
+            pattern: '^+:'
+            tag: CIS-6.2.4
+      description: Ensure no legacy "+" entries exist in /etc/group
+    legacy_passwd_entries_passwd:
       data:
         '*CoreOS*':
-        - /etc/issue:
-            pattern: '\\\\v'
-            tag: CIS-1.7.1.2
-        - /etc/issue:
-            pattern: '\\\\r'
-            tag: CIS-1.7.1.2
-        - /etc/issue:
-            pattern: '\\\\m'
-            tag: CIS-1.7.1.2
-        - /etc/issue:
-            pattern: '\\\\s'
-            tag: CIS-1.7.1.2
-      description: Ensure local login warning banner is configured properly
-    ensure_remote_login_warning:
+        - /etc/passwd:
+            pattern: '^+:'
+            tag: CIS-6.2.2
+      description: Ensure no legacy "+" entries exist in /etc/passwd
+    legacy_passwd_entries_shadow:
       data:
         '*CoreOS*':
-        - /etc/issue.net:
-            pattern: '\\\\v'
-            tag: CIS-1.7.1.3
-        - /etc/issue.net:
-            pattern: '\\\\r'
-            tag: CIS-1.7.1.3
-        - /etc/issue.net:
-            pattern: '\\\\m'
-            tag: CIS-1.7.1.3
-        - /etc/issue.net:
-            pattern: '\\\\s'
-            tag: CIS-1.7.1.3
-      description: Ensure remote login warning banner is configured properly
+        - /etc/shadow:
+            pattern: '^+:'
+            tag: CIS-6.2.3
+      description: Ensure no legacy "+" entries exist in /etc/shadow
   whitelist:
-    ssh_passwd_disabled:
+    activate_gpg_check:
       data:
         '*CoreOS*':
-        - /etc/ssh/sshd_config:
-            match_output: 'PasswordAuthentication no'
-            pattern: ^\\s*PasswordAuthentication
-            tag: CIS-7.4
-      description: Ensure password authentication is disabled in sshd_config
-    sshd_approved_macs:
+        - /etc/yum.conf:
+            match_output: gpgcheck=1
+            pattern: gpgcheck
+            tag: CIS-1.2.3
+      description: Ensure gpgcheck is globally activated
+    aide_filesystem_scans:
       data:
         '*CoreOS*':
-        - /etc/ssh/sshd_config:
-            match_output: 'MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com'
-            pattern: MACs
-            tag: CIS-5.2.12
-      description: Ensure only approved MAC algorithms are used  
-    limit_su_access:
+        - /etc/cron.d:
+            pattern: aide
+            grep_args:
+              - '-r'
+            tag: CIS-1.3.2
+      description: Ensure filesystem integrity is regularly checked
+    boot_loader_passwd:
+      data:
+        '*CoreOS*':
+        - /etc/grub.conf:
+            pattern: password
+            tag: CIS-1.4.2
+      description: Ensure bootloader password is set
+    chargen_disabled:
+      data:
+        Red Hat Enterprise Server-7:
+        - /etc/xinetd.d/chargen-dgram:
+            pattern: disable
+            match_output: 'yes'
+            tag: CIS-2.1.1
+        - /etc/xinetd.d/chargen-stream:
+            pattern: disable
+            match_output: 'yes'
+            tag: CIS-2.1.1
+      description: Ensure chargen services are not enabled
+    daytime_disabled:
+      data:
+        Red Hat Enterprise Server-7:
+        - /etc/xinetd.d/daytime-dgram:
+            pattern: disable
+            match_output: 'yes'
+            tag: CIS-2.1.2
+        - /etc/xinetd.d/daytime-stream:
+            pattern: disable
+            match_output: 'yes'
+            tag: CIS-2.1.2
+      description: Ensure daytime services are not enabled
+    discard_disabled:
+      data:
+        Red Hat Enterprise Server-7:
+        - /etc/xinetd.d/discard-dgram:
+            pattern: disable
+            match_output: 'yes'
+            tag: CIS-2.1.3
+        - /etc/xinetd.d/discard-stream:
+            pattern: disable
+            match_output: 'yes'
+            tag: CIS-2.1.3
+      description: Ensure discard services are not enabled
+    echo_disabled:
+      data:
+        Red Hat Enterprise Server-7:
+        - /etc/xinetd.d/echo-dgram:
+            pattern: disable
+            match_output: 'yes'
+            tag: CIS-2.1.4
+        - /etc/xinetd.d/echo-stream:
+            pattern: disable
+            match_output: 'yes'
+            tag: CIS-2.1.4
+      description: Ensure echo services are not enabled
+    time_disabled:
+      data:
+        Red Hat Enterprise Server-7:
+        - /etc/xinetd.d/time-dgram:
+            pattern: disable
+            match_output: 'yes'
+            tag: CIS-2.1.5
+        - /etc/xinetd.d/time-stream:
+            pattern: disable
+            match_output: 'yes'
+            tag: CIS-2.1.5
+      description: Ensure time services are not enabled
+    configure_ntp:
+      data:
+        '*CoreOS*':
+        - /etc/ntp.conf:
+            pattern: ^restrict
+            match_output: default
+            tag: CIS-2.2.1.2
+        - /etc/ntp.conf:
+            pattern: restrict -6 default
+            tag: CIS-2.2.1.2
+        - /etc/ntp.conf:
+            tag: CIS-2.2.1.2
+            pattern: '^server'
+        - /etc/sysconfig/ntpd:
+            tag: CIS-2.2.1.2
+            pattern: 'ntp:ntp'
+      description: Ensure ntp is configured
+    configure_chrony:
+      data:
+        '*CoreOS*':
+        - /etc/chrony.conf:
+            tag: CIS-2.2.1.3
+            pattern: '^server'
+        - /etc/sysconfig/chronyd:
+            tag: CIS-2.2.1.3
+            pattern: 'chrony'
+      description: Ensure chrony is configured
+    local_mail:
+      data:
+        '*CoreOS*':
+        - /etc/postfix/main.cf:
+            pattern: ^inet_interfaces
+            match_output: localhost
+            tag: CIS-2.2.15
+      description: Ensure mail transfer agent is configured for local-only mode
+    default_umask:
+      data:
+        '*CoreOS*':
+        - /etc/bashrc:
+            pattern: umask
+            match_pattern: '027'
+            tag: CIS-5.4.4
+        - /etc/profile.d:
+            pattern: umask
+            match_pattern: '027'
+            grep_args:
+              - '-r'
+            tag: CIS-5.4.4
+      description: Ensure default user umask is 027 or more restrictive
+    disable_mount_cramfs:
+      data:
+        '*CoreOS*':
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: cramfs
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.1
+      description: Ensure mounting of cramfs filesystems is disabled
+    disable_mount_freevxfs:
+      data:
+        '*CoreOS*':
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: freevxfs
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.2
+      description: Ensure mounting of freevxfs filesystems is disabled
+    disable_mount_jffs2:
+      data:
+        '*CoreOS*':
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: jffs2
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.3
+      description: Ensure mounting of jffs2 filesystems is disabled
+    disable_mount_hfs:
+      data:
+        '*CoreOS*':
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: hfs
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.4
+      description: Ensure mounting of hfs filesystems is disabled
+    disable_mount_hfsplus:
+      data:
+        '*CoreOS*':
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: hfsplus
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.5
+      description: Ensure mounting of hfsplus filesystems is disabled
+    disable_mount_squashfs:
+      data:
+        '*CoreOS*':
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: squashfs
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.6
+      description: Ensure mounting of squashfs filesystems is disabled
+    disable_mount_udf:
+      data:
+        '*CoreOS*':
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: udf
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.7
+      description: Ensure mounting of udf filesystems is disabled
+    disable_mount_fat:
+      data:
+        '*CoreOS*':
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: vfat
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.8
+      description: Ensure mounting of FAT filesystems is disabled
+    fstab_dev_shm_partition_nodev:
+      data:
+        '*CoreOS*':
+        - /etc/fstab:
+            match_output: nodev
+            pattern: /dev/shm
+            tag: CIS-1.1.15
+      description: Ensure nodev option set on /dev/shm partition
+    fstab_dev_shm_partition_noexec:
+      data:
+        '*CoreOS*':
+        - /etc/fstab:
+            match_output: noexec
+            pattern: /dev/shm
+            tag: CIS-1.1.17
+      description: Ensure noexec option set on /dev/shm partition
+    fstab_dev_shm_partition_nosuid:
+      data:
+        '*CoreOS*':
+        - /etc/fstab:
+            match_output: nosuid
+            pattern: /dev/shm
+            tag: CIS-1.1.16
+      description: Ensure nosuid option set on /dev/shm partition
+    fstab_home_partition_nodev:
+      data:
+        '*CoreOS*':
+        - /etc/fstab:
+            match_output: nodev
+            pattern: /home
+            tag: CIS-1.1.14
+      description: Ensure nodev option set on /home partition
+    fstab_tmp_partition_nodev:
+      data:
+        '*CoreOS*':
+        - /etc/fstab:
+            match_output: nodev
+            pattern: /tmp
+            tag: CIS-1.1.3
+      description: Ensure nodev option set on /tmp partition
+    fstab_tmp_partition_noexec:
+      data:
+        '*CoreOS*':
+        - /etc/fstab:
+            match_output: noexec
+            pattern: /tmp
+            tag: CIS-1.1.5
+      description: Ensure noexec option set on /tmp partition
+    fstab_tmp_partition_nosuid:
+      data:
+        '*CoreOS*':
+        - /etc/fstab:
+            match_output: nosuid
+            pattern: /tmp
+            tag: CIS-1.1.4
+      description: Ensure nosuid option set on /tmp partition
+    hosts_allow:
+      data:
+        '*CoreOS*':
+        - /etc/hosts.allow:
+            pattern: ALL
+            tag: CIS-3.4.2
+      description: Ensure /etc/hosts.allow is configured
+    hosts_deny:
+      data:
+        '*CoreOS*':
+        - /etc/hosts.deny:
+            pattern:  ALL
+            tag: CIS-3.4.3
+      description: Ensure /etc/hosts.deny is configured
+    firewall_default_deny:
+      data:
+        '*CoreOS*':
+        - /etc/sysconfig/iptables:
+            pattern: :INPUT
+            match_output: DROP
+            tag: CIS-3.6.2
+        - /etc/sysconfig/iptables:
+            pattern: :FORWARD
+            match_pattern: DROP
+            tag: CIS-3.6.2
+        - /etc/sysconfig/iptables:
+            pattern: :OUTPUT
+            match_output: DROP
+            tag: CIS-3.6.2
+      description: Ensure default deny firewall policy
+    firewall_accept_lo:
+      data:
+        '*CoreOS*':
+        - /etc/sysconfig/iptables:
+            pattern: lo
+            match_output: ACCEPT
+            tag: CIS-3.6.3
+      description: Ensure loopback traffic is configured
+    rsyslog_file_perms:
+      data:
+        '*CoreOS*':
+        - /etc/rsyslog.conf:
+            pattern: '^\$FileCreateMode'
+            match_output: '0640'
+            tag: CIS-4.2.1.3
+      description: Ensure rsyslog default file permissions configured
+    rsyslog_remote_logging:
+      data:
+        '*CoreOS*':
+        - /etc/rsyslog.conf:
+            pattern: ^*.*[^I][^I]*@
+            tag: CIS-4.2.1.4
+      description: Ensure rsyslog is configured to send logs to a remote log host
+    syslog-ng_file_perms:
+      data:
+        '*CoreOS*':
+        - /etc/syslog-ng/syslog-ng.conf:
+            pattern: ^options
+            match_output: 'perm(0640)'
+            tag: CIS-4.2.2.3
+      description: Ensure syslog-ng default file permissions configured
+    limit_password_reuse:
+      data:
+        '*CoreOS*':
+        - /etc/pam.d/system-auth:
+            pattern: '"^password\s+sufficient\s+pam_unix\.so.*"'
+            match_output: remember=5
+            grep_args:
+              - '-E'
+            tag: CIS-5.3.3
+      description: Ensure password reuse is limited
+    password_hash:
+      data:
+        '*CoreOS*':
+        - /etc/pam.d/password-auth:
+            pattern: '"^password\s+\w+\s+pam_unix\.so"'
+            match_output: sha512
+            grep_args:
+              - '-E'
+            tag: CIS-5.3.4
+      description: Ensure password hashing algorithm is SHA-512
+    limit_su_command_access:
       data:
         '*CoreOS*':
         - /etc/pam.d/su:
-            pattern: pam_wheel.so
             match_output: use_uid
+            pattern: pam_wheel.so
             tag: CIS-5.6
         - /etc/group:
             pattern: wheel
             tag: CIS-5.6
       description: Ensure access to the su command is restricted
+    pam_pwquality_try_first_pass:
+      data:
+        '*CoreOS*':
+        - /etc/pam.d/system-auth:
+            match_output: try_first_pass
+            pattern: pam_pwquality.so
+            tag: CIS-5.3.1
+        - /etc/pam.d/system-auth:
+            match_output: retry=3
+            pattern: pam_pwquality.so
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: minlen
+            match_output: '14'
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: dcredit
+            match_output: '-1'
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: ucredit
+            match_output: '-1'
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: ocredit
+            match_output: '-1'
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: lcredit
+            match_output: '-1'
+            tag: CIS-5.3.1
+      description: Ensure password creation requirements are configured
+    passwd_change_min_days:
+      data:
+        '*CoreOS*':
+        - /etc/login.defs:
+            match_output: '7'
+            pattern: PASS_MIN_DAYS
+            tag: CIS-5.4.1.2
+      description: Ensure minimum days between password changes is 7 or more
+    passwd_expiration_days:
+      data:
+        '*CoreOS*':
+        - /etc/login.defs:
+            match_output: '90'
+            pattern: PASS_MAX_DAYS
+            tag: CIS-5.4.1.1
+      description: Ensure password expiration is 90 days or less
+    passwd_expiry_warning:
+      data:
+        '*CoreOS*':
+        - /etc/login.defs:
+            match_output: '7'
+            pattern: PASS_WARN_AGE
+            tag: CIS-5.4.1.3
+      description: Ensure password expiration warning days is 7 or more
+    passwd_inactive:
+      data:
+        '*CoreOS*':
+        - /etc/default/useradd:
+            pattern: INACTIVE=30
+            tag: CIS-5.4.1.4
+      description: Ensure inactive password lock is 30 days or less
+    restrict_core_dumps:
+      data:
+        '*CoreOS*':
+        - /etc/security/limits.conf:
+            match_output: '0'
+            pattern: hard core
+            tag: CIS-1.5.1
+      description: Ensure core dumps are restricted
+    rsyslog_remote_logging:
+      data:
+        '*CoreOS*':
+        - /etc/rsyslog.conf:
+            pattern: ^*.*[^I][^I]*@
+            tag: CIS-4.2.1.4
+      description: Ensure rsyslog is configured to send logs to a remote log host
     sshd_approved_cipher:
       data:
         '*CoreOS*':
@@ -164,7 +549,8 @@ grep:
       data:
         '*CoreOS*':
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
+            match_output_regex: True
             pattern: ^MaxAuthTries
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
@@ -200,6 +586,368 @@ grep:
             pattern: ^X11Forwarding
             tag: CIS-5.2.4
       description: Ensure SSH X11 forwarding is disabled
+    lockout_account:
+      data:
+        '*CoreOS*':
+        - /etc/pam.d/system-auth:
+            pattern: '"^auth\s+required\s+pam_faillock\.so.*"'
+            match_output: deny=5
+            grep_args:
+              - '-E'
+            tag: CIS-5.3.2
+        - /etc/pam.d/password-auth:
+            pattern: '"^auth\s+required\s+pam_faillock\.so.*"'
+            match_output: deny=5
+            grep_args:
+              - '-E'
+            tag: CIS-5.3.2
+      description: Ensure lockout for failed password attempts is configured
+service:
+  blacklist:
+    autofs:
+      data:
+        '*CoreOS*':
+        - autofs: CIS-1.1.22
+      description: Disable Automounting
+    rsync:
+      data:
+        '*CoreOS*':
+        - rsyncd: CIS-2.2.20
+      description: Ensure rsync service is not enabled
+    nfs:
+      data:
+        '*CoreOS*':
+        - nfs: CIS-2.2.7
+      description: Ensure NFS and RPC are not enabled
+    rpc:
+      data:
+        '*CoreOS*':
+        - rpcbind: CIS-2.2.7
+      description: Ensure NFS and RPC are not enabled
+    named:
+      data:
+        '*CoreOS*':
+        - named: CIS-2.2.8
+      description: Ensure DNS Server is not enabled
+    httpd:
+      data:
+        '*CoreOS*':
+        - httpd: CIS-2.2.10
+      description: Ensure HTTP server is not enabled
+    pop3_imap:
+      data:
+        Red Hat Enterprise LInux Server-7:
+        - dovecot: CIS-2.2.11
+      description: Ensure IMAP and POP3 server is not enabled
+    samba:
+      data:
+        '*CoreOS*':
+        - smb: CIS-2.2.12
+      description: Ensure Samba is not enabled
+    http_proxy:
+      data:
+        '*CoreOS*':
+        - squid: CIS-2.2.13
+      description: Ensure HTTP Proxy Server is not enabled
+    snmp:
+      data:
+        '*CoreOS*':
+        - snmpd: CIS-2.2.14
+      description: Ensure SNMP Server is not enabled
+  whitelist:
+    auditd_running:
+      data:
+        '*CoreOS*':
+        - auditd: CIS-4.1.1.1
+      description: auditd should be running
+    crond_running:
+      data:
+        '*CoreOS*':
+        - crond: CIS-5.1.1
+      description: Ensure cron daemon is enabled
+    iptables_running:
+      data:
+        '*CoreOS*':
+        - iptables: CIS-3.6.1
+      description: Ensure iptables is installed
+    rsyslogd_running:
+      data:
+        '*CoreOS*':
+        - rsyslog: CIS-4.2.1.1
+      description: Ensure rsyslog Service is enabled
+    syslog-ng_running:
+      data:
+        '*CoreOS*':
+        - syslog-ng: CIS-4.2.2.1
+      description: Ensure syslog-ng service is enabled
+    sshd_approved_macs:
+      data:
+        '*CoreOS*':
+        - /etc/ssh/sshd_config:
+            match_output: 'MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com'
+            pattern: ^MACs
+            tag: CIS-5.2.12
+      description: Ensure only approved MAC algorithms are used
+stat:
+  at_cron_allow:
+    data:
+      '*CoreOS*':
+      - /etc/cron.deny:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-5.1.8
+          uid: 0
+          user: root
+      - /etc/at.deny:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-5.1.8
+          uid: 0
+          user: root
+      - /etc/cron.allow:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-5.1.8
+          uid: 0
+          user: root
+      - /etc/at.allow:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-5.1.8
+          uid: 0
+          user: root
+    description: Ensure at/cron is restricted to authorized users
+  cron_d:
+    data:
+      '*CoreOS*':
+      - /etc/cron.d:
+          gid: 0
+          group: root
+          mode: 700
+          tag: CIS-5.1.7
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/cron.d are configured
+  cron_daily:
+    data:
+      '*CoreOS*':
+      - /etc/cron.daily:
+          gid: 0
+          group: root
+          mode: 700
+          tag: CIS-5.1.4
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/cron.daily are configured
+  cron_hourly:
+    data:
+      '*CoreOS*':
+      - /etc/cron.hourly:
+          gid: 0
+          group: root
+          mode: 700
+          tag: CIS-5.1.3
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/cron.hourly are configured
+  cron_monthly:
+    data:
+      '*CoreOS*':
+      - /etc/cron.monthly:
+          gid: 0
+          group: root
+          mode: 700
+          tag: CIS-5.1.6
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/cron.monthly are configured
+  cron_weekly:
+    data:
+      '*CoreOS*':
+      - /etc/cron.weekly:
+          gid: 0
+          group: root
+          mode: 700
+          tag: CIS-5.1.5
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/cron.weekly are configured
+  crontab:
+    data:
+      '*CoreOS*':
+      - /etc/crontab:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-5.1.2
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/crontab are configured
+  passwd_own_perm:
+    data:
+      '*CoreOS*':
+      - /etc/passwd:
+          group: root
+          tag: CIS-6.1.2
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/passwd are configured
+  shadow_own_perm:
+    data:
+      '*CoreOS*':
+      - /etc/shadow:
+          gid: 0
+          group: root
+          mode: 000
+          tag: CIS-6.1.3
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/shadow are configured
+  group_own_perm:
+    data:
+      '*CoreOS*':
+      - /etc/group:
+          gid: 0
+          group: root
+          mode: 644
+          tag: CIS-6.1.4
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/group are configured
+  gshadow_own_perm:
+    data:
+      '*CoreOS*':
+      - /etc/gshadow:
+          gid: 0
+          group: root
+          mode: 0
+          tag: CIS-6.1.5
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/gshadow are configured
+  passwd-_own_perm:
+    data:
+      '*CoreOS*':
+      - /etc/passwd-:
+          group: root
+          tag: CIS-6.1.6
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/passwd- are configured
+  shadow-_own_perm:
+    data:
+      '*CoreOS*':
+      - /etc/shadow-:
+          gid: 0
+          group: root
+          mode: 000
+          tag: CIS-6.1.7
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/shadow- are configured
+  group-_own_perm:
+    data:
+      '*CoreOS*':
+      - /etc/group-:
+          gid: 0
+          group: root
+          mode: 644
+          tag: CIS-6.1.8
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/group- are configured
+  gshadow-_own_perm:
+    data:
+      '*CoreOS*':
+      - /etc/gshadow-:
+          gid: 0
+          group: root
+          mode: 0
+          tag: CIS-6.1.9
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/gshadow- are configured
+  grub_conf_own_perm:
+    data:
+      '*CoreOS*':
+      - /etc/grub.conf:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-1.4.1
+          uid: 0
+          user: root
+    description: Ensure permissions on bootloader config are configured
+  hosts_allow:
+    data:
+      '*CoreOS*':
+      - /etc/hosts.allow:
+          gid: 0
+          group: root
+          mode: 644
+          tag: CIS-3.4.4
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/hosts.allow are configured
+  hosts_deny:
+    data:
+      '*CoreOS*':
+      - /etc/hosts.deny:
+          gid: 0
+          group: root
+          mode: 644
+          tag: CIS-3.4.5
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/hosts.deny are 644
+  sshd_config:
+    data:
+      '*CoreOS*':
+      - /etc/ssh/sshd_config:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-5.2.1
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/ssh/sshd_config are configured
+  warning_banner_motd:
+    data:
+      '*CoreOS*':
+      - /etc/motd:
+          gid: 0
+          group: root
+          mode: 644
+          tag: CIS-1.7.1.4
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/motd are configured
+  warning_banner_issue:
+    data:
+      '*CoreOS*':
+      - /etc/issue:
+          gid: 0
+          group: root
+          mode: 644
+          tag: CIS-1.7.1.5
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/issue are configured
+  warning_banner_issue.net:
+    data:
+      '*CoreOS*':
+      - /etc/issue.net:
+          gid: 0
+          group: root
+          mode: 644
+          tag: CIS-1.7.1.6
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/issue.net are configured
 sysctl:
   bad_error_message_protection:
     data:
@@ -208,26 +956,6 @@ sysctl:
           match_output: '1'
           tag: CIS-3.2.6
     description: Ensure bogus ICMP responses are ignored
-  disable_packet_redirect:
-    data:
-      '*CoreOS*':
-      - net.ipv4.conf.all.send_redirects:
-          match_output: '0'
-          tag: CIS-3.1.2
-      - net.ipv4.conf.default.send_redirects:
-          match_output: '0'
-          tag: CIS-3.1.2
-    description: Ensure packet redirect sending is disabled
-  enable_reverse_path_filtering:
-    data:
-      '*CoreOS*':
-      - net.ipv4.conf.all.rp_filter:
-          match_output: '1'
-          tag: CIS-3.2.7
-      - net.ipv4.conf.default.rp_filter:
-          match_output: '1'
-          tag: CIS-3.2.7
-    description: Ensure Reverse Path Filtering is enabled
   icmp_redirect_acceptance:
     data:
       '*CoreOS*':
@@ -282,6 +1010,20 @@ sysctl:
           match_output: '0'
           tag: CIS-3.3.2
     description: Ensure IPv6 redirects are not accepted
+  randomize_va_space:
+    data:
+      '*CoreOS*':
+      - kernel.randomize_va_space:
+          match_output: '2'
+          tag: CIS-1.5.3
+    description: Ensure address space layout randomization (ASLR) is enabled
+  restrict_suid_core_dumps:
+    data:
+      '*CoreOS*':
+      - fs.suid_dumpable:
+          match_output: '0'
+          tag: CIS-1.5.1
+    description: Ensure core dumps are restricted
   secure_icmp_redirect_acceptance:
     data:
       '*CoreOS*':
@@ -292,6 +1034,16 @@ sysctl:
           match_output: '0'
           tag: CIS-3.2.3
     description: Ensure secure ICMP redirects are not accepted
+  send_packet_redirect:
+    data:
+      '*CoreOS*':
+      - net.ipv4.conf.all.send_redirects:
+          match_output: '0'
+          tag: CIS-3.1.2
+      - net.ipv4.conf.default.send_redirects:
+          match_output: '0'
+          tag: CIS-3.1.2
+    description: Ensure packet redirect sending is disabled
   source_routed_packet_acceptance:
     data:
       '*CoreOS*':
@@ -309,311 +1061,21 @@ sysctl:
           match_output: '1'
           tag: CIS-3.2.8
     description: Ensure TCP SYN Cookies is enabled
-stat:
-  passwd_own_perm:
+  reverse_path_filtering:
     data:
       '*CoreOS*':
-      - /etc/passwd:
-          gid: 0
-          group: root
-          mode: 644
-          tag: CIS-6.1.2
-          uid: 0
-          user: root
-    description: Ensure permissions on /etc/passwd are configured
-  shadow_own_perm:
-    data:
-      '*CoreOS*':
-      - /etc/shadow:
-          gid: 0
-          group: root
-          mode: 000
-          tag: CIS-6.1.3
-          uid: 0
-          user: root
-    description: Ensure permissions on /etc/shadow are configured
-  group_own_perm:
-    data:
-      '*CoreOS*':
-      - /etc/group:
-          gid: 0
-          group: root
-          mode: 644
-          tag: CIS-6.1.4
-          uid: 0
-          user: root
-    description: Ensure permissions on /etc/group are configured
-  gshadow_own_perm:
-    data:
-      '*CoreOS*':
-      - /etc/gshadow:
-          gid: 0
-          group: root
-          mode: 000
-          tag: CIS-6.1.5
-          uid: 0
-          user: root
-    description: Ensure permissions on /etc/gshadow are configured
-  passwd-_own_perm:
-    data:
-      '*CoreOS*':
-      - /etc/passwd-:
-          gid: 0
-          group: root
-          mode: 600
-          tag: CIS-6.1.6
-          uid: 0
-          user: root
-    description: Ensure permissions on /etc/passwd- are configured
-  shadow-_own_perm:
-    data:
-      '*CoreOS*':
-      - /etc/shadow-:
-          gid: 0
-          group: root
-          mode: 600
-          tag: CIS-6.1.7
-          uid: 0
-          user: root
-    description: Ensure permissions on /etc/shadow- are configured
-  group-_own_perm:
-    data:
-      '*CoreOS*':
-      - /etc/group-:
-          gid: 0
-          group: root
-          mode: 600
-          tag: CIS-6.1.8
-          uid: 0
-          user: root
-    description: Ensure permissions on /etc/group- are configured
-  gshadow-_own_perm:
-    data:
-      '*CoreOS*':
-      - /etc/gshadow-:
-          gid: 0
-          group: root
-          mode: 600
-          tag: CIS-6.1.9
-          uid: 0
-          user: root
-    description: Ensure permissions on /etc/gshadow- are configured
-  sshd_config:
-    data:
-      '*CoreOS*':
-      - /etc/ssh/sshd_config:
-          gid: 0
-          group: root
-          mode: 600
-          tag: CIS-5.2.1
-          uid: 0
-          user: root
-    description: Ensure permissions on /etc/ssh/sshd_config are configured
-  warning_banner_motd:
-    data:
-      '*CoreOS*':
-      - /etc/motd:
-          gid: 0
-          group: root
-          mode: 644
-          tag: CIS-1.7.1.4
-          uid: 0
-          user: root
-    description: Ensure permissions on /etc/motd are configured
-  warning_banner_issue:
-    data:
-      '*CoreOS*':
-      - /etc/issue:
-          gid: 0
-          group: root
-          mode: 644
-          tag: CIS-1.7.1.5
-          uid: 0
-          user: root
-    description: Ensure permissions on /etc/issue are configured
-  warning_banner_issue.net:
-    data:
-      '*CoreOS*':
-      - /etc/issue.net:
-          gid: 0
-          group: root
-          mode: 644
-          tag: CIS-1.7.1.6
-          uid: 0
-          user: root
-    description: Ensure permissions on /etc/issue.net are configured
-  docker_directory_ownership:
-    data:
-      '*CoreOS*':
-      - /etc/docker:
-          gid: 0
-          group: root
-          tag: CIS-7.5
-          uid: 0
-          user: root
-    description: Ensure that /etc/docker directory ownership is set to root:root
-  systemd_system_ownership:
-    data:
-      '*CoreOS*':
-      - /etc/systemd/system:
-          gid: 0
-          group: root
-          tag: CIS-7.2
-          uid: 0
-          user: root
-    description: Ensure that /etc/systemd/system directory ownership is set to root:root
-misc:
-  system_account_non_login:
-    data:
-      '*CoreOS*':
-       tag: CIS-5.4.2
-       function: system_account_non_login
-       description: Ensure system accounts are non-login
-  default_group_for_root_account:
-    data:
-      '*CoreOS*':
-       tag: CIS-5.4.3
-       function: default_group_for_root
-       description: Ensure default group for the root account is GID 0
-  root_is_only_uid_0_account:
-    data:
-      '*CoreOS*':
-       tag: CIS-6.2.5
-       function: root_is_only_uid_0_account
-       description: Ensure root is the only UID 0 account
-  ensure_nodev_option_on_/tmp:
-    data:
-      '*CoreOS*':
-       tag: CIS-1.1.3
-       function: test_mount_attrs
-       args:
-         - /tmp
-         - nodev
-         - soft
-       description: Ensure nodev option set on /tmp partition
-  ensure_nosuid_option_on_/tmp:
-    data:
-      '*CoreOS*':
-       tag: CIS-1.1.4
-       function: test_mount_attrs
-       args:
-         - /tmp
-         - nosuid
-         - soft
-       description: Ensure nosuid option set on /tmp partition
-  ensure_noexec_option_on_/tmp:
-    data:
-      '*CoreOS*':
-       tag: CIS-1.1.5
-       function: test_mount_attrs
-       args:
-         - /tmp
-         - noexec
-         - soft
-       description: Ensure noexec option set on /tmp partition
-  ensure_nodev_option_on_/dev/shm:
-    data:
-      '*CoreOS*':
-       tag: CIS-1.1.15
-       function: test_mount_attrs
-       args:
-         - /dev/shm
-         - nodev
-         - soft
-       description: Ensure nodev option set on /dev/shm partition
-  ensure_nosuid_option_on_/dev/shm:
-    data:
-      '*CoreOS*':
-       tag: CIS-1.1.16
-       function: test_mount_attrs
-       args:
-         - /dev/shm
-         - nosuid
-         - soft
-       description: Ensure nosuid option set on /dev/shm partition
-  ensure_noexec_option_on_/dev/shm:
-    data:
-      '*CoreOS*':
-       tag: CIS-1.1.17
-       function: test_mount_attrs
-       args:
-         - /dev/shm
-         - noexec
-         - soft
-       description: Ensure noexec option set on /dev/shm partition
-  sticky_bit_on_writable_directories:
-    data:
-      '*CoreOS*':
-       tag: CIS-1.1.21
-       function: sticky_bit_on_world_writable_dirs
-       description: Ensure sticky bit is set on all world-writable directories
-  ensure_path_integrity:
-    data:
-      '*CoreOS*':
-       tag: CIS-6.2.6
-       function: check_path_integrity
-       description: Ensure root PATH Integrity
-  docker_directory_permissions:
-    data:
-      '*CoreOS*':
-       tag: CIS-7.6
-       function: restrict_permissions
-       args:
-        - /etc/docker
-        - 755
-       description: Ensure that /etc/docker directory permissions are set to 755 or more restrictive
-  time_sync:
-    data:
-      '*CoreOS*':
-       tag: CIS-7.1
-       function: check_time_synchronization
-       description: Ensure that some service running to synchronize system time
-  check_duplicate_uids:
-    data:
-      '*CoreOS*':
-       tag: CIS-6.1.16
-       function: check_duplicate_uids
-       description: Ensure no duplicate UIDs exist
-  check_duplicate_gids:
-    data:
-      '*CoreOS*':
-       tag: CIS-6.2.17
-       function: check_duplicate_gids
-       description: Ensure no duplicate GIDs exist
-  check_duplicate_unames:
-    data:
-      '*CoreOS*':
-       tag: CIS-6.2.18
-       function: check_duplicate_unames
-       description: Ensure no duplicate user names exist
-  check_duplicate_gnames:
-    data:
-      '*CoreOS*':
-       tag: CIS-6.2.19
-       function: check_duplicate_gnames
-       description: Ensure no duplicate group names exist
-  restrict_core_dumps:
-    data:
-      '*CoreOS*':
-       tag: CIS-1.5.1
-       function: check_core_dumps
-       description: Ensure core dumps are restricted
-  check_log_files_permission:
-    data:
-      '*CoreOS*':
-       tag: CIS-4.2.4
-       function: check_directory_files_permission
-       args:
-        - /var/log
-        - 740
-       description: Ensure permissions on all logfiles are configured
-  systemd_system_permission:
-    data:
-      '*CoreOS*':
-       tag: CIS-7.3
-       function: restrict_permissions
-       args:
-        - /etc/systemd/system
-        - 755
-       description: Ensure that /etc/systemd/system directory permissions are set to 755 or more restrictive
+      - net.ipv4.conf.all.rp_filter:
+          match_output: '1'
+          tag: CIS-3.2.7
+      - net.ipv4.conf.default.rp_filter:
+          match_output: '1'
+          tag: CIS-3.2.7
+    description: Ensure Reverse Path Filtering is enabled
 
+misc:
+  check_all_ports_firewall_rules:
+    data:
+      '*CoreOS*':
+       tag: CIS-3.6.5
+       function: check_all_ports_firewall_rules
+       description: Ensure firewall rules exist for all open ports

--- a/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
@@ -204,7 +204,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: Set SSH MaxAuthTries to 4 or Less
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/debian-9.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9.yaml
@@ -192,7 +192,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: Set SSH MaxAuthTries to 4 or Less
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
@@ -723,7 +723,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.5
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: Ensure SSH MaxAuthTries is set to 4 or less
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -591,7 +591,8 @@ grep:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]"
+            match_output_regex: True
             pattern: ^MaxAuthTries
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -581,7 +581,8 @@ grep:
       data:
         Red Hat Enterprise Linux Workstation-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
+            match_output_regex: True
             pattern: ^MaxAuthTries
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less

--- a/hubblestack_nova_profiles/cis/ubuntu-1204-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1204-level-1-scored-v1-0-0.yaml
@@ -221,7 +221,7 @@ grep:
       data:
         Ubuntu-12.04:
         - /etc/ssh/sshd_config:
-            pattern: X11Forwarding
+            pattern: XForwarding
             match: 'no'
             tag: CIS-9.3.4
       description: Disable SSH X11 Forwarding
@@ -627,7 +627,7 @@ sysctl:
   bogus_errors:
     data:
       Ubuntu-12.04:
-      - net.ipv4.icmp_ignore_bogus_error_responses:
+      - icmp_ignore_bogus_error_responses:
           match_output: '1'
           tag: CIS-7.2.6
     description: Enable Bad Error Message Protection

--- a/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
@@ -244,7 +244,7 @@ grep:
       data:
         Ubuntu-14.04:
         - /etc/ssh/sshd_config:
-            pattern: X11Forwarding
+            pattern: XForwarding
             match: 'no'
             tag: CIS-9.3.4
       description: Disable SSH X11 Forwarding
@@ -253,7 +253,8 @@ grep:
         Ubuntu-14.04:
         - /etc/ssh/sshd_config:
             pattern: MaxAuthTries
-            match: '4'
+            match_output_regex: True
+            match: '^MaxAuthTries +[1-4]$'
             tag: CIS-9.3.5
       description: Set SSH MaxAuthTries to 4 or Less
     ssh_ignore_rhosts:
@@ -650,7 +651,7 @@ sysctl:
   bogus_errors:
     data:
       Ubuntu-14.04:
-      - net.ipv4.icmp_ignore_bogus_error_responses:
+      - icmp_ignore_bogus_error_responses:
           match_output: '1'
           tag: CIS-7.2.6
     description: Enable Bad Error Message Protection

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
@@ -221,7 +221,7 @@ grep:
       data:
         Ubuntu-16.04:
         - /etc/ssh/sshd_config:
-            pattern: X11Forwarding
+            pattern: XForwarding
             match: 'no'
             tag: CIS-9.3.4
       description: Disable SSH X11 Forwarding
@@ -230,7 +230,8 @@ grep:
         Ubuntu-16.04:
         - /etc/ssh/sshd_config:
             pattern: MaxAuthTries
-            match: '4'
+            match_output_regex: True
+            match: '^MaxAuthTries +[1-4]$'
             tag: CIS-9.3.5
       description: Set SSH MaxAuthTries to 4 or Less
     ssh_ignore_rhosts:
@@ -627,7 +628,7 @@ sysctl:
   bogus_errors:
     data:
       Ubuntu-16.04:
-      - net.ipv4.icmp_ignore_bogus_error_responses:
+      - net.ipv4.icmp_echo_ignore_bogus_error_responses:
           match_output: '1'
           tag: CIS-7.2.6
     description: Enable Bad Error Message Protection

--- a/hubblestack_nova_profiles/cis/windows-2008r2-level-1-scored-v3-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/windows-2008r2-level-1-scored-v3-0-0.yaml
@@ -19,7 +19,7 @@ win_secedit:
               tag: CIS-1.1.1
               match_output: '23'
               value_type: 'more'
-      description: (l1) ensure 'enforce password history' is set to '24 or more password(s)'
+      description: (L1) Ensure 'Enforce password history' is set to '24 or more password(s)'
     maximum_password_age:
       data:
         'Microsoft Windows Server 2008*':
@@ -27,7 +27,7 @@ win_secedit:
               tag: CIS-1.1.2
               match_output: '61'
               value_type: 'less'
-      description: (l1) ensure 'maximum password age' is set to '60 or fewer days, but not 0'
+      description: (L1) Ensure 'Maximum password age' is set to '60 or fewer days, but not 0'
     minimum_password_age:
       data:
         'Microsoft Windows Server 2008*':
@@ -35,7 +35,7 @@ win_secedit:
               tag: CIS-1.1.3
               match_output: '1'
               value_type: 'more'
-      description: (l1) ensure 'minimum password age' is set to '1 or more day(s)'
+      description: (L1) Ensure 'Minimum password age' is set to '1 or more day(s)'
     minimum_password_length:
       data:
         'Microsoft Windows Server 2008*':
@@ -43,7 +43,7 @@ win_secedit:
               tag: CIS-1.1.4
               match_output: '14'
               value_type: 'more'
-      description: (l1) ensure 'minimum password length' is set to '14 or more character(s)'
+      description: (L1) Ensure 'Minimum password length' is set to '14 or more character(s)'
     password_complexity:
       data:
         'Microsoft Windows Server 2008*':
@@ -51,7 +51,7 @@ win_secedit:
               tag: CIS-1.1.5
               match_output: '1'
               value_type: 'equal'
-      description: (l1) ensure 'password must meet complexity requirements' is set to 'enabled'
+      description: (L1) Ensure 'Password must meet complexity requirements' is set to 'Enabled'
     reversible_encryption:
       data:
         'Microsoft Windows Server 2008*':
@@ -59,7 +59,7 @@ win_secedit:
               tag: CIS-1.1.6
               match_output: '0'
               value_type: 'equal'
-      description: (l1) ensure 'store passwords using reversible encryption' is set to 'disabled'
+      description: (L1) Ensure 'Store passwords using reversible encryption' is set to 'Disabled'
     lockout_duration:
       data:
         'Microsoft Windows Server 2008*':
@@ -67,7 +67,7 @@ win_secedit:
               tag: CIS-1.2.1
               match_output: '14'
               value_type: 'more'
-      description: (l1) ensure 'account lockout duration' is set to '15 or more minute(s)'
+      description: (L1) Ensure 'Account lockout duration' is set to '15 or more minute(s)'
     lockout_threshold:
       data:
         'Microsoft Windows Server 2008*':
@@ -75,7 +75,7 @@ win_secedit:
               tag: CIS-1.2.2
               match_output: '11'
               value_type: 'less'
-      description: (l1) ensure 'account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0'
+      description: (L1) Ensure 'Account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0'
     reset_lockout_counter:
       data:
         'Microsoft Windows Server 2008*':
@@ -83,7 +83,7 @@ win_secedit:
               tag: CIS-1.2.3
               match_output: '14'
               value_type: 'more'
-      description: (l1) ensure 'reset account lockout counter after' is set to '15 or more minute(s)'
+      description: (L1) Ensure 'Reset account lockout counter after' is set to '15 or more minute(s)'
     access_from_network:
       data:
         'Microsoft Windows Server 2008*':
@@ -91,7 +91,7 @@ win_secedit:
               tag: CIS-2.2.2
               match_output: 'Administrators, Authenticated Users'
               value_type: 'account'
-      description: (l1) configure 'access this computer from the network'
+      description: (L1) configure 'access this computer from the network'
     adjust_memory_quotas:
       data:
         'Microsoft Windows Server 2008*':
@@ -99,7 +99,7 @@ win_secedit:
               tag: CIS-2.2.5
               match_output: 'Administrators, LOCAL SERVICE, NETWORK SERVICE'
               value_type: 'match'
-      description: (l1) ensure 'adjust memory quotas for a process' is set to 'administrators, local service, network service'
+      description: (L1) Ensure 'Adjust Memory Quotas For A Process' is set to 'administrators, local service, network service'
     allow_logon_locally:
       data:
         'Microsoft Windows Server 2008*':
@@ -107,15 +107,15 @@ win_secedit:
               tag: CIS-2.2.6
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) configure 'allow log on locally'
+      description: (L1) configure 'allow log on locally'
     allow_log_on_through_remote_desktop_services :
       data:
         'Microsoft Windows Server 2008*':
           - 'SeRemoteInteractiveLogonRight':
               tag: CIS-2.2.7
-              match_output: 'Administrators'
+              match_output: Administrators
               value_type: 'account'
-      description: (l1) configure 'allow log on through remote desktop services'
+      description: (L1) configure 'allow log on through remote desktop services'
     back_up_files_and_directories :
       data:
         'Microsoft Windows Server 2008*':
@@ -123,7 +123,7 @@ win_secedit:
               tag: CIS-2.2.8
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'back up files and directories' is set to 'administrators'
+      description: (L1) Ensure 'Back Up Files And Directories' is set to 'administrators'
     change_the_system_time :
       data:
         'Microsoft Windows Server 2008*':
@@ -131,7 +131,7 @@ win_secedit:
               tag: CIS-2.2.9
               match_output: 'Administrators, LOCAL SERVICE'
               value_type: 'account'
-      description: (l1) ensure 'change the system time' is set to 'administrators, local service'
+      description: (L1) Ensure 'Change The System Time' is set to 'administrators, local service'
     change_the_time_zone :
       data:
         'Microsoft Windows Server 2008*':
@@ -139,7 +139,7 @@ win_secedit:
               tag: CIS-2.2.10
               match_output: 'Administrators, LOCAL SERVICE'
               value_type: 'account'
-      description: (l1) ensure 'change the time zone' is set to 'administrators, local service'
+      description: (L1) Ensure 'Change The Time Zone' is set to 'administrators, local service'
     create_a_pagefile :
       data:
         'Microsoft Windows Server 2008*':
@@ -147,7 +147,7 @@ win_secedit:
               tag: CIS-2.2.11
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'create a pagefile' is set to 'administrators'
+      description: (L1) Ensure 'Create A Pagefile' is set to 'administrators'
     create_global_objects :
       data:
         'Microsoft Windows Server 2008*':
@@ -155,7 +155,7 @@ win_secedit:
               tag: CIS-2.2.13
               match_output: 'Administrators, LOCAL SERVICE, NETWORK SERVICE, SERVICE'
               value_type: 'account'
-      description: (l1) ensure 'create global objects' is set to 'administrators, local service, network service, service'
+      description: (L1) Ensure 'Create Global Objects' is set to 'administrators, local service, network service, service'
     create_symbolic_links :
       data:
         'Microsoft Windows Server 2008*':
@@ -163,7 +163,7 @@ win_secedit:
               tag: CIS-2.2.15
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'create symbolic links' is set to 'administrators'
+      description: (L1) Ensure 'Create Symbolic Links' is set to 'administrators'
     debug_programs :
       data:
         'Microsoft Windows Server 2008*':
@@ -171,7 +171,7 @@ win_secedit:
               tag: CIS-2.2.16
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'debug programs' is set to 'administrators'
+      description: (L1) Ensure 'Debug Programs' is set to 'administrators'
     deny_access_to_this_computer_from_the_network :
       data:
         'Microsoft Windows Server 2008*':
@@ -179,7 +179,7 @@ win_secedit:
               tag: CIS-2.2.17
               match_output: 'Guests'
               value_type: 'account'
-      description: (l1) ensure 'deny access to this computer from the network' to include 'guests'
+      description: (L1) Ensure 'Deny Access To This Computer From The Network' to include 'guests'
     deny_log_on_as_a_batch_job :
       data:
         'Microsoft Windows Server 2008*':
@@ -187,7 +187,7 @@ win_secedit:
               tag: CIS-2.2.18
               match_output: 'Guests'
               value_type: 'account'
-      description: (l1) ensure 'deny log on as a batch job' to include 'guests'
+      description: (L1) Ensure 'Deny Log On As A Batch Job' to include 'guests'
     deny_log_on_as_a_service :
       data:
         'Microsoft Windows Server 2008*':
@@ -195,7 +195,7 @@ win_secedit:
               tag: CIS-2.2.19
               match_output: 'Guests'
               value_type: 'account'
-      description: (l1) ensure 'deny log on as a service' to include 'guests'
+      description: (L1) Ensure 'Deny Log On As A Service' to include 'guests'
     deny_log_on_locally :
       data:
         'Microsoft Windows Server 2008*':
@@ -203,7 +203,7 @@ win_secedit:
               tag: CIS-2.2.20
               match_output: 'Guests'
               value_type: 'account'
-      description: (l1) ensure 'deny log on locally' to include 'guests'
+      description: (L1) Ensure 'Deny Log On Locally' to include 'guests'
     deny_log_on_through_remote_desktop_services :
       data:
         'Microsoft Windows Server 2008*':
@@ -211,7 +211,7 @@ win_secedit:
               tag: CIS-2.2.21
               match_output: 'Guests, LOCAL SERVICE'
               value_type: 'account'
-      description: (l1) ensure 'deny log on through remote desktop services' to include 'guests'
+      description: (L1) Ensure 'Deny Log On Through Remote Desktop Services' to include 'guests'
     force_shutdown_from_a_remote_system :
       data:
         'Microsoft Windows Server 2008*':
@@ -219,7 +219,7 @@ win_secedit:
               tag: CIS-2.2.23
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'force shutdown from a remote system' is set to 'administrators'
+      description: (L1) Ensure 'Force Shutdown From A Remote System' is set to 'administrators'
     generate_security_audits :
       data:
         'Microsoft Windows Server 2008*':
@@ -227,7 +227,7 @@ win_secedit:
               tag: CIS-2.2.24
               match_output: 'LOCAL SERVICE, NETWORK SERVICE'
               value_type: 'account'
-      description: (l1) ensure 'generate security audits' is set to 'local service, network service'
+      description: (L1) Ensure 'Generate Security Audits' is set to 'local service, network service'
     impersonate_a_client_after_authentication :
       data:
         'Microsoft Windows Server 2008*':
@@ -235,7 +235,7 @@ win_secedit:
               tag: CIS-2.2.25
               match_output: 'Administrators, LOCAL SERVICE, NETWORK SERVICE, SERVICE'
               value_type: 'account'
-      description: (l1) configure 'impersonate a client after authentication'
+      description: (L1) configure 'impersonate a client after authentication'
     increase_scheduling_priority :
       data:
         'Microsoft Windows Server 2008*':
@@ -243,7 +243,7 @@ win_secedit:
               tag: CIS-2.2.26
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'increase scheduling priority' is set to 'administrators'
+      description: (L1) Ensure 'Increase Scheduling Priority' is set to 'administrators'
     load_and_unload_device_drivers :
       data:
         'Microsoft Windows Server 2008*':
@@ -251,7 +251,7 @@ win_secedit:
               tag: CIS-2.2.27
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'load and unload device drivers' is set to 'administrators'
+      description: (L1) Ensure 'Load And Unload Device Drivers' is set to 'administrators'
     manage_auditing_and_security_log :
       data:
         'Microsoft Windows Server 2008*':
@@ -259,7 +259,7 @@ win_secedit:
               tag: CIS-2.2.30
               match_output: '*S-1-5-32-544' #Administrators
               value_type: 'account'
-      description: (l1) configure 'manage auditing and security log'
+      description: (L1) configure 'manage auditing and security log'
     modify_firmware_environment_values :
       data:
         'Microsoft Windows Server 2008*':
@@ -267,7 +267,7 @@ win_secedit:
               tag: CIS-2.2.32
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'modify firmware environment values' is set to 'administrators'
+      description: (L1) Ensure 'Modify Firmware Environment Values' is set to 'administrators'
     perform_volume_maintenance_tasks :
       data:
         'Microsoft Windows Server 2008*':
@@ -275,7 +275,7 @@ win_secedit:
               tag: CIS-2.2.33
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'perform volume maintenance tasks' is set to 'administrators'
+      description: (L1) Ensure 'Perform Volume Maintenance Tasks' is set to 'administrators'
     profile_single_process :
       data:
         'Microsoft Windows Server 2008*':
@@ -283,7 +283,7 @@ win_secedit:
               tag: CIS-2.2.34
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'profile single process' is set to 'administrators'
+      description: (L1) Ensure 'Profile Single Process' is set to 'administrators'
     profile_system_performance :
       data:
         'Microsoft Windows Server 2008*':
@@ -291,7 +291,7 @@ win_secedit:
               tag: CIS-2.2.35
               match_output: 'Administrators, NT SERVICE\WdiServiceHost'
               value_type: 'account'
-      description: (l1) ensure 'profile system performance' is set to 'administrators, nt service\wdiservicehost'
+      description: (L1) Ensure 'Profile System Performance' is set to 'administrators, nt service\wdiservicehost'
     replace_a_process_level_token :
       data:
         'Microsoft Windows Server 2008*':
@@ -299,7 +299,7 @@ win_secedit:
               tag: CIS-2.2.36
               match_output: 'LOCAL SERVICE, NETWORK SERVICE'
               value_type: 'account'
-      description: (l1) ensure 'replace a process level token' is set to 'local service, network service'
+      description: (L1) Ensure 'Replace A Process Level Token' is set to 'local service, network service'
     restore_files_and_directories :
       data:
         'Microsoft Windows Server 2008*':
@@ -307,7 +307,7 @@ win_secedit:
               tag: CIS-2.2.37
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'restore files and directories' is set to 'administrators'
+      description: (L1) Ensure 'Restore Files And Directories' is set to 'administrators'
     shut_down_the_system :
       data:
         'Microsoft Windows Server 2008*':
@@ -315,7 +315,7 @@ win_secedit:
               tag: CIS-2.2.38
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'shut down the system' is set to 'administrators'
+      description: (L1) Ensure 'Shut Down The System' is set to 'administrators'
     take_ownership_of_files_or_other_objects :
       data:
         'Microsoft Windows Server 2008*':
@@ -323,7 +323,7 @@ win_secedit:
               tag: CIS-2.2.40
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'take ownership of files or other objects' is set to 'administrators'
+      description: (L1) Ensure 'Take Ownership Of Files Or Other Objects' is set to 'administrators'
     accounts_administrator_account_status :
       data:
         'Microsoft Windows Server 2008*':
@@ -331,39 +331,39 @@ win_secedit:
               tag: CIS-2.3.1.1
               match_output: '0'
               value_type: 'equal'
-      description: (l1) ensure 'accounts - administrator account status' is set to 'disabled'
+      description: (L1) Ensure 'Accounts - Administrator Account Status' is set to 'Disabled'
     accounts_guest_account_status :
       data:
         'Microsoft Windows Server 2008*':
           - 'EnableGuestAccount':
               tag: CIS-2.3.1.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'accounts - guest account status' is set to 'disabled'
+      description: (L1) Ensure 'Accounts - Guest Account Status' is set to 'Disabled'
     accounts_limit_local_account_use_of_blank_passwords_to_console_logon_only :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\LimitBlankPasswordUse':
               tag: CIS-2.3.1.3
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'accounts - limit local account use of blank passwords to console logon only' is set to 'enabled'
+      description: (L1) Ensure 'Accounts - Limit Local Account Use Of Blank Passwords To Console Logon Only' is set to 'Enabled'
     audit_force_audit_policy_subcategory_settings_to_override_audit_policy_category_settings :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\SCENoApplyLegacyAuditPolicy':
               tag: CIS-2.3.2.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'audit - force audit policy subcategory settings (windows vista or later) to override audit policy category settings' is set to 'enabled'
+      description: (L1) Ensure 'Audit - Force Audit Policy Subcategory Settings (windows Vista Or Later) To Override Audit Policy Category Settings' is set to 'Enabled'
     audit_shut_down_system_immediately_if_unable_to_log_security_audits :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\CrashOnAuditFail':
               tag: CIS-2.3.2.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'audit - shut down system immediately if unable to log security audits' is set to 'disabled'
+      description: (L1) Ensure 'Audit - Shut Down System Immediately If Unable To Log Security Audits' is set to 'Disabled'
     devices_allowed_to_format_and_eject_removable_media :
       data:
         'Microsoft Windows Server 2008*':
@@ -371,47 +371,47 @@ win_secedit:
               tag: CIS-2.3.4.1
               match_output: 'Administrators'
               value_type: 'equal'
-      description: (l1) ensure 'devices - allowed to format and eject removable media' is set to 'administrators'
+      description: (L1) Ensure 'Devices - Allowed To Format And Eject Removable Media' is set to 'administrators'
     devices_prevent_users_from_installing_printer_drivers :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Control\Print\Providers\LanMan Print Services\Servers\AddPrinterDrivers':
               tag: CIS-2.3.4.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'devices - prevent users from installing printer drivers' is set to 'enabled'
+      description: (L1) Ensure 'Devices - Prevent Users From Installing Printer Drivers' is set to 'Enabled'
     domain_member_digitally_encrypt_or_sign_secure_channel_data_ :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters\RequireSignOrSeal':
               tag: CIS-2.3.6.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'domain member - digitally encrypt or sign secure channel data (always)' is set to 'enabled'
+      description: (L1) Ensure 'Domain Member - Digitally Encrypt Or Sign Secure Channel Data (always)' is set to 'Enabled'
     domain_member_digitally_encrypt_secure_channel_data :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters\SealSecureChannel':
               tag: CIS-2.3.6.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'domain member - digitally encrypt secure channel data (when possible)' is set to 'enabled'
+      description: (L1) Ensure 'Domain Member - Digitally Encrypt Secure Channel Data (when Possible)' is set to 'Enabled'
     domain_member_digitally_sign_secure_channel_data :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters\SignSecureChannel':
               tag: CIS-2.3.6.3
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'domain member - digitally sign secure channel data (when possible)' is set to 'enabled'
+      description: (L1) Ensure 'Domain Member - Digitally Sign Secure Channel Data (when Possible)' is set to 'Enabled'
     domain_member_disable_machine_account_password_changes :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters\DisablePasswordChange':
               tag: CIS-2.3.6.4
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'domain member - disable machine account password changes' is set to 'disabled'
+      description: (L1) Ensure 'Domain Member - Disable Machine Account Password Changes' is set to 'Disabled'
     domain_member_maximum_machine_account_password_age :
       data:
         'Microsoft Windows Server 2008*':
@@ -419,31 +419,31 @@ win_secedit:
               tag: CIS-2.3.6.5
               match_output: '31'
               value_type: 'less'
-      description: (l1) ensure 'domain member - maximum machine account password age' is set to '30 or fewer days, but not 0'
+      description: (L1) Ensure 'Domain Member - Maximum Machine Account Password Age' is set to '30 or fewer days, but not 0'
     domain_member_require_strong_session_key :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters\RequireStrongKey':
               tag: CIS-2.3.6.6
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'domain member - require strong (windows 2000 or later) session key' is set to 'enabled'
+      description: (L1) Ensure 'Domain Member - Require Strong (windows 2000 Or Later) Session Key' is set to 'Enabled'
     interactive_logon_do_not_display_last_user_name :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\DontDisplayLastUserName':
               tag: CIS-2.3.7.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'interactive logon - do not display last user name' is set to 'enabled'
+      description: (L1) Ensure 'Interactive Logon - Do Not Display Last User Name' is set to 'Enabled'
     interactive_logon_do_not_require_ctrl+alt+del :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\DisableCAD':
               tag: CIS-2.3.7.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'interactive logon - do not require ctrl+alt+del' is set to 'disabled'
+      description: (L1) Ensure 'Interactive Logon - Do Not Require Ctrl+alt+del' is set to 'Disabled'
     interactive_logon_message_text_for_users_attempting_to_log_on : #NOTE: Configure this
       data:
         'Microsoft Windows Server 2008*':
@@ -451,7 +451,7 @@ win_secedit:
               tag: CIS-2.3.7.3
               match_output: ''
               value_type: 'configured'
-      description: (l1) configure 'interactive logon - message text for users attempting to log on'
+      description: (L1) configure 'interactive logon - message text for users attempting to log on'
     interactive_logon_message_title_for_users_attempting_to_log_on : #NOTE: Configure this
       data:
         'Microsoft Windows Server 2008*':
@@ -459,21 +459,21 @@ win_secedit:
               tag: CIS-2.3.7.4
               match_output: ''
               value_type: 'configured'
-      description: (l1) configure 'interactive logon - message title for users attempting to log on'
+      description: (L1) configure 'interactive logon - message title for users attempting to log on'
     interactive_logon_prompt_user_to_change_password_before_expiration :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\PasswordExpiryWarning':
               tag: CIS-2.3.7.6
-              match_output: '15'
+              match_output: '15' # between 5 and 14
               value_type: 'less'
-      description: (l1) ensure 'interactive logon - prompt user to change password before expiration' is set to 'between 5 and 14 days'
+      description: (L1) Ensure 'Interactive Logon - Prompt User To Change Password Before Expiration' is set to 'between 5 and 14 days'
     interactive_logon_require_domain_controller_authentication_to_unlock_workstation :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\ForceUnlockLogon':
               tag: CIS-2.3.7.7
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
       description: 'Interactive logon Require Domain Controller Authentication to unlock workstation'
     interactive_logon_smart_card_removal_behavior :
@@ -483,31 +483,31 @@ win_secedit:
               tag: CIS-2.3.7.8
               match_output: 'Lock Workstation' # can be anything but No Action
               value_type: 'equal'
-      description: (l1) ensure 'interactive logon - smart card removal behavior' is set to 'lock workstation' or higher
-    microsoft_network_client_digitally_sign_communications_ :
+      description: (L1) Ensure 'Interactive Logon - Smart Card Removal Behavior' is set to 'lock workstation' or higher
+    microsoft_network_client_digitally_sign_communications_require:
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters\RequireSecuritySignature':
               tag: CIS-2.3.8.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'microsoft network client - digitally sign communications (always)' is set to 'enabled'
-    microsoft_network_client_digitally_sign_communications_ :
+      description: (L1) Ensure 'Microsoft Network Client - Digitally Sign Communications (always)' is set to 'Enabled'
+    microsoft_network_client_digitally_sign_communications_enable:
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters\EnableSecuritySignature':
               tag: CIS-2.3.8.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'microsoft network client - digitally sign communications (if server agrees)' is set to 'enabled'
+      description: (L1) Ensure 'Microsoft Network Client - Digitally Sign Communications (if Server Agrees)' is set to 'Enabled'
     microsoft_network_client_send_unencrypted_password_to_third-party_smb_servers :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters\EnablePlainTextPassword':
               tag: CIS-2.3.8.3
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'microsoft network client - send unencrypted password to third-party smb servers' is set to 'disabled'
+      description: (L1) Ensure 'Microsoft Network Client - Send Unencrypted Password To Third-party Smb Servers' is set to 'Disabled'
     microsoft_network_server_amount_of_idle_time_required_before_suspending_session :
       data:
         'Microsoft Windows Server 2008*':
@@ -515,31 +515,31 @@ win_secedit:
               tag: CIS-2.3.9.1
               match_output: '16'
               value_type: 'less'
-      description: (l1) ensure 'microsoft network server - amount of idle time required before suspending session' is set to '15 or fewer minute(s), but not 0'
-    microsoft_network_server_digitally_sign_communications_ :
+      description: (L1) Ensure 'Microsoft Network Server - Amount Of Idle Time Required Before Suspending Session' is set to '15 or fewer minute(s), but not 0'
+    microsoft_network_server_digitally_sign_communications_always :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\RequireSecuritySignature':
               tag: CIS-2.3.9.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'microsoft network server - digitally sign communications (always)' is set to 'enabled'
-    microsoft_network_server_digitally_sign_communications_ :
+      description: (L1) Ensure 'Microsoft Network Server - Digitally Sign Communications (always)' is set to 'Enabled'
+    microsoft_network_server_digitally_sign_communications_if_client_agrees :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\EnableSecuritySignature':
               tag: CIS-2.3.9.3
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'microsoft network server - digitally sign communications (if client agrees)' is set to 'enabled'
+      description: (L1) Ensure 'Microsoft Network Server - Digitally Sign Communications (if Client Agrees)' is set to 'Enabled'
     microsoft_network_server_disconnect_clients_when_logon_hours_expire :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\EnableForcedLogOff':
               tag: CIS-2.3.9.4
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'microsoft network server - disconnect clients when logon hours expire' is set to 'enabled'
+      description: (L1) Ensure 'Microsoft Network Server - Disconnect Clients When Logon Hours Expire' is set to 'Enabled'
     microsoft_network_server_server_spn_target_name_validation_level :
       data:
         'Microsoft Windows Server 2008*':
@@ -547,47 +547,39 @@ win_secedit:
               tag: CIS-2.3.9.5
               match_output: 'Accept if provided by client'
               value_type: 'equal'
-      description: (l1) ensure 'microsoft network server - server spn target name validation level' is set to 'accept if provided by client' or higher
+      description: (L1) Ensure 'Microsoft Network Server - Server Spn Target Name Validation Level' is set to 'accept if provided by client' or higher
     network_access_allow_anonymous_sid/name_translation :
       data:
         'Microsoft Windows Server 2008*':
           - 'LSAAnonymousNameLookup':
               tag: CIS-2.3.10.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'network access - allow anonymous sid/name translation' is set to 'disabled'
+      description: (L1) Ensure 'Network Access - Allow Anonymous Sid/name Translation' is set to 'Disabled'
     network_access_do_not_allow_anonymous_enumeration_of_sam_accounts :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\RestrictAnonymousSAM':
               tag: CIS-2.3.10.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'network access - do not allow anonymous enumeration of sam accounts' is set to 'enabled'
+      description: (L1) Ensure 'Network Access - Do Not Allow Anonymous Enumeration Of Sam Accounts' is set to 'Enabled'
     network_access_do_not_allow_anonymous_enumeration_of_sam_accounts_and_shares :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\RestrictAnonymous':
               tag: CIS-2.3.10.3
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'network access - do not allow anonymous enumeration of sam accounts and shares' is set to 'enabled'
-    network_access_do_not_allow_storage_of_passwords_and_credentials_for_network_authentication :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'MACHINE\System\CurrentControlSet\Control\Lsa\DisableDomainCreds':
-              tag: CIS-2.3.10.4
-              match_output: '1'
-              value_type: 'equal'
-      description: 'Network access Do not allow storage of passwords and credentials for network authentication'
+      description: (L1) Ensure 'Network Access - Do Not Allow Anonymous Enumeration Of Sam Accounts And Shares' is set to 'Enabled'
     network_access_let_everyone_persmissions_apply_to_anonymous_users :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\EveryoneIncludesAnonymous':
               tag: CIS-2.3.10.5
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'network access - let everyone permissions apply to anonymous users' is set to 'disabled'
+      description: (L1) Ensure 'Network Access - Let Everyone Permissions Apply To Anonymous Users' is set to 'Disabled'
     network_access_remotely_accessible_registry_paths :
       data:
         'Microsoft Windows Server 2008*':
@@ -595,7 +587,7 @@ win_secedit:
               tag: CIS-2.3.10.7
               match_output: 'System\CurrentControlSet\Control\ProductOptions, System\CurrentControlSet\Control\Server Applications, Software\Microsoft\Windows NT\CurrentVersion'
               value_type: 'equal'
-      description: (l1) ensure 'network access - remotely accessible registry paths'
+      description: (L1) Ensure 'Network Access - Remotely Accessible Registry Paths'
     network_access_remotely_accessible_registry_paths_and_sub-paths :
       data:
         'Microsoft Windows Server 2008*':
@@ -603,15 +595,15 @@ win_secedit:
               tag: CIS-2.3.10.8
               match_output: 'System\CurrentControlSet\Control\Print\Printers, System\CurrentControlSet\Services\Eventlog, Software\Microsoft\OLAP Server, Software\Microsoft\Windows NT\CurrentVersion\Print, Software\Microsoft\Windows NT\CurrentVersion\Windows, System\CurrentControlSet\Control\ContentIndex, System\CurrentControlSet\Control\Terminal Server, System\CurrentControlSet\Control\Terminal Server\UserConfig, System\CurrentControlSet\Control\Terminal Server\DefaultUserConfiguration, Software\Microsoft\Windows NT\CurrentVersion\Perflib, System\CurrentControlSet\Services\SysmonLog'
               value_type: 'equal'
-      description: (l1) ensure 'network access - remotely accessible registry paths and sub-paths'
+      description: (L1) Ensure 'Network Access - Remotely Accessible Registry Paths And Sub-paths'
     network_access_restrict_anonymous_access_to_named_pipes_and_shares :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\RestrictNullSessAccess':
               tag: CIS-2.3.10.9
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'network access - restrict anonymous access to named pipes and shares' is set to 'enabled'
+      description: (L1) Ensure 'Network Access - Restrict Anonymous Access To Named Pipes And Shares' is set to 'Enabled'
     network_access_sharing_and_security_model_for_local_accounts :
       data:
         'Microsoft Windows Server 2008*':
@@ -619,31 +611,31 @@ win_secedit:
               tag: CIS-2.3.10.11
               match_output: 'Classic - local users authenticate as themselves'
               value_type: 'equal'
-      description: (l1) ensure 'network access - sharing and security model for local accounts' is set to 'classic - local users authenticate as themselves'
+      description: (L1) Ensure 'Network Access - Sharing And Security Model For Local Accounts' is set to 'classic - local users authenticate as themselves'
     network_security_allow_local_system_to_use_computer_identity_for_ntlm :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\UseMachineId':
               tag: CIS-2.3.11.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'network security - allow local system to use computer identity for ntlm' is set to 'enabled'
+      description: (L1) Ensure 'Network Security - Allow Local System To Use Computer Identity For Ntlm' is set to 'Enabled'
     network_security_allow_localsystem_null_session_fallback :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0\allownullsessionfallback':
               tag: CIS-2.3.11.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'network security - allow localsystem null session fallback' is set to 'disabled'
+      description: (L1) Ensure 'Network Security - Allow Localsystem Null Session Fallback' is set to 'Disabled'
     network_security_allow_pku2u_authentication_requests_to_this_computer_to_use_online_identities :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\pku2u\AllowOnlineID':
               tag: CIS-2.3.11.3
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'network security - allow pku2u authentication requests to this computer to use online identities' is set to 'disabled'
+      description: (L1) Ensure 'Network Security - Allow Pku2u Authentication Requests To This Computer To Use Online Identities' is set to 'Disabled'
     network_security_configure_encryption_types_allowed_for_kerberos :
       data:
         'Microsoft Windows Server 2008*':
@@ -651,23 +643,23 @@ win_secedit:
               tag: CIS-2.3.11.4
               match_output: 'RC4_HMAC_MD5, AES128_HMAC_SHA1, AES256_HMAC_SHA1, Future encryption types'
               value_type: 'equal'
-      description: (l1) ensure 'network security - configure encryption types allowed for kerberos' is set to 'rc4_hmac_md5, aes128_hmac_sha1, aes256_hmac_sha1, future encryption types'
+      description: (L1) Ensure 'Network Security - Configure Encryption Types Allowed For Kerberos' is set to 'rc4_hmac_md5, aes128_hmac_sha1, aes256_hmac_sha1, future encryption types'
     network_security_do_not_store_lan_manager_hash_value_on_next_password_change :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\NoLMHash':
               tag: CIS-2.3.11.5
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'network security - do not store lan manager hash value on next password change' is set to 'enabled'
+      description: (L1) Ensure 'Network Security - Do Not Store Lan Manager Hash Value On Next Password Change' is set to 'Enabled'
     network_security_force_logoff_when_logon_hours_expire :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\EnableForcedLogOff':
               tag: CIS-2.3.11.6
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'network security - force logoff when logon hours expire' is set to 'enabled'
+      description: (L1) Ensure 'Network Security - Force Logoff When Logon Hours Expire' is set to 'Enabled'
     network_security_lan_manager_authentication_level :
       data:
         'Microsoft Windows Server 2008*':
@@ -675,7 +667,7 @@ win_secedit:
               tag: CIS-2.3.11.7
               match_output: 'Send NTLMv2 response only. Refuse LM & NTLM'
               value_type: 'equal'
-      description: (l1) ensure 'network security - lan manager authentication level' is set to 'send ntlmv2 response only. refuse lm & ntlm'
+      description: (L1) Ensure 'Network Security - Lan Manager Authentication Level' is set to 'send ntlmv2 response only. refuse lm & ntlm'
     network_security_ldap_client_signing_requirements :
       data:
         'Microsoft Windows Server 2008*':
@@ -683,7 +675,7 @@ win_secedit:
               tag: CIS-2.3.11.8
               match_output: 'Negotiate signing'
               value_type: 'equal'
-      description: (l1) ensure 'network security - ldap client signing requirements' is set to 'negotiate signing' or higher
+      description: (L1) Ensure 'Network Security - Ldap Client Signing Requirements' is set to 'negotiate signing' or higher
     network_security_minimum_session_security_for_ntlm_ssp_based_clients :
       data:
         'Microsoft Windows Server 2008*':
@@ -691,7 +683,7 @@ win_secedit:
               tag: CIS-2.3.11.9
               match_output: 'Require NTLMv2 session security, Require 128-bit encryption'
               value_type: 'equal'
-      description: (l1) ensure 'network security - minimum session security for ntlm ssp based (including secure rpc) clients' is set to 'require ntlmv2 session security, require 128-bit encryption'
+      description: (L1) Ensure 'Network Security - Minimum Session Security For Ntlm Ssp Based (including Secure Rpc) Clients' is set to 'require ntlmv2 session security, require 128-bit encryption'
     network_security_minimum_session_security_for_ntlm_ssp_based_(including_secure_rpc_servers :
       data:
         'Microsoft Windows Server 2008*':
@@ -699,31 +691,31 @@ win_secedit:
               tag: CIS-2.3.11.10
               match_output: 'Require NTLMv2 session security, Require 128-bit encryption'
               value_type: 'equal'
-      description: (l1) ensure 'network security - minimum session security for ntlm ssp based (including secure rpc) servers' is set to 'require ntlmv2 session security, require 128-bit encryption'
+      description: (L1) Ensure 'Network Security - Minimum Session Security For Ntlm Ssp Based (including Secure Rpc) Servers' is set to 'require ntlmv2 session security, require 128-bit encryption'
     shutdown_allow_system_to_be_shut_down_without_having_to_log_on :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\ShutdownWithoutLogon':
               tag: CIS-2.3.13.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'shutdown - allow system to be shut down without having to log on' is set to 'disabled'
+      description: (L1) Ensure 'Shutdown - Allow System To Be Shut Down Without Having To Log On' is set to 'Disabled'
     system_objects_require_case_insensitivity_for_non-windows_subsystems :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Control\Session Manager\Kernel\ObCaseInsensitive':
               tag: CIS-2.3.15.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'system objects - require case insensitivity for non-windows subsystems' is set to 'enabled'
+      description: (L1) Ensure 'System Objects - Require Case Insensitivity For Non-windows Subsystems' is set to 'Enabled'
     system_objects_strengthen_default_permissions_of_internal_system_objects_(e.g._symbolic_links :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\System\CurrentControlSet\Control\Session Manager\ProtectionMode':
               tag: CIS-2.3.15.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'system objects - strengthen default permissions of internal system objects (e.g. symbolic links)' is set to 'enabled'
+      description: (L1) Ensure 'System Objects - Strengthen Default Permissions Of Internal System Objects (e.g. Symbolic Links)' is set to 'Enabled'
     system_settings_optional_subsystems :
       data:
         'Microsoft Windows Server 2008*':
@@ -731,23 +723,23 @@ win_secedit:
               tag: CIS-2.3.16.1
               match_output: 'Defined' # blank
               value_type: 'equal'
-      description: (l1) ensure 'system settings - optional subsystems' is set to 'defined - (blank)'
+      description: (L1) Ensure 'System Settings - Optional Subsystems' is set to 'defined - (blank)'
     user_account_control_admin_approval_mode_for_the_built-in_administrator_account :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\FilterAdministratorToken':
               tag: CIS-2.3.17.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - admin approval mode for the built-in administrator account' is set to 'enabled'
+      description: (L1) Ensure 'User Account Control - Admin Approval Mode For The Built-in Administrator Account' is set to 'Enabled'
     user_account_control_allow_uiaccess_applications_to_prompt_for_elevation_without_using_the_secure_desktop :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\EnableUIADesktopToggle':
               tag: CIS-2.3.17.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - allow uiaccess applications to prompt for elevation without using the secure desktop' is set to 'disabled'
+      description: (L1) Ensure 'User Account Control - Allow Uiaccess Applications To Prompt For Elevation Without Using The Secure Desktop' is set to 'Disabled'
     user_account_control_behavior_of_the_elevation_prompt_for_administrators_in_admin_approval_mode :
       data:
         'Microsoft Windows Server 2008*':
@@ -755,7 +747,7 @@ win_secedit:
               tag: CIS-2.3.17.3
               match_output: 'Prompt for consent on the secure desktop'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - behavior of the elevation prompt for administrators in admin approval mode' is set to 'prompt for consent on the secure desktop'
+      description: (L1) Ensure 'User Account Control - Behavior Of The Elevation Prompt For Administrators In Admin Approval Mode' is set to 'prompt for consent on the secure desktop'
     user_account_control_behavior_of_the_elevation_prompt_for_standard_users :
       data:
         'Microsoft Windows Server 2008*':
@@ -763,47 +755,47 @@ win_secedit:
               tag: CIS-2.3.17.4
               match_output: 'Automatically deny elevation requests'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - behavior of the elevation prompt for standard users' is set to 'automatically deny elevation requests'
+      description: (L1) Ensure 'User Account Control - Behavior Of The Elevation Prompt For Standard Users' is set to 'automatically deny elevation requests'
     user_account_control_detect_application_installations_and_prompt_for_elevation :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\EnableInstallerDetection':
               tag: CIS-2.3.17.5
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - detect application installations and prompt for elevation' is set to 'enabled'
+      description: (L1) Ensure 'User Account Control - Detect Application Installations And Prompt For Elevation' is set to 'Enabled'
     user_account_control_only_elevate_uiaccess_applications_that_are_installed_in_secure_locations :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\EnableSecureUIAPaths':
               tag: CIS-2.3.17.6
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - only elevate uiaccess applications that are installed in secure locations' is set to 'enabled'
+      description: (L1) Ensure 'User Account Control - Only Elevate Uiaccess Applications That Are Installed In Secure Locations' is set to 'Enabled'
     user_account_control_run_all_administrators_in_admin_approval_mode :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\EnableLUA':
               tag: CIS-2.3.17.7
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - run all administrators in admin approval mode' is set to 'enabled'
+      description: (L1) Ensure 'User Account Control - Run All Administrators In Admin Approval Mode' is set to 'Enabled'
     user_account_control_switch_to_the_secure_desktop_when_prompting_for_elevation :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\PromptOnSecureDesktop':
               tag: CIS-2.3.17.8
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - switch to the secure desktop when prompting for elevation' is set to 'enabled'
+      description: (L1) Ensure 'User Account Control - Switch To The Secure Desktop When Prompting For Elevation' is set to 'Enabled'
     user_account_control_virtualize_file_and_registry_write_failures_to_per-user_locations :
       data:
         'Microsoft Windows Server 2008*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\':
               tag: CIS-2.3.17.9
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - virtualize file and registry write failures to per-user locations' is set to 'enabled'
+      description: (L1) Ensure 'User Account Control - Virtualize File And Registry Write Failures To Per-user Locations' is set to 'Enabled'
 
   blacklist:
     accounts_rename_administrator_account :
@@ -813,7 +805,7 @@ win_secedit:
               tag: CIS-2.3.1.4
               match_output: 'Administrator'
               value_type: 'equal'
-      description: (l1) configure 'accounts - rename administrator account'
+      description: (L1) configure 'accounts - rename administrator account'
     accounts_rename_guest_account :
       data:
         'Microsoft Windows Server 2008*':
@@ -821,7 +813,7 @@ win_secedit:
               tag: CIS-2.3.1.5
               match_output: 'Guest'
               value_type: 'equal'
-      description: (l1) configure 'accounts - rename guest account'
+      description: (L1) configure 'accounts - rename guest account'
     network_access_named_pipes_that_can_be_accessed_anonymously :
       data:
         'Microsoft Windows Server 2008*':
@@ -829,7 +821,7 @@ win_secedit:
               tag: CIS-2.3.10.6
               match_output: ''
               value_type: 'equal'
-      description: (l1) configure 'network access - named pipes that can be accessed anonymously'
+      description: (L1) configure 'network access - named pipes that can be accessed anonymously'
     network_access_shares_that_can_be_accessed_anonymously :
       data:
         'Microsoft Windows Server 2008*':
@@ -837,7 +829,7 @@ win_secedit:
               tag: CIS-2.3.10.10
               match_output: ''
               value_type: 'equal'
-      description: (l1) ensure 'network access - shares that can be accessed anonymously' is set to 'none'
+      description: (L1) Ensure 'Network Access - Shares That Can Be Accessed Anonymously' is set to 'none'
     access_credential_manager:
       data:
         'Microsoft Windows Server 2008*':
@@ -845,7 +837,7 @@ win_secedit:
               tag: CIS-2.2.1
               match_output: 'No One'
               value_type: 'match'
-      description: (l1) ensure 'access credential manager as a trusted caller' is set to 'no one'
+      description: (L1) Ensure 'Access Credential Manager As A Trusted Caller' is set to 'no one'
     act_as_operating_system:
       data:
         'Microsoft Windows Server 2008*':
@@ -853,7 +845,7 @@ win_secedit:
               tag: CIS-2.2.3
               match_output: 'No One'
               value_type: 'match'
-      description: (l1) ensure 'act as part of the operating system' is set to 'no one'
+      description: (L1) Ensure 'Act As Part Of The Operating System' is set to 'no one'
     create_a_token_object :
       data:
         'Microsoft Windows Server 2008*':
@@ -861,7 +853,7 @@ win_secedit:
               tag: CIS-2.2.12
               match_output: 'No One'
               value_type: 'account'
-      description: (l1) ensure 'create a token object' is set to 'no one'
+      description: (L1) Ensure 'Create A Token Object' is set to 'no one'
     create_permanent_shared_objects :
       data:
         'Microsoft Windows Server 2008*':
@@ -869,7 +861,7 @@ win_secedit:
               tag: CIS-2.2.14
               match_output: 'No One'
               value_type: 'account'
-      description: (l1) ensure 'create permanent shared objects' is set to 'no one'
+      description: (L1) Ensure 'Create Permanent Shared Objects' is set to 'no one'
     enable_computer_and_user_accounts_to_be_trusted_for_delegation :
       data:
         'Microsoft Windows Server 2008*':
@@ -877,7 +869,7 @@ win_secedit:
               tag: CIS-2.2.22
               match_output: 'No one'
               value_type: 'account'
-      description: (l1) configure 'enable computer and user accounts to be trusted for delegation'
+      description: (L1) configure 'enable computer and user accounts to be trusted for delegation'
     lock_pages_in_memory :
       data:
         'Microsoft Windows Server 2008*':
@@ -885,7 +877,7 @@ win_secedit:
               tag: CIS-2.2.28
               match_output: 'No One'
               value_type: 'account'
-      description: (l1) ensure 'lock pages in memory' is set to 'no one'
+      description: (L1) Ensure 'Lock Pages In Memory' is set to 'no one'
     modify_an_object_label :
       data:
         'Microsoft Windows Server 2008*':
@@ -893,7 +885,7 @@ win_secedit:
               tag: CIS-2.2.31
               match_output: 'No One'
               value_type: 'account'
-      description: (l1) ensure 'modify an object label' is set to 'no one'
+      description: (L1) Ensure 'Modify An Object Label' is set to 'no one'
     synchronize_directory_service_data :
       data:
         'Microsoft Windows Server 2008*':
@@ -901,250 +893,8 @@ win_secedit:
               tag: CIS-2.2.39
               match_output: 'No One'
               value_type: 'account'
-      description: (l1) ensure 'synchronize directory service data' is set to 'no one' (dc only)
+      description: (L1) Ensure 'Synchronize Directory Service Data' is set to 'no one' (dc only)
 
-#win_firewall:
-#  whitelist:
-#    windows_firewall_domain_firewall_state :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'Enabled':
-#              tag: CIS-9.1.1
-#              match_output: 'True'
-#              value_type: 'domain'
-#      description: (l1) ensure 'windows firewall - domain - firewall state' is set to 'on (recommended)'
-#    windows_firewall_domain_inbound_connections :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'DefaultInboundAction':
-#              tag: CIS-9.1.2
-#              match_output: 'Block'
-#              value_type: 'domain'
-#      description: (l1) ensure 'windows firewall - domain - inbound connections' is set to 'block (default)'
-#    windows_firewall_domain_outbound_connections :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'DefaultOutboundAction':
-#              tag: CIS-9.1.3
-#              match_output: 'Allow'
-#              value_type: 'domain'
-#      description: (l1) ensure 'windows firewall - domain - outbound connections' is set to 'allow (default)'
-#    windows_firewall_domain_settings_display_a_notification :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'NotifyOnListen':
-#              tag: CIS-9.1.4
-#              match_output: 'False'
-#              value_type: 'domain'
-#      description: (l1) ensure 'windows firewall - domain - settings - display a notification' is set to 'no'
-#    windows_firewall_domain_settings_apply_local_firewall_rules :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'AllowLocalFirewallRules':
-#              tag: CIS-9.1.5
-#              match_output: 'True'
-#              value_type: 'domain'
-#      description: (l1) ensure 'windows firewall - domain - settings - apply local firewall rules' is set to 'yes (default)'
-#    windows_firewall_domain_settings_apply_local_connection_security_rules :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'AllowLocalIPsecRules':
-#              tag: CIS-9.1.6
-#              match_output: 'True'
-#              value_type: 'domain'
-#      description: (l1) ensure 'windows firewall - domain - settings - apply local connection security rules' is set to 'yes (default)'
-#    windows_firewall_domain_logging_name :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'LogFileName':
-#              tag: CIS-9.1.7
-#              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\domainfw.log'
-#              value_type: 'domain'
-#      description: (l1) ensure 'windows firewall - domain - logging - name' is set to '%systemroot%\system32\logfiles\firewall\domainfw.log'
-#    windows_firewall_domain_logging_size_limit :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'LogMaxSizeKilobytes':
-#              tag: CIS-9.1.8
-#              match_output: '16384'
-#              value_type: 'domain'
-#      description: (l1) ensure 'windows firewall - domain - logging - size limit (kb)' is set to '16,384 kb or greater'
-#    windows_firewall_domain_logging_log_dropped_packets :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'LogBlocked':
-#              tag: CIS-9.1.9
-#              match_output: 'True'
-#              value_type: 'domain'
-#      description: (l1) ensure 'windows firewall - domain - logging - log dropped packets' is set to 'yes'
-#    windows_firewall_domain_logging_log_successful_connections :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'LogAllowed':
-#              tag: CIS-9.1.10
-#              match_output: 'True'
-#              value_type: 'domain'
-#      description: (l1) ensure 'windows firewall - domain - logging - log successful connections' is set to 'yes'
-#    windows_firewall_private_firewall_state :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'Enabled':
-#              tag: CIS-9.2.1
-#              match_output: 'True'
-#              value_type: 'private'
-#      description: (l1) ensure 'windows firewall - private - firewall state' is set to 'on (recommended)'
-#    windows_firewall_private_inbound_connections :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'DefaultInboundAction':
-#              tag: CIS-9.2.2
-#              match_output: 'Block'
-#              value_type: 'private'
-#      description: (l1) ensure 'windows firewall - private - inbound connections' is set to 'block (default)'
-#    windows_firewall_private_outbound_connections :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'DefaultOutboundAction':
-#              tag: CIS-9.2.3
-#              match_output: 'Allow'
-#              value_type: 'private'
-#      description: (l1) ensure 'windows firewall - private - outbound connections' is set to 'allow (default)'
-#    windows_firewall_private_settings_display_a_notification :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'NotifyOnListen':
-#              tag: CIS-9.2.4
-#              match_output: 'False'
-#              value_type: 'private'
-#      description: (l1) ensure 'windows firewall - private - settings - display a notification' is set to 'no'
-#    windows_firewall_private_settings_apply_local_firewall_rules :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'AllowLocalFirewallRules':
-#              tag: CIS-9.2.5
-#              match_output: 'True'
-#              value_type: 'private'
-#      description: (l1) ensure 'windows firewall - private - settings - apply local firewall rules' is set to 'yes (default)'
-#    windows_firewall_private_settings_apply_local_connection_security_rules :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'AllowLocalIPsecRules':
-#              tag: CIS-9.2.6
-#              match_output: 'True'
-#              value_type: 'private'
-#      description: (l1) ensure 'windows firewall - private - settings - apply local connection security rules' is set to 'yes (default)'
-#    windows_firewall_private_logging_name :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'LogFileName':
-#              tag: CIS-9.2.7
-#              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\privatefw.log'
-#              value_type: 'private'
-#      description: (l1) ensure 'windows firewall - private - logging - name' is set to '%systemroot%\system32\logfiles\firewall\privatefw.log'
-#    windows_firewall_private_logging_size_limit :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'LogMaxSizeKilobytes':
-#              tag: CIS-9.2.8
-#              match_output: '16384'
-#              value_type: 'private'
-#      description: (l1) ensure 'windows firewall - private - logging - size limit (kb)' is set to '16,384 kb or greater'
-#    windows_firewall_private_logging_log_dropped_packets :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'LogBlocked':
-#              tag: CIS-9.2.9
-#              match_output: 'True'
-#              value_type: 'private'
-#      description: (l1) ensure 'windows firewall - private - logging - log dropped packets' is set to 'yes'
-#    windows_firewall_private_logging_log_successful_connections :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'LogAllowed':
-#              tag: CIS-9.2.10
-#              match_output: 'True'
-#              value_type: 'private'
-#      description: (l1) ensure 'windows firewall - private - logging - log successful connections' is set to 'yes'
-#    windows_firewall_public_firewall_state :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'Enabled':
-#              tag: CIS-9.3.1
-#              match_output: 'True'
-#              value_type: 'public'
-#      description: (l1) ensure 'windows firewall - public - firewall state' is set to 'on (recommended)'
-#    windows_firewall_public_inbound_connections :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'DefaultInboundAction':
-#              tag: CIS-9.3.2
-#              match_output: 'Block'
-#              value_type: 'public'
-#      description: (l1) ensure 'windows firewall - public - inbound connections' is set to 'block (default)'
-#    windows_firewall_public_outbound_connections :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'DefaultOutboundAction':
-#              tag: CIS-9.3.3
-#              match_output: 'Allow'
-#              value_type: 'public'
-#      description: (l1) ensure 'windows firewall - public - outbound connections' is set to 'allow (default)'
-#    windows_firewall_public_settings_display_a_notification :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'NotifyOnListen':
-#              tag: CIS-9.3.4
-#              match_output: 'True'
-#              value_type: 'public'
-#      description: (l1) ensure 'windows firewall - public - settings - display a notification' is set to 'yes'
-#    windows_firewall_public_settings_apply_local_firewall_rules :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'AllowLocalFirewallRules':
-#              tag: CIS-9.3.5
-#              match_output: 'False'
-#              value_type: 'public'
-#      description: (l1) ensure 'windows firewall - public - settings - apply local firewall rules' is set to 'no'
-#    windows_firewall_public_settings_apply_local_connection_security_rules :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'AllowLocalIPsecRules':
-#              tag: CIS-9.3.6
-#              match_output: 'False'
-#              value_type: 'public'
-#      description: (l1) ensure 'windows firewall - public - settings - apply local connection security rules' is set to 'no'
-#    windows_firewall_public_logging_name :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'LogFileName':
-#              tag: CIS-9.3.7
-#              match_output: '%SYSTEMROOT%\System32\logfiles\firewall\publicfw.log'
-#              value_type: 'public'
-#      description: (l1) ensure 'windows firewall - public - logging - name' is set to '%systemroot%\system32\logfiles\firewall\publicfw.log'
-#    windows_firewall_public_logging_size_limit_(kb :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'LogMaxSizeKilobytes':
-#              tag: CIS-9.3.8
-#              match_output: '16384'
-#              value_type: 'public'
-#      description: (l1) ensure 'windows firewall - public - logging - size limit (kb)' is set to '16,384 kb or greater'
-#    windows_firewall_public_logging_log_dropped_packets :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'LogBlocked':
-#              tag: CIS-9.3.9
-#              match_output: 'True'
-#              value_type: 'public'
-#      description: (l1) ensure 'windows firewall - public - logging - log dropped packets' is set to 'yes'
-#    windows_firewall_public_logging_log_successful_connections :
-#      data:
-#        'Microsoft Windows Server 2008*':
-#          - 'LogAllowed':
-#              tag: CIS-9.3.10
-#              match_output: 'True'
-#              value_type: 'public'
-#      description: (l1) ensure 'windows firewall - public - logging - log successful connections' is set to 'yes'
 
 win_auditpol:
   whitelist:
@@ -1155,7 +905,7 @@ win_auditpol:
               tag: CIS-17.1.1
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit credential validation' is set to 'success and failure'
+      description: (L1) Ensure 'Audit Credential Validation' is set to 'Success and Failure'
     Audit Application Group Management :
       data:
         'Microsoft Windows Server 2008*':
@@ -1163,7 +913,7 @@ win_auditpol:
               tag: CIS-17.2.1
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit application group management' is set to 'success and failure'
+      description: (L1) Ensure 'Audit Application Group Management' is set to 'Success and Failure'
     Audit Computer Account Management :
       data:
         'Microsoft Windows Server 2008*':
@@ -1171,7 +921,7 @@ win_auditpol:
               tag: CIS-17.2.2
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit computer account management' is set to 'success and failure'
+      description: (L1) Ensure 'Audit Computer Account Management' is set to 'Success and Failure'
     Audit Other Account Management Events :
       data:
         'Microsoft Windows Server 2008*':
@@ -1179,7 +929,7 @@ win_auditpol:
               tag: CIS-17.2.4
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit other account management events' is set to 'success and failure'
+      description: (L1) Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'
     Audit Security Group Management :
       data:
         'Microsoft Windows Server 2008*':
@@ -1187,7 +937,7 @@ win_auditpol:
               tag: CIS-17.2.5
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit security group management' is set to 'success and failure'
+      description: (L1) Ensure 'Audit Security Group Management' is set to 'Success and Failure'
     Audit User Account Management :
       data:
         'Microsoft Windows Server 2008*':
@@ -1195,7 +945,7 @@ win_auditpol:
               tag: CIS-17.2.6
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit user account management' is set to 'success and failure'
+      description: (L1) Ensure 'Audit User Account Management' is set to 'Success and Failure'
     Audit Process Creation :
       data:
         'Microsoft Windows Server 2008*':
@@ -1203,7 +953,7 @@ win_auditpol:
               tag: CIS-17.3.1
               match_output: 'Success'
               value_type: 'equal'
-      description: (l1) ensure 'audit process creation' is set to 'success'
+      description: (L1) Ensure 'Audit Process Creation' is set to 'Success'
     Audit Account Lockout :
       data:
         'Microsoft Windows Server 2008*':
@@ -1211,7 +961,7 @@ win_auditpol:
               tag: CIS-17.5.1
               match_output: 'Success'
               value_type: 'equal'
-      description: (l1) ensure 'audit account lockout' is set to 'success'
+      description: (L1) Ensure 'Audit Account Lockout' is set to 'Success'
     Audit Logoff :
       data:
         'Microsoft Windows Server 2008*':
@@ -1219,7 +969,7 @@ win_auditpol:
               tag: CIS-17.5.2
               match_output: 'Success'
               value_type: 'equal'
-      description: (l1) ensure 'audit logoff' is set to 'success'
+      description: (L1) Ensure 'Audit Logoff' is set to 'Success'
     Audit Logon :
       data:
         'Microsoft Windows Server 2008*':
@@ -1227,7 +977,7 @@ win_auditpol:
               tag: CIS-17.5.3
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit logon' is set to 'success and failure'
+      description: (L1) Ensure 'Audit Logon' is set to 'Success and Failure'
     Audit Other Logon/Logoff Events :
       data:
         'Microsoft Windows Server 2008*':
@@ -1235,7 +985,7 @@ win_auditpol:
               tag: CIS-17.5.4
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit other logon/logoff events' is set to 'success and failure'
+      description: (L1) Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'
     Audit Special Logon :
       data:
         'Microsoft Windows Server 2008*':
@@ -1243,7 +993,7 @@ win_auditpol:
               tag: CIS-17.5.5
               match_output: 'Success'
               value_type: 'equal'
-      description: (l1) ensure 'audit special logon' is set to 'success'
+      description: (L1) Ensure 'Audit Special Logon' is set to 'Success'
     Audit Audit Policy Change :
       data:
         'Microsoft Windows Server 2008*':
@@ -1251,7 +1001,7 @@ win_auditpol:
               tag: CIS-17.7.1
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit audit policy change' is set to 'success and failure'
+      description: (L1) Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'
     Audit Authentication Policy Change :
       data:
         'Microsoft Windows Server 2008*':
@@ -1259,7 +1009,7 @@ win_auditpol:
               tag: CIS-17.7.2
               match_output: 'Success'
               value_type: 'equal'
-      description: (l1) ensure 'audit authentication policy change' is set to 'success'
+      description: (L1) Ensure 'Audit Authentication Policy Change' is set to 'Success'
     Audit Sensitive Privilege Use :
       data:
         'Microsoft Windows Server 2008*':
@@ -1267,7 +1017,7 @@ win_auditpol:
               tag: CIS-17.8.1
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit sensitive privilege use' is set to 'success and failure'
+      description: (L1) Ensure 'Audit Sensitive Privilege Use' is set to 'Success and Failure'
     Audit IPsec Driver :
       data:
         'Microsoft Windows Server 2008*':
@@ -1275,7 +1025,7 @@ win_auditpol:
               tag: CIS-17.9.1
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit ipsec driver' is set to 'success and failure'
+      description: (L1) Ensure 'Audit IPsec Driver' is set to 'Success and Failure'
     Audit Other System Events :
       data:
         'Microsoft Windows Server 2008*':
@@ -1283,7 +1033,7 @@ win_auditpol:
               tag: CIS-17.9.2
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit other system events' is set to 'success and failure'
+      description: (L1) Ensure 'Audit Other System Events' is set to 'Success and Failure'
     Audit Security State Change :
       data:
         'Microsoft Windows Server 2008*':
@@ -1291,7 +1041,7 @@ win_auditpol:
               tag: CIS-17.9.3
               match_output: 'Success'
               value_type: 'equal'
-      description: (l1) ensure 'audit security state change' is set to 'success'
+      description: (L1) Ensure 'Audit Security State Change' is set to 'Success'
     Audit Security System Extension :
       data:
         'Microsoft Windows Server 2008*':
@@ -1299,7 +1049,7 @@ win_auditpol:
               tag: CIS-17.9.4
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit security system extension' is set to 'success and failure'
+      description: (L1) Ensure 'Audit Security System Extension' is set to 'Success and Failure'
     Audit System Integrity :
       data:
         'Microsoft Windows Server 2008*':
@@ -1307,7 +1057,7 @@ win_auditpol:
               tag: CIS-17.9.5
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit system integrity' is set to 'success and failure'
+      description: (L1) Ensure 'Audit System Integrity' is set to 'Success and Failure'
 
 win_reg:
   whitelist:
@@ -1316,120 +1066,112 @@ win_reg:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd\PwdExpirationProtectionEnabled':
               tag: CIS-18.2.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: 'Ensure Do not allow password expiration time longer than required by policy is set to Enabled '
+      description: (L1) Ensure 'Do not allow password expiration time longer than required by policy' is set to 'Enabled' (MS only)
     Enable Local Admin Password Management :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd\AdmPwdEnabled':
               tag: CIS-18.2.3
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: 'Ensure Enable Local Admin Password Management is set to Enabled '
+      description: (L1) Ensure 'Enable Local Admin Password Management' is set to 'Enabled' (MS only)
     Password Settings_ Password Complexity :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd\PasswordComplexity':
               tag: CIS-18.2.4
-              match_output: '1' 
+              match_output: 'Enabled: Large letters + small letters + numbers + special characters'
               value_type: 'equal'
-      description: 'Ensure Password Settings- Password Complexity is set to Enabled - Large letters + small letters + numbers + special characters '
+      description: "(L1) Ensure 'Password Settings: Password Complexity' is set to 'Enabled: Large letters + small letters + numbers + special characters' (MS only)"
     Password Settings_ Password Length :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd\PasswordLength':
               tag: CIS-18.2.5
-              match_output: '15'
-              value_type: 'more'
-      description: 'Ensure Password SettingS- Password Length is set to Enabled - 15 or more '
+              match_output: 'Enabled: 15 or more'
+              value_type: 'equal'
+      description: "(L1) Ensure 'Password Settings: Password Length' is set to 'Enabled: 15 or more' (MS only)"
     Password Settings_ Password Age :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd\PasswordAgeDays':
               tag: CIS-18.2.6
-              match_output: '30'
-              value_type: 'less'
-      description: 'Ensure Password SettingS- Password Age is set to Enabled - 30 or fewer '
+              match_output: 'Enabled: 30 or fewer'
+              value_type: 'equal'
+      description: "(L1) Ensure 'Password Settings: Password Age (Days)' is set to 'Enabled: 30 or fewer' (MS only)"
 
     MSS_DisableIPSourceRouting IPv6 IP source routing protection level protects against packet spoofing :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip6\Parameters\DisableIPSourceRouting':
               tag: CIS-18.3.2
-              match_output: '1'
+              match_output: 'Enabled' #: Highest protection, source routing is completely disabled'
               value_type: 'equal'
-      description: (l1) ensure 'mss - (disableipsourcerouting ipv6) ip source routing protection level (protects against packet spoofing)' is set to 'enabled - highest protection, source routing is completely disabled'
+      description: (L1) Ensure 'Mss - (disableipsourcerouting Ipv6) Ip Source Routing Protection Level (protects Against Packet Spoofing)' is set to 'enabled - highest protection, source routing is completely disabled'
     MSS_ IP source routing protection level protects against packet spoofing :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip\Parameters\DisableIPSourceRouting':
               tag: CIS-18.3.3
-              match_output: '1'
+              match_output: 'Enabled' #: Highest protection, source routing is completely disabled'
               value_type: 'equal'
-      description: (l1) ensure 'mss - (disableipsourcerouting) ip source routing protection level (protects against packet spoofing)' is set to 'enabled - highest protection, source routing is completely disabled'
+      description: (L1) Ensure 'Mss - (disableipsourcerouting) Ip Source Routing Protection Level (protects Against Packet Spoofing)' is set to 'enabled - highest protection, source routing is completely disabled'
     MSS_ Allow ICMP redirects to override OSPF generated routes :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip\Parameters\EnableICMPRedirect':
               tag: CIS-18.3.4
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'mss - (enableicmpredirect) allow icmp redirects to override ospf generated routes' is set to 'disabled'
+      description: (L1) Ensure 'Mss - (enableicmpredirect) Allow Icmp Redirects To Override Ospf Generated Routes' is set to 'Disabled'
     MSS_ Allow the computer to ignore NetBIOS name release requests except from WINS servers :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\NetBT\Parameters\nonamereleaseondemand':
               tag: CIS-18.3.6
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'mss - (nonamereleaseondemand) allow the computer to ignore netbios name release requests except from wins servers' is set to 'enabled'
+      description: (L1) Ensure 'Mss - (nonamereleaseondemand) Allow The Computer To Ignore Netbios Name Release Requests Except From Wins Servers' is set to 'Enabled'
     MSS_ Enable Safe DLL search mode :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\SafeDllSearchMode':
               tag: CIS-18.3.8
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'mss - (safedllsearchmode) enable safe dll search mode (recommended)' is set to 'enabled'
+      description: (L1) Ensure 'Mss - (safedllsearchmode) Enable Safe Dll Search Mode (recommended)' is set to 'Enabled'
     MSS_ The time in seconds before the screen saver grace period expires :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\ScreenSaverGracePeriod':
               tag: CIS-18.3.9
-              match_output: '5' 
-              value_type: 'less'
-      description: (l1) ensure 'mss - (screensavergraceperiod) the time in seconds before the screen saver grace period expires (0 recommended)' is set to 'enabled - 5 or fewer seconds'
+              match_output: 'Enabled: 5 or fewer seconds'
+              value_type: 'equal'
+      description: (L1) Ensure 'Mss - (screensavergraceperiod) The Time In Seconds Before The Screen Saver Grace Period Expires (0 Recommended)' is set to 'enabled - 5 or fewer seconds'
     MSS_ Percentage threshold for the security event log at which the system will generate a warning :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security\WarningLevel':
               tag: CIS-18.3.12
-              match_output: '90' 
+              match_output: 'Enabled' #Enabled: 90% or less
               value_type: 'less'
-      description: (l1) ensure 'mss - (warninglevel) percentage threshold for the security event log at which the system will generate a warning' is set to 'enabled - 90% or less'
-    Ensure Turn off Microsoft Peer-to-Peer Networking Services is set to Enabled :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Peernet\Disabled':
-              tag: CIS-18.4.9.2
-              match_output: '1'
-              value_type: 'equal'
-      description: 'Ensure Turn off Microsoft Peer-to-Peer Networking Services is set to Enabled'
+      description: "(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less'"
     Prohibit installation and configuration of Network Bridge on your DNS domain network :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections\NC_AllowNetBridge_NLA':
               tag: CIS-18.4.10.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'prohibit installation and configuration of network bridge on your dns domain network' is set to 'enabled'
+      description: (L1) Ensure 'Prohibit Installation And Configuration Of Network Bridge On Your Dns Domain Network' is set to 'Enabled'
     Require domain users to elevate when setting a network :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Network Connections\NC_StdDomainUserSetLocation':
               tag: CIS-18.4.10.3
-              match_output: '1'
+              match_output: ' is set to '
               value_type: 'equal'
       description: 'Ensure Require domain users to elevate when setting a networks location is set to Enabled'
     Hardened UNC Paths :
@@ -1437,23 +1179,15 @@ win_reg:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths\\*\NETLOGON':
               tag: CIS-18.4.13.1
-              match_output: '1' #with "Require Mutual Authentication" and "Require Integrity" set for all NETLOGON and SYSVOL shares'
+              match_output: 'Enabled' #with "Require Mutual Authentication" and "Require Integrity" set for all NETLOGON and SYSVOL shares'
               value_type: 'equal'
-      description: (l1) ensure 'hardened unc paths' is set to 'enabled, with "require mutual authentication" and "require integrity" set for all netlogon and sysvol shares'
-    Disable IPv6 :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP6\Parameters\DisabledComponents':
-              tag: CIS-18.4.18.2.1
-              match_output: '255'
-              value_type: 'equal'
-      description: 'Disable IPv6 - Ensure TCPIP6 Parameter DisabledComponents is set to 0xff (255)'
+      description: (L1) Ensure 'Hardened Unc Paths' is set to 'enabled, with "require mutual authentication" and "require integrity" set for all netlogon and sysvol shares'
     Apply UAC restrictions to local accounts on network logons :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\LocalAccountTokenFilterPolicy':
               tag: CIS-18.6.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
       description: 'Ensure Apply UAC restrictions to local accounts on network logons is set to Enabled '
     Configure registry policy processing_ Do not apply during periodic background processing :
@@ -1461,23 +1195,23 @@ win_reg:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}\NoBackgroundPolicy':
               tag: CIS-18.8.18.2
-              match_output: '1' #: FALSE'
+              match_output: 'Enabled'# : FALSE'
               value_type: 'equal'
-      description: (l1) ensure 'configure registry policy processing - do not apply during periodic background processing' is set to 'enabled - false'
+      description: (L1) Ensure 'Configure Registry Policy Processing - Do Not Apply During Periodic Background Processing' is set to 'enabled - false'
     Configure registry policy processing_ Process even if the Group Policy objects have not changed :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}\NoGPOListChanges':
               tag: CIS-18.8.18.3
-              match_output: '1' #: TRUE'
+              match_output: 'Enabled' #: TRUE'
               value_type: 'equal'
-      description: (l1) ensure 'configure registry policy processing - process even if the group policy objects have not changed' is set to 'enabled - true'
+      description: (L1) Ensure 'Configure Registry Policy Processing - Process Even If The Group Policy Objects Have Not Changed' is set to 'enabled - true'
     Do not display network selection UI :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\LogonType':
               tag: CIS-18.8.24.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
       description: 'Ensure Always use classic logon is set to enabled'
     Enable RPC Endpoint Mapper Client Authentication :
@@ -1485,7 +1219,7 @@ win_reg:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Rpc\EnableAuthEpResolution':
               tag: CIS-18.8.31.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
       description: 'Ensure Enable RPC Endpoint Mapper Client Authentication is set to Enabled '
     Disallow Autoplay for non-volume devices :
@@ -1493,23 +1227,23 @@ win_reg:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Explorer\NoAutoplayfornonVolume':
               tag: CIS-18.9.8.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'set the default behavior for autorun' is set to 'enabled - do not execute any autorun commands'
+      description: (L1) Ensure 'Set The Default Behavior For Autorun' is set to 'enabled - do not execute any autorun commands'
     Set the default behavior for AutoRun :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\NoAutorun':
               tag: CIS-18.9.8.2
-              match_output: '1'
+              match_output: 'Enabled'# : Do not execute any autorun commands'
               value_type: 'equal'
-      description: (l1) ensure 'set the default behavior for autorun' is set to 'enabled - no not execute any autorun commands'
+      description: (L1) Ensure 'Turn Off Autoplay' is set to 'enabled - all drives'
     Turn off Autoplay :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\NoDriveTypeAutoRun':
               tag: CIS-18.9.8.3
-              match_output: '255'
+              match_output: 'Enabled: All drives'
               value_type: 'equal'
       description: 'Ensure Turn off Autoplay is set to Enabled - All drives'
     Do not display the password reveal button :
@@ -1517,193 +1251,193 @@ win_reg:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CredUI\DisablePasswordReveal':
               tag: CIS-18.9.13.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'enumerate administrator accounts on elevation' is set to 'disabled'
+      description: (L1) Ensure 'Enumerate Administrator Accounts On Elevation' is set to 'Disabled'
     Turn off desktop gadgets :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Windows\Sidebar\TurnOffSideb':
               tag: CIS-18.9.16.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'turn off desktop gadgets' is set to 'enabled'
+      description: (L1) Ensure 'Turn Off Desktop Gadgets' is set to 'Enabled'
     Turn off user-installed desktop gadgets :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Windows\Sidebar\TurnOffUserInstalledGadget':
               tag: CIS-18.9.16.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'turn off user-installed desktop gadgets' is set to 'enabled'
+      description: (L1) Ensure 'Turn Off User-installed Desktop Gadgets' is set to 'Enabled'
     Default Action and Mitigation Settings :
       data:
         'Microsoft Windows Server 2008*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\SysSettings\AntiDetours':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\SysSettings\AntiDetours': #, HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\SysSettings\BannedFunctions, HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\SysSettings\DeepHooks, HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\SysSettings\ExploitAction':
               tag: CIS-18.9.22.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'default action and mitigation settings' is set to 'enabled' (plus subsettings)
+      description: (L1) Ensure 'Default Action And Mitigation Settings' is set to 'Enabled' (plus subsettings)
     Default Protections for Internet Explorer :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\Defaults\IE':
               tag: CIS-18.9.22.3
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'default protections for internet explorer' is set to 'enabled'
+      description: (L1) Ensure 'Default Protections For Internet Explorer' is set to 'Enabled'
     Default Protections for Popular Software :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\Defaults':
               tag: CIS-18.9.22.4
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'default protections for popular software' is set to 'enabled'
+      description: (L1) Ensure 'Default Protections For Popular Software' is set to 'Enabled'
     Default Protections for Recommended Software :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\Defaults':
               tag: CIS-18.9.22.5
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'default protections for recommended software' is set to 'enabled'
+      description: (L1) Ensure 'Default Protections For Recommended Software' is set to 'Enabled'
     System ASLR :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\SysSettings\ASLR':
               tag: CIS-18.9.22.6
-              match_output: '1'
+              match_output: 'Enabled'#: Application Opt-In'
               value_type: 'equal'
-      description: (l1) ensure 'system aslr' is set to 'enabled - application opt-in'
+      description: (L1) Ensure 'System Aslr' is set to 'enabled - application opt-in'
     System DEP :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\SysSettings\DEP':
               tag: CIS-18.9.22.7
-              match_output: '1' #: Application Opt-Out'
+              match_output: 'Enabled'#: Application Opt-Out'
               value_type: 'equal'
-      description: (l1) ensure 'system dep' is set to 'enabled - application opt-out'
+      description: (L1) Ensure 'System Dep' is set to 'enabled - application opt-out'
     System SEHOP :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\SysSettings\SEHOP':
               tag: CIS-18.9.22.8
-              match_output: '1' #: Application Opt-Out'
+              match_output: 'Enabled'#: Application Opt-Out'
               value_type: 'equal'
-      description: (l1) ensure 'system sehop' is set to 'enabled - application opt-out'
+      description: (L1) Ensure 'System Sehop' is set to 'enabled - application opt-out'
     Application_ Specify the maximum log file size  :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Application\MaxSize':
               tag: CIS-18.9.24.1.2
-              match_output: '1' #_ 32768 or greater'
+              match_output: 'Enabled'#_ 32768 or greater'
               value_type: 'equal'
-      description: (l1) ensure 'application - specify the maximum log file size (kb)' is set to 'enabled - 32,768 or greater'
+      description: (L1) Ensure 'Application - Specify The Maximum Log File Size (kb)' is set to 'enabled - 32,768 or greater'
     Security_ Specify the maximum log file size  :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Security\MaxSize':
               tag: CIS-18.9.24.2.2
-              match_output: '1' #_ 196608 or greater'
+              match_output: 'Enabled'#_ 196608 or greater'
               value_type: 'equal'
-      description: (l1) ensure 'security - specify the maximum log file size (kb)' is set to 'enabled - 196,608 or greater'
+      description: (L1) Ensure 'Security - Specify The Maximum Log File Size (kb)' is set to 'enabled - 196,608 or greater'
     Setup_ Specify the maximum log file size  :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Setup\MaxSize':
               tag: CIS-18.9.24.3.2
-              match_output: '1' # 32,768 or greater'
+              match_output: 'Enabled' # 32,768 or greater'
               value_type: 'equal'
-      description: (l1) ensure 'setup - specify the maximum log file size (kb)' is set to 'enabled - 32,768 or greater'
+      description: (L1) Ensure 'Setup - Specify The Maximum Log File Size (kb)' is set to 'enabled - 32,768 or greater'
     System_ Specify the maximum log file size  :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\System\MaxSize':
               tag: CIS-18.9.24.4.2
-              match_output: '1' #_ 32768 or greater'
+              match_output: 'Enabled'#_ 32768 or greater'
               value_type: 'equal'
-      description: (l1) ensure 'system - specify the maximum log file size (kb)' is set to 'enabled - 32,768 or greater'
+      description: (L1) Ensure 'System - Specify The Maximum Log File Size (kb)' is set to 'enabled - 32,768 or greater'
     Do not allow passwords to be saved :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\DisablePasswordSaving':
               tag: CIS-18.9.48.2.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'do not allow passwords to be saved' is set to 'enabled'
+      description: (L1) Ensure 'Do Not Allow Passwords To Be Saved' is set to 'Enabled'
     Do not allow drive redirection :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\fDisableCdm':
               tag: CIS-18.9.48.3.3.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'do not allow drive redirection' is set to 'enabled'
+      description: (L1) Ensure 'Do Not Allow Drive Redirection' is set to 'Enabled'
     Always prompt for password upon connection :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\fPromptForPassword':
               tag: CIS-18.9.48.3.9.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'always prompt for password upon connection' is set to 'enabled'
+      description: (L1) Ensure 'Always Prompt For Password Upon Connection' is set to 'Enabled'
     Require secure RPC communication :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services\fEncryptRPCTraffic':
               tag: CIS-18.9.48.3.9.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'require secure rpc communication' is set to 'enabled'
+      description: (L1) Ensure 'Require Secure Rpc Communication' is set to 'Enabled'
     Set client connection encryption level :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\MinEncryptionLevel':
               tag: CIS-18.9.48.3.9.3
-              match_output: '1' #: High Level'
+              match_output: 'Enabled'#: High Level'
               value_type: 'equal'
-      description: (l1) ensure 'set client connection encryption level' is set to 'enabled - high level'
+      description: (L1) Ensure 'Set Client Connection Encryption Level' is set to 'enabled - high level'
     Prevent downloading of enclosures :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Internet Explorer\Feeds\DisableEnclosureDownload':
               tag: CIS-18.9.49.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'prevent downloading of enclosures' is set to 'enabled'
+      description: (L1) Ensure 'Prevent Downloading Of Enclosures' is set to 'Enabled'
     Configure Default consent :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting\Consent\DefaultConsent':
               tag: CIS-18.9.67.2.1
-              match_output: '1' #: Always ask before sending data'
+              match_output: 'Enabled'#: Always ask before sending data'
               value_type: 'equal'
-      description: (l1) ensure 'configure default consent' is set to 'enabled - always ask before sending data'
+      description: (L1) Ensure 'Configure Default Consent' is set to 'enabled - always ask before sending data'
     Disallow Digest authentication :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client\AllowDigest':
               tag: CIS-18.9.81.1.3
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'disallow digest authentication' is set to 'enabled'
+      description: (L1) Ensure 'Disallow Digest Authentication' is set to 'Enabled'
     Disallow WinRM from storing RunAs credentials :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service\DisableRunAs':
               tag: CIS-18.9.81.2.3
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'disallow winrm from storing runas credentials' is set to 'enabled'
+      description: (L1) Ensure 'Disallow Winrm From Storing Runas Credentials' is set to 'Enabled'
     Configure Automatic Updates :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU\NoAutoUpdate':
               tag: CIS-18.9.85.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'configure automatic updates' is set to 'enabled'
+      description: (L1) Ensure 'Configure Automatic Updates' is set to 'Enabled'
     Configure Automatic Updates_ Scheduled install day :
       data:
         'Microsoft Windows Server 2008*':
@@ -1711,87 +1445,79 @@ win_reg:
               tag: CIS-18.9.85.2
               match_output: '0'# - Every day'
               value_type: 'equal'
-      description: (l1) ensure 'configure automatic updates - scheduled install day' is set to '0 - every day'
+      description: (L1) Ensure 'Configure Automatic Updates - Scheduled Install Day' is set to '0 - every day'
     Do Not Adjust Default Option To Install Updates and Shutdown Windows Dialog Box :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU\NoAUAsDefaultShutdownOption':
               tag: CIS-18.9.85.3
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'do not adjust default option to 'install updates and shut down' in shut down windows dialog box' is set to 'disabled'
+      description: (L1) Ensure 'Do Not Adjust Default Option To 'install updates and shut down' in shut down windows dialog box' is set to 'Disabled'
     Do Not Display Install Updates and Shut Down Dialog Box :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU\NoAUShutdownOption':
               tag: CIS-18.9.85.4
-              match_output: '0' # - Every day'
+              match_output: '0'# - Every day'
               value_type: 'equal'
-      description: (l1) ensure 'do not display 'install updates and shut down' option in shut down windows dialog box' is set to 'disabled'
-    No Auto-Restart With Logged on Users for Scheduled Updates Installations :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU\U\NoAutoRebootWithLoggedOnUsers':
-              tag: CIS-18.9.85.5
-              match_output: '0' # - Every day'
-              value_type: 'equal'
-      description: (l1) ensure 'no auto-restart with logged on users for scheduled automatic updates installations' is set to 'disabled'
+      description: (L1) Ensure 'Do Not Display 'install updates and shut down' option in shut down windows dialog box' is set to 'Disabled'
     Reschedule Automatic Updates Scheduled Installations :
       data:
         'Microsoft Windows Server 2008*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU\U:RescheduleWaitTime1':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU\U:RescheduleWaitTimeEnabled':
               tag: CIS-18.9.85.6
-              match_output: '0' # - Every day'
+              match_output: '0'# - Every day'
               value_type: 'equal'
-      description: (l1) ensure 'reschedule automatic updates scheduled installations' is set to 'enabled - 1 minute'
+      description: (L1) Ensure 'Reschedule Automatic Updates Scheduled Installations' is set to 'enabled - 1 minute'
     Enable Screen Saver :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_USERS\<SID>\Software\Policies\Microsoft\Windows\Control Panel\Desktop\ScreenSaveActive':
               tag: CIS-19.1.3.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'enable screen saver' is set to 'enabled'
+      description: (L1) Ensure 'Enable Screen Saver' is set to 'Enabled'
     Force specific screen saver_ Screen saver executable name :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_USERS\<SID>\Software\Policies\Microsoft\Windows\Control Panel\Desktop\SCRNSAVE.EXE':
               tag: CIS-19.1.3.2
-              match_output: '1' #: scrnsave.scr'
+              match_output: 'Enabled'#: scrnsave.scr'
               value_type: 'equal'
-      description: (l1) ensure 'force specific screen saver - screen saver executable name' is set to 'enabled - scrnsave.scr'
+      description: (L1) Ensure 'Force Specific Screen Saver - Screen Saver Executable Name' is set to 'enabled - scrnsave.scr'
     Password protect the screen saver :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_USERS\<SID>\Software\Policies\Microsoft\Windows\Control Panel\Desktop\ScreenSaverIsSecure':
               tag: CIS-19.1.3.3
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'password protect the screen saver' is set to 'enabled'
+      description: (L1) Ensure 'Password Protect The Screen Saver' is set to 'Enabled'
     Screen saver timeout :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_USERS\<SID>\Software\Policies\Microsoft\Windows\Control Panel\Desktop\ScreenSaveTimeOut':
               tag: CIS-19.1.3.4
-              match_output: '1' #: 900 seconds or fewer, but not 0'
+              match_output: 'Enabled'#: 900 seconds or fewer, but not 0'
               value_type: 'equal'
-      description: (l1) ensure 'screen saver timeout' is set to 'enabled - 900 seconds or fewer, but not 0'
+      description: (L1) Ensure 'Screen Saver Timeout' is set to 'enabled - 900 seconds or fewer, but not 0'
     Notify antivirus programs when opening attachments :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_USERS\<SID>\Software\Microsoft\Windows\CurrentVersion\Policies\Attachments\ScanWithAntiVirus':
               tag: CIS-19.7.4.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'notify antivirus programs when opening attachments' is set to 'enabled'
+      description: (L1) Ensure 'Notify Antivirus Programs When Opening Attachments' is set to 'Enabled'
     Prevent users from sharing files within their profile. :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_USERS\[USER SID]\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\NoInplaceSharing':
               tag: CIS-19.7.25.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'prevent users from sharing files within their profile.' is set to 'enabled'
+      description: (L1) Ensure 'Prevent Users From Sharing Files Within Their Profile.' is set to 'Enabled'
 
   blacklist:
     MSS_ Enable Automatic Logon :
@@ -1799,31 +1525,15 @@ win_reg:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\AutoAdminLogon':
               tag: CIS-18.3.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'mss - (autoadminlogon) enable automatic logon (not recommended)' is set to 'disabled'
-    Ensure Turn on Mapper I/O driver is set to Disabled :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\LLTD\AllowLLTDIOOnDomain':
-              tag: CIS-18.4.8.1
-              match_output: '1'
-              value_type: 'equal'
-      description: 'Ensure Turn on Mapper I/O (LLTDIO) driver is set to Disabled'
-    Ensure Turn on Responder (RSPNDR) driver is set to Disabled :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\LLTD\AllowRspndrOnDomain':
-              tag: CIS-18.4.8.2
-              match_output: '1'
-              value_type: 'equal'
-      description: 'Ensure Turn on Responder (RSPNDR) driver is set to Disabled'
+      description: "(L1) Ensure 'MSS: (AutoAdminLogon) Enable Automatic Logon (not recommended)' is set to 'Disabled'"
     WDigest Authentication :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest\UseLogonCredential':
               tag: CIS-18.6.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
       description: 'Ensure WDigest Authentication is set to Disabled'
     Ensure Include command line in process creation events is Disabled:
@@ -1831,7 +1541,7 @@ win_reg:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit\ProcessCreationIncludeCmdLine_Enabled':
               tag: CIS-18.8.2.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
       description: 'Ensure Include command line in process creation events is set to Disabled'
     Allow remote access to the Plug and Play interface :
@@ -1839,55 +1549,39 @@ win_reg:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Settings\AllowRemoteRPC':
               tag: CIS-18.8.5.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'allow remote access to the plug and play interface' is set to 'disabled'
+      description: (L1) Ensure 'Allow Remote Access To The Plug And Play Interface' is set to 'Disabled'
     Turn off background refresh of Group Policy :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\DisableBkGndGroupPolicy':
               tag: CIS-18.8.18.4
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'turn off background refresh of group policy' is set to 'disabled'
-    Enumerate local users on domain-joined computers :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System\EnumerateLocalUsers':
-              tag: CIS-18.8.24.3
-              match_output: '0'
-              value_type: 'equal'
-      description: 'Ensure Enumerate local users on domain-joined computers is set to Disabled'
-    Turn on convenience PIN sign-in :
-      data:
-        'Microsoft Windows Server 2008*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System\AllowDomainPINLogon':
-              tag: CIS-18.8.24.5
-              match_output: '0'
-              value_type: 'equal'
-      description: 'Ensure Turn on convenience PIN sign-in is set to Disabled'
+      description: (L1) Ensure 'Turn Off Background Refresh Of Group Policy' is set to 'Disabled'
     Configure Offer Remote Assistance :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\policies\Microsoft\Windows NT\Terminal Services\fAllowUnsolicited':
               tag: CIS-18.8.30.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'configure offer remote assistance' is set to 'disabled'
+      description: (L1) Ensure 'Configure Offer Remote Assistance' is set to 'Disabled'
     Configure Solicited Remote Assistance :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\policies\Microsoft\Windows NT\Terminal Services\fAllowToGetHelp':
               tag: CIS-18.8.30.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'configure solicited remote assistance' is set to 'disabled'
+      description: (L1) Ensure 'Configure Solicited Remote Assistance' is set to 'Disabled'
     Enumerate administrator accounts on elevation :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\CredUI\EnumerateAdministrators':
               tag: CIS-18.9.13.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
       description: 'Ensure Enumerate administrator accounts on elevation is set to Disabled'
     Application_ Control Event Log behavior when the log file reaches its maximum size :
@@ -1895,55 +1589,55 @@ win_reg:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Application\Retention':
               tag: CIS-18.9.24.1.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'application - control event log behavior when the log file reaches its maximum size' is set to 'disabled'
+      description: (L1) Ensure 'Application - Control Event Log Behavior When The Log File Reaches Its Maximum Size' is set to 'Disabled'
     Security_ Control Event Log behavior when the log file reaches its maximum size :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Security\Retention':
               tag: CIS-18.9.24.2.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'security - control event log behavior when the log file reaches its maximum size' is set to 'disabled'
+      description: (L1) Ensure 'Security - Control Event Log Behavior When The Log File Reaches Its Maximum Size' is set to 'Disabled'
     Setup_ Control Event Log behavior when the log file reaches its maximum size :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Setup\Retention':
               tag: CIS-18.9.24.3.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'setup - control event log behavior when the log file reaches its maximum size' is set to 'disabled'
+      description: (L1) Ensure 'Setup - Control Event Log Behavior When The Log File Reaches Its Maximum Size' is set to 'Disabled'
     System_ Control Event Log behavior when the log file reaches its maximum size :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\System\Retention':
               tag: CIS-18.9.24.4.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'system - control event log behavior when the log file reaches its maximum size' is set to 'disabled'
+      description: (L1) Ensure 'System - Control Event Log Behavior When The Log File Reaches Its Maximum Size' is set to 'Disabled'
     Turn off Data Execution Prevention for Explorer :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Explorer\NoDataExecutionPrevention':
               tag: CIS-18.9.28.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'turn off heap termination on corruption' is set to 'disabled'
+      description: (L1) Ensure 'Turn Off Heap Termination On Corruption' is set to 'Disabled'
     Turn off heap termination on corruption :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Explorer\NoHeapTerminationOnCorruption':
               tag: CIS-18.9.28.3
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'turn off shell protocol protected mode' is set to 'disabled'
+      description: (L1) Ensure 'Turn Off Shell Protocol Protected Mode' is set to 'Disabled'
     Turn off shell protocol protected mode :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\PreXPSP2ShellProtocolBehavior':
               tag: CIS-18.9.28.4
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
       description: 'Ensure Turn off shell protocol protected mode is set to Disabled'
     Do not delete temp folders upon exit :
@@ -1951,113 +1645,113 @@ win_reg:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\DeleteTempDirsOnExit':
               tag: CIS-18.9.48.3.11.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'do not delete temp folders upon exit' is set to 'disabled'
+      description: (L1) Ensure 'Do Not Delete Temp Folders Upon Exit' is set to 'Disabled'
     Do not use temporary folders per session :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services\PerSessionTempDir':
               tag: CIS-18.9.48.3.11.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'do not use temporary folders per session' is set to 'disabled'
+      description: (L1) Ensure 'Do Not Use Temporary Folders Per Session' is set to 'Disabled'
     Allow indexing of encrypted files :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search\AllowIndexingEncryptedStoresOrItems':
               tag: CIS-18.9.50.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'allow indexing of encrypted files' is set to 'disabled'
+      description: (L1) Ensure 'Allow Indexing Of Encrypted Files' is set to 'Disabled'
     Allow user control over installs :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Installer\EnableUserControl':
               tag: CIS-18.9.69.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'allow user control over installs' is set to 'disabled'
+      description: (L1) Ensure 'Allow User Control Over Installs' is set to 'Disabled'
     Always install with elevated privileges :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated':
               tag: CIS-18.9.69.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'always install with elevated privileges' is set to 'disabled'
+      description: (L1) Ensure 'Always Install With Elevated Privileges' is set to 'Disabled'
     Turn on PowerShell Script Block Logging :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging\EnableScriptBlockLogging':
               tag: CIS-18.9.79.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'turn on powershell script block logging' is set to 'disabled'
+      description: (L1) Ensure 'Turn On Powershell Script Block Logging' is set to 'Disabled'
     Turn on PowerShell Transcription :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription\EnableTranscripting':
               tag: CIS-18.9.79.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'turn on powershell transcription' is set to 'disabled'
-    Allow Basic authentication :
+      description: (L1) Ensure 'Turn On Powershell Transcription' is set to 'Disabled'
+    Allow Basic authentication winrm client:
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client\AllowBasic':
               tag: CIS-18.9.81.1.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'allow basic authentication' is set to 'disabled'
-    Allow unencrypted traffic :
+      description: (L1) Ensure 'Allow Basic Authentication' is set to 'Disabled'
+    Allow unencrypted traffic winrm client:
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client\AllowUnencryptedTraffic':
               tag: CIS-18.9.81.1.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'allow unencrypted traffic' is set to 'disabled'
-    Allow Basic authentication :
+      description: (L1) Ensure 'Allow Unencrypted Traffic' is set to 'Disabled'
+    Allow Basic authentication winrm server:
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service\AllowBasic':
               tag: CIS-18.9.81.2.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'allow basic authentication' is set to 'disabled'
-    Allow unencrypted traffic :
+      description: (L1) Ensure 'Allow Basic Authentication' is set to 'Disabled'
+    Allow unencrypted traffic winrm server:
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service\AllowUnencryptedTraffic':
               tag: CIS-18.9.81.2.2
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'allow unencrypted traffic' is set to 'disabled'
+      description: (L1) Ensure 'Allow Unencrypted Traffic' is set to 'Disabled'
     No auto-restart with logged on users for scheduled automatic updates installations :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU\NoAutoRebootWithLoggedOnUsers':
-              tag: CIS-18.9.85.3
-              match_output: '0'
+              tag: CIS-18.9.85.5
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'do not adjust default option to 'install updates and shut down' in shut down windows dialog box' is set to 'disabled'
+      description: (L1) Ensure 'No Auto-restart With Logged On Users For Scheduled Automatic Updates Installations' is set to 'Disabled'
     Do not preserve zone information in file attachments :
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_USERS\<SID>\Software\Microsoft\Windows\CurrentVersion\Policies\Attachments\SaveZoneInformation':
               tag: CIS-19.7.4.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'do not preserve zone information in file attachments' is set to 'disabled'
-    Always install with elevated privileges :
+      description: (L1) Ensure 'Do Not Preserve Zone Information In File Attachments' is set to 'Disabled'
+    Always install with elevated privileges user:
       data:
         'Microsoft Windows Server 2008*':
           - 'HKEY_USERS\<SID>\Software\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated':
               tag: CIS-19.7.37.1
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'always install with elevated privileges' is set to 'disabled'
+      description: (L1) Ensure 'Always Install With Elevated Privileges' is set to 'Disabled'
 
 
 win_pkg:
@@ -2069,7 +1763,7 @@ win_pkg:
               tag: CIS-18.9.22.1
               match_output: '5.4'
               value_type: 'more'
-      description: (l1) ensure 'emet 5.5' or higher is installed
+      description: (L1) Ensure 'Emet 5.5' or higher is installed
     LAPS AdmPwd GPO Extension / CSE is installed :
       data:
         'Microsoft Windows Server 2008*':
@@ -2077,4 +1771,247 @@ win_pkg:
               tag: CIS-18.2.1
               match_output: 'Local Administrator Password Solution'
               value_type: 'equal'
-      description: 'Ensure LAPS AdmPwd GPO Extension / CSE is installed '
+      description: '(L1) Ensure LAPS AdmPwd GPO Extension / CSE is installed (MS only)'
+
+win_firewall:
+ whitelist:
+   windows_firewall_domain_firewall_state :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'Enabled':
+             tag: CIS-9.1.1
+             match_output: 'True'
+             value_type: 'domain'
+     description: "(L1) Ensure 'Windows Firewall: Domain - Firewall State' is set to 'on (recommended)'"
+   windows_firewall_domain_inbound_connections :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'DefaultInboundAction':
+             tag: CIS-9.1.2
+             match_output: 'Block'
+             value_type: 'domain'
+     description: "(L1) Ensure 'Windows Firewall: Domain - Inbound Connections' is set to 'block (default)'"
+   windows_firewall_domain_outbound_connections :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'DefaultOutboundAction':
+             tag: CIS-9.1.3
+             match_output: 'Allow'
+             value_type: 'domain'
+     description: "(L1) Ensure 'Windows Firewall: Domain - Outbound Connections' is set to 'allow (default)'"
+   windows_firewall_domain_settings_display_a_notification :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'NotifyOnListen':
+             tag: CIS-9.1.4
+             match_output: 'False'
+             value_type: 'domain'
+     description: "(L1) Ensure 'Windows Firewall: Domain - Settings - Display A Notification' is set to 'no'"
+   windows_firewall_domain_settings_apply_local_firewall_rules :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'AllowLocalFirewallRules':
+             tag: CIS-9.1.5
+             match_output: 'True'
+             value_type: 'domain'
+     description: "(L1) Ensure 'Windows Firewall: Domain - Settings - Apply Local Firewall Rules' is set to 'yes (default)'"
+   windows_firewall_domain_settings_apply_local_connection_security_rules :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'AllowLocalIPsecRules':
+             tag: CIS-9.1.6
+             match_output: 'True'
+             value_type: 'domain'
+     description: "(L1) Ensure 'Windows Firewall: Domain - Settings - Apply Local Connection Security Rules' is set to 'yes (default)'"
+   windows_firewall_domain_logging_name :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'LogFileName':
+             tag: CIS-9.1.7
+             match_output: '%SYSTEMROOT%\System32\logfiles\firewall\domainfw.log'
+             value_type: 'domain'
+     description: "(L1) Ensure 'Windows Firewall: Domain - Logging - Name' is set to '%systemroot%\\system32\\logfiles\\firewall\\domainfw.log'"
+   windows_firewall_domain_logging_size_limit :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'LogMaxSizeKilobytes':
+             tag: CIS-9.1.8
+             match_output: '16384'
+             value_type: 'domain'
+     description: "(L1) Ensure 'Windows Firewall: Domain - Logging - Size Limit (kb)' is set to '16,384 kb or greater'"
+   windows_firewall_domain_logging_log_dropped_packets :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'LogBlocked':
+             tag: CIS-9.1.9
+             match_output: 'True'
+             value_type: 'domain'
+     description: "(L1) Ensure 'Windows Firewall: Domain - Logging - Log Dropped Packets' is set to 'yes'"
+   windows_firewall_domain_logging_log_successful_connections :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'LogAllowed':
+             tag: CIS-9.1.10
+             match_output: 'True'
+             value_type: 'domain'
+     description: "(L1) Ensure 'Windows Firewall: Domain - Logging - Log Successful Connections' is set to 'yes'"
+   windows_firewall_private_firewall_state :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'Enabled':
+             tag: CIS-9.2.1
+             match_output: 'True'
+             value_type: 'private'
+     description: "(L1) Ensure 'Windows Firewall: Private - Firewall State' is set to 'on (recommended)'"
+   windows_firewall_private_inbound_connections :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'DefaultInboundAction':
+             tag: CIS-9.2.2
+             match_output: 'Block'
+             value_type: 'private'
+     description: "(L1) Ensure 'Windows Firewall: Private - Inbound Connections' is set to 'block (default)'"
+   windows_firewall_private_outbound_connections :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'DefaultOutboundAction':
+             tag: CIS-9.2.3
+             match_output: 'Allow'
+             value_type: 'private'
+     description: "(L1) Ensure 'Windows Firewall: Private - Outbound Connections' is set to 'allow (default)'"
+   windows_firewall_private_settings_display_a_notification :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'NotifyOnListen':
+             tag: CIS-9.2.4
+             match_output: 'False'
+             value_type: 'private'
+     description: "(L1) Ensure 'Windows Firewall: Private - Settings - Display A Notification' is set to 'no'"
+   windows_firewall_private_settings_apply_local_firewall_rules :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'AllowLocalFirewallRules':
+             tag: CIS-9.2.5
+             match_output: 'True'
+             value_type: 'private'
+     description: "(L1) Ensure 'Windows Firewall: Private - Settings - Apply Local Firewall Rules' is set to 'yes (default)'"
+   windows_firewall_private_settings_apply_local_connection_security_rules :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'AllowLocalIPsecRules':
+             tag: CIS-9.2.6
+             match_output: 'True'
+             value_type: 'private'
+     description: "(L1) Ensure 'Windows Firewall: Private - Settings - Apply Local Connection Security Rules' is set to 'yes (default)'"
+   windows_firewall_private_logging_name :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'LogFileName':
+             tag: CIS-9.2.7
+             match_output: '%SYSTEMROOT%\System32\logfiles\firewall\privatefw.log'
+             value_type: 'private'
+     description: "(L1) Ensure 'Windows Firewall: Private - Logging - Name' is set to '%systemroot%\\system32\\logfiles\\firewall\\privatefw.log'"
+   windows_firewall_private_logging_size_limit :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'LogMaxSizeKilobytes':
+             tag: CIS-9.2.8
+             match_output: '16384'
+             value_type: 'private'
+     description: "(L1) Ensure 'Windows Firewall: Private - Logging - Size Limit (kb)' is set to '16,384 kb or greater'"
+   windows_firewall_private_logging_log_dropped_packets :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'LogBlocked':
+             tag: CIS-9.2.9
+             match_output: 'True'
+             value_type: 'private'
+     description: "(L1) Ensure 'Windows Firewall: Private - Logging - Log Dropped Packets' is set to 'yes'"
+   windows_firewall_private_logging_log_successful_connections :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'LogAllowed':
+             tag: CIS-9.2.10
+             match_output: 'True'
+             value_type: 'private'
+     description: "(L1) Ensure 'Windows Firewall: Private - Logging - Log Successful Connections' is set to 'yes'"
+   windows_firewall_public_firewall_state :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'Enabled':
+             tag: CIS-9.3.1
+             match_output: 'True'
+             value_type: 'public'
+     description: "(L1) Ensure 'Windows Firewall: Public: Firewall State' is set to 'on (recommended)'"
+   windows_firewall_public_inbound_connections :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'DefaultInboundAction':
+             tag: CIS-9.3.2
+             match_output: 'Block'
+             value_type: 'public'
+     description: "(L1) Ensure 'Windows Firewall: Public: Inbound Connections' is set to 'block (default)'"
+   windows_firewall_public_outbound_connections :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'DefaultOutboundAction':
+             tag: CIS-9.3.3
+             match_output: 'Allow'
+             value_type: 'public'
+     description: "(L1) Ensure 'Windows Firewall: Public: Outbound Connections' is set to 'allow (default)'"
+   windows_firewall_public_settings_display_a_notification :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'NotifyOnListen':
+             tag: CIS-9.3.4
+             match_output: 'True'
+             value_type: 'public'
+     description: "(L1) Ensure 'Windows Firewall: Public: Settings: Display A Notification' is set to 'yes'"
+   windows_firewall_public_settings_apply_local_firewall_rules :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'AllowLocalFirewallRules':
+             tag: CIS-9.3.5
+             match_output: 'False'
+             value_type: 'public'
+     description: "(L1) Ensure 'Windows Firewall: Public: Settings: Apply Local Firewall Rules' is set to 'no'"
+   windows_firewall_public_settings_apply_local_connection_security_rules :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'AllowLocalIPsecRules':
+             tag: CIS-9.3.6
+             match_output: 'False'
+             value_type: 'public'
+     description: "(L1) Ensure 'Windows Firewall: Public: Settings: Apply Local Connection Security Rules' is set to 'no'"
+   windows_firewall_public_logging_name :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'LogFileName':
+             tag: CIS-9.3.7
+             match_output: '%SYSTEMROOT%\System32\logfiles\firewall\publicfw.log'
+             value_type: 'public'
+     description: "(L1) Ensure 'Windows Firewall: Public: Logging: Name' is set to '%systemroot%\\system32\\logfiles\\firewall\\publicfw.log'"
+   windows_firewall_public_logging_size_limit_(kb :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'LogMaxSizeKilobytes':
+             tag: CIS-9.3.8
+             match_output: '16384'
+             value_type: 'public'
+     description: "(L1) Ensure 'Windows Firewall: Public: Logging: Size Limit (kb)' is set to '16,384 kb or greater'"
+   windows_firewall_public_logging_log_dropped_packets :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'LogBlocked':
+             tag: CIS-9.3.9
+             match_output: 'True'
+             value_type: 'public'
+     description: "(L1) Ensure 'Windows Firewall: Public: Logging: Log dropped packets' is set to 'Yes'"
+   windows_firewall_public_logging_log_successful_connections :
+     data:
+       'Microsoft Windows Server 2008*':
+         - 'LogAllowed':
+             tag: CIS-9.3.10
+             match_output: 'True'
+             value_type: 'public'
+     description: "(L1) Ensure 'Windows Firewall: Public: Logging: Log Successful Connections' is set to 'yes'"

--- a/hubblestack_nova_profiles/cis/windows-2012r2-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/windows-2012r2-level-1-scored-v2-0-0.yaml
@@ -19,7 +19,7 @@ win_secedit:
               tag: CIS-1.1.1
               match_output: '23'
               value_type: 'more'
-      description: (l1) ensure 'enforce password history' is set to '24 or more password(s)'
+      description: (L1) Ensure 'enforce password history' is set to '24 or more password(s)'
     maximum_password_age:
       data:
         'Microsoft Windows Server 2012*':
@@ -27,7 +27,7 @@ win_secedit:
               tag: CIS-1.1.2
               match_output: '61'
               value_type: 'less'
-      description: (l1) ensure 'maximum password age' is set to '60 or fewer days, but not 0'
+      description: (L1) Ensure 'maximum password age' is set to '60 or fewer days, but not 0'
     minimum_password_age:
       data:
         'Microsoft Windows Server 2012*':
@@ -35,7 +35,7 @@ win_secedit:
               tag: CIS-1.1.3
               match_output: '1'
               value_type: 'more'
-      description: (l1) ensure 'minimum password age' is set to '1 or more day(s)'
+      description: (L1) Ensure 'minimum password age' is set to '1 or more day(s)'
     minimum_password_length:
       data:
         'Microsoft Windows Server 2012*':
@@ -43,7 +43,7 @@ win_secedit:
               tag: CIS-1.1.4
               match_output: '14'
               value_type: 'more'
-      description: (l1) ensure 'minimum password length' is set to '14 or more character(s)'
+      description: (L1) Ensure 'minimum password length' is set to '14 or more character(s)'
     password_complexity:
       data:
         'Microsoft Windows Server 2012*':
@@ -51,7 +51,7 @@ win_secedit:
               tag: CIS-1.1.5
               match_output: '1'
               value_type: 'equal'
-      description: (l1) ensure 'password must meet complexity requirements' is set to 'enabled'
+      description: (L1) Ensure 'password must meet complexity requirements' is set to 'enabled'
     reversible_encryption:
       data:
         'Microsoft Windows Server 2012*':
@@ -59,7 +59,7 @@ win_secedit:
               tag: CIS-1.1.6
               match_output: '0'
               value_type: 'equal'
-      description: (l1) ensure 'store passwords using reversible encryption' is set to 'disabled'
+      description: (L1) Ensure 'store passwords using reversible encryption' is set to 'disabled'
     lockout_duration:
       data:
         'Microsoft Windows Server 2012*':
@@ -67,7 +67,7 @@ win_secedit:
               tag: CIS-1.2.1
               match_output: '14'
               value_type: 'more'
-      description: (l1) ensure 'account lockout duration' is set to '15 or more minute(s)'
+      description: (L1) Ensure 'account lockout duration' is set to '15 or more minute(s)'
     lockout_threshold:
       data:
         'Microsoft Windows Server 2012*':
@@ -75,7 +75,7 @@ win_secedit:
               tag: CIS-1.2.2
               match_output: '11'
               value_type: 'less'
-      description: (l1) ensure 'account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0'
+      description: (L1) Ensure 'account lockout threshold' is set to '10 or fewer invalid logon attempt(s), but not 0'
     reset_lockout_counter:
       data:
         'Microsoft Windows Server 2012*':
@@ -83,13 +83,13 @@ win_secedit:
               tag: CIS-1.2.3
               match_output: '14'
               value_type: 'more'
-      description: (l1) ensure 'reset account lockout counter after' is set to '15 or more minute(s)'
+      description: (L1) Ensure 'reset account lockout counter after' is set to '15 or more minute(s)'
     access_from_network:
       data:
         'Microsoft Windows Server 2012*':
           - 'SeNetworkLogonRight':
               tag: CIS-2.2.2
-              match_output: '*S-1-5-11,*S-1-5-32-544'
+              match_output: 'Administrators, Authenticated Users'
               value_type: 'account'
       description: (l1) configure 'access this computer from the network'
     adjust_memory_quotas:
@@ -99,7 +99,7 @@ win_secedit:
               tag: CIS-2.2.5
               match_output: 'Administrators, LOCAL SERVICE, NETWORK SERVICE'
               value_type: 'match'
-      description: (l1) ensure 'adjust memory quotas for a process' is set to 'administrators, local service, network service'
+      description: (L1) Ensure 'adjust memory quotas for a process' is set to 'administrators, local service, network service'
     allow_logon_locally:
       data:
         'Microsoft Windows Server 2012*':
@@ -113,7 +113,7 @@ win_secedit:
         'Microsoft Windows Server 2012*':
           - 'SeRemoteInteractiveLogonRight':
               tag: CIS-2.2.7
-              match_output: '*S-1-5-32-544,*S-1-5-32-555'
+              match_output: Administrators
               value_type: 'account'
       description: (l1) configure 'allow log on through remote desktop services'
     back_up_files_and_directories :
@@ -123,15 +123,15 @@ win_secedit:
               tag: CIS-2.2.8
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'back up files and directories' is set to 'administrators'
+      description: (L1) Ensure 'back up files and directories' is set to 'administrators'
     change_the_system_time :
       data:
         'Microsoft Windows Server 2012*':
-          - 'SeTimeZonePrivilege':
+          - 'Changethesystemtime':
               tag: CIS-2.2.9
               match_output: 'Administrators, LOCAL SERVICE'
               value_type: 'account'
-      description: (l1) ensure 'change the system time' is set to 'administrators, local service'
+      description: (L1) Ensure 'change the system time' is set to 'administrators, local service'
     change_the_time_zone :
       data:
         'Microsoft Windows Server 2012*':
@@ -139,7 +139,7 @@ win_secedit:
               tag: CIS-2.2.10
               match_output: 'Administrators, LOCAL SERVICE'
               value_type: 'account'
-      description: (l1) ensure 'change the time zone' is set to 'administrators, local service'
+      description: (L1) Ensure 'change the time zone' is set to 'administrators, local service'
     create_a_pagefile :
       data:
         'Microsoft Windows Server 2012*':
@@ -147,7 +147,7 @@ win_secedit:
               tag: CIS-2.2.11
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'create a pagefile' is set to 'administrators'
+      description: (L1) Ensure 'create a pagefile' is set to 'administrators'
     create_global_objects :
       data:
         'Microsoft Windows Server 2012*':
@@ -155,7 +155,7 @@ win_secedit:
               tag: CIS-2.2.13
               match_output: 'Administrators, LOCAL SERVICE, NETWORK SERVICE, SERVICE'
               value_type: 'account'
-      description: (l1) ensure 'create global objects' is set to 'administrators, local service, network service, service'
+      description: (L1) Ensure 'create global objects' is set to 'administrators, local service, network service, service'
     create_symbolic_links :
       data:
         'Microsoft Windows Server 2012*':
@@ -171,13 +171,13 @@ win_secedit:
               tag: CIS-2.2.16
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'debug programs' is set to 'administrators'
+      description: (L1) Ensure 'debug programs' is set to 'administrators'
     deny_access_to_this_computer_from_the_network :
       data:
         'Microsoft Windows Server 2012*':
           - 'SeDenyNetworkLogonRight':
               tag: CIS-2.2.17
-              match_output: '*S-1-5-114,*S-1-5-32-546'
+              match_output: 'Guests'
               value_type: 'account'
       description: (l1) configure 'deny access to this computer from the network'
     deny_log_on_as_a_batch_job :
@@ -187,7 +187,7 @@ win_secedit:
               tag: CIS-2.2.18
               match_output: 'Guests'
               value_type: 'account'
-      description: (l1) ensure 'deny log on as a batch job' to include 'guests'
+      description: (L1) Ensure 'deny log on as a batch job' to include 'guests'
     deny_log_on_as_a_service :
       data:
         'Microsoft Windows Server 2012*':
@@ -195,7 +195,7 @@ win_secedit:
               tag: CIS-2.2.19
               match_output: 'Guests'
               value_type: 'account'
-      description: (l1) ensure 'deny log on as a service' to include 'guests'
+      description: (L1) Ensure 'deny log on as a service' to include 'guests'
     deny_log_on_locally :
       data:
         'Microsoft Windows Server 2012*':
@@ -203,15 +203,15 @@ win_secedit:
               tag: CIS-2.2.20
               match_output: 'Guests'
               value_type: 'account'
-      description: (l1) ensure 'deny log on locally' to include 'guests'
+      description: (L1) Ensure 'deny log on locally' to include 'guests'
     deny_log_on_through_remote_desktop_services :
       data:
         'Microsoft Windows Server 2012*':
           - 'SeDenyRemoteInteractiveLogonRight':
               tag: CIS-2.2.21
-              match_output: '*S-1-5-113,*S-1-5-32-546'
+              match_output: 'Guests, LOCAL SERVICE'
               value_type: 'account'
-      description: (l1) ensure 'deny log on through remote desktop services' to include 'guests, local account'
+      description: (L1) Ensure 'deny log on through remote desktop services' to include 'guests, local account'
     force_shutdown_from_a_remote_system :
       data:
         'Microsoft Windows Server 2012*':
@@ -219,7 +219,7 @@ win_secedit:
               tag: CIS-2.2.23
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'force shutdown from a remote system' is set to 'administrators'
+      description: (L1) Ensure 'force shutdown from a remote system' is set to 'administrators'
     generate_security_audits :
       data:
         'Microsoft Windows Server 2012*':
@@ -227,13 +227,13 @@ win_secedit:
               tag: CIS-2.2.24
               match_output: 'LOCAL SERVICE, NETWORK SERVICE'
               value_type: 'account'
-      description: (l1) ensure 'generate security audits' is set to 'local service, network service'
+      description: (L1) Ensure 'generate security audits' is set to 'local service, network service'
     impersonate_a_client_after_authentication :
       data:
         'Microsoft Windows Server 2012*':
           - 'SeImpersonatePrivilege':
               tag: CIS-2.2.25
-              match_output: '*S-1-5-19,*S-1-5-32-544,*S-1-5-32-568,*S-1-5-6'
+              match_output: 'Administrators, LOCAL SERVICE, NETWORK SERVICE, SERVICE'
               value_type: 'account'
       description: (l1) configure 'impersonate a client after authentication'
     increase_scheduling_priority :
@@ -243,7 +243,7 @@ win_secedit:
               tag: CIS-2.2.26
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'increase scheduling priority' is set to 'administrators'
+      description: (L1) Ensure 'increase scheduling priority' is set to 'administrators'
     load_and_unload_device_drivers :
       data:
         'Microsoft Windows Server 2012*':
@@ -251,12 +251,12 @@ win_secedit:
               tag: CIS-2.2.27
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'load and unload device drivers' is set to 'administrators'
+      description: (L1) Ensure 'load and unload device drivers' is set to 'administrators'
     manage_auditing_and_security_log :
       data:
         'Microsoft Windows Server 2012*':
           - 'SeSecurityPrivilege':
-              tag: CIS-2.2.30
+              tag: CIS-2.2.29
               match_output: '*S-1-5-32-544' #Administrators
               value_type: 'account'
       description: (l1) configure 'manage auditing and security log'
@@ -264,66 +264,66 @@ win_secedit:
       data:
         'Microsoft Windows Server 2012*':
           - 'SeSystemEnvironmentPrivilege':
-              tag: CIS-2.2.32
+              tag: CIS-2.2.31
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'modify firmware environment values' is set to 'administrators'
+      description: (L1) Ensure 'modify firmware environment values' is set to 'administrators'
     perform_volume_maintenance_tasks :
       data:
         'Microsoft Windows Server 2012*':
           - 'SeManageVolumePrivilege':
-              tag: CIS-2.2.33
+              tag: CIS-2.2.32
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'perform volume maintenance tasks' is set to 'administrators'
+      description: (L1) Ensure 'perform volume maintenance tasks' is set to 'administrators'
     profile_single_process :
       data:
         'Microsoft Windows Server 2012*':
           - 'SeProfileSingleProcessPrivilege':
-              tag: CIS-2.2.34
+              tag: CIS-2.2.33
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'profile single process' is set to 'administrators'
+      description: (L1) Ensure 'profile single process' is set to 'administrators'
     profile_system_performance :
       data:
         'Microsoft Windows Server 2012*':
           - 'SeSystemProfilePrivilege':
-              tag: CIS-2.2.35
-              match_output: '*S-1-5-32-544, NT SERVICE\WdiServiceHost' #Needs work for NT Service accounts
+              tag: CIS-2.2.34
+              match_output: 'Administrators, NT SERVICE\WdiServiceHost'
               value_type: 'account'
-      description: (l1) ensure 'profile system performance' is set to 'administrators, nt service\wdiservicehost'
+      description: (L1) Ensure 'profile system performance' is set to 'administrators, nt service\wdiservicehost'
     replace_a_process_level_token :
       data:
         'Microsoft Windows Server 2012*':
           - 'SeAssignPrimaryTokenPrivilege':
-              tag: CIS-2.2.36
+              tag: CIS-2.2.35
               match_output: 'LOCAL SERVICE, NETWORK SERVICE'
               value_type: 'account'
-      description: (l1) ensure 'replace a process level token' is set to 'local service, network service'
+      description: (L1) Ensure 'replace a process level token' is set to 'local service, network service'
     restore_files_and_directories :
       data:
         'Microsoft Windows Server 2012*':
           - 'SeRestorePrivilege':
-              tag: CIS-2.2.37
+              tag: CIS-2.2.36
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'restore files and directories' is set to 'administrators'
+      description: (L1) Ensure 'restore files and directories' is set to 'administrators'
     shut_down_the_system :
       data:
         'Microsoft Windows Server 2012*':
           - 'SeShutdownPrivilege':
-              tag: CIS-2.2.38
+              tag: CIS-2.2.37
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'shut down the system' is set to 'administrators'
+      description: (L1) Ensure 'shut down the system' is set to 'administrators'
     take_ownership_of_files_or_other_objects :
       data:
         'Microsoft Windows Server 2012*':
           - 'SeTakeOwnershipPrivilege':
-              tag: CIS-2.2.40
+              tag: CIS-2.2.39
               match_output: 'Administrators'
               value_type: 'account'
-      description: (l1) ensure 'take ownership of files or other objects' is set to 'administrators'
+      description: (L1) Ensure 'take ownership of files or other objects' is set to 'administrators'
     accounts_administrator_account_status :
       data:
         'Microsoft Windows Server 2012*':
@@ -331,7 +331,7 @@ win_secedit:
               tag: CIS-2.3.1.1
               match_output: '0'
               value_type: 'equal'
-      description: (l1) ensure 'accounts - administrator account status' is set to 'disabled'
+      description: (L1) Ensure 'accounts - administrator account status' is set to 'disabled'
     accounts_block_microsoft_accounts :
       data:
         'Microsoft Windows Server 2012*':
@@ -339,39 +339,39 @@ win_secedit:
               tag: CIS-2.3.1.2
               match_output: 'users cant add or log on with microsoft accounts'
               value_type: 'equal'
-      description: (l1) ensure 'accounts - - block microsoft accounts' is set to 'users can't add or log on with microsoft accounts'
+      description: (L1) Ensure 'accounts - - block microsoft accounts' is set to 'users can't add or log on with microsoft accounts'
     accounts_guest_account_status :
       data:
         'Microsoft Windows Server 2012*':
           - 'EnableGuestAccount':
               tag: CIS-2.3.1.3
-              match_output: '0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'accounts - guest account status' is set to 'disabled'
+      description: (L1) Ensure 'accounts - guest account status' is set to 'disabled'
     accounts_limit_local_account_use_of_blank_passwords_to_console_logon_only :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\LimitBlankPasswordUse':
               tag: CIS-2.3.1.4
-              match_output: '4,1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'accounts - limit local account use of blank passwords to console logon only' is set to 'enabled'
+      description: (L1) Ensure 'accounts - limit local account use of blank passwords to console logon only' is set to 'enabled'
     audit_force_audit_policy_subcategory_settings_to_override_audit_policy_category_settings :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\SCENoApplyLegacyAuditPolicy':
               tag: CIS-2.3.2.1
-              match_output: '4,1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'audit - force audit policy subcategory settings (windows vista or later) to override audit policy category settings' is set to 'enabled'
+      description: (L1) Ensure 'audit - force audit policy subcategory settings (windows vista or later) to override audit policy category settings' is set to 'enabled'
     audit_shut_down_system_immediately_if_unable_to_log_security_audits :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\CrashOnAuditFail':
               tag: CIS-2.3.2.2
-              match_output: '4,0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'audit - shut down system immediately if unable to log security audits' is set to 'disabled'
+      description: (L1) Ensure 'audit - shut down system immediately if unable to log security audits' is set to 'disabled'
     devices_allowed_to_format_and_eject_removable_media :
       data:
         'Microsoft Windows Server 2012*':
@@ -379,47 +379,47 @@ win_secedit:
               tag: CIS-2.3.4.1
               match_output: 'Administrators'
               value_type: 'equal'
-      description: (l1) ensure 'devices - allowed to format and eject removable media' is set to 'administrators'
+      description: (L1) Ensure 'devices - allowed to format and eject removable media' is set to 'administrators'
     devices_prevent_users_from_installing_printer_drivers :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Print\Providers\LanMan Print Services\Servers\AddPrinterDrivers':
               tag: CIS-2.3.4.2
-              match_output: '4,1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'devices - prevent users from installing printer drivers' is set to 'enabled'
+      description: (L1) Ensure 'devices - prevent users from installing printer drivers' is set to 'enabled'
     domain_member_digitally_encrypt_or_sign_secure_channel_data_ :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters\RequireSignOrSeal':
               tag: CIS-2.3.6.1
-              match_output: '4,1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'domain member - digitally encrypt or sign secure channel data (always)' is set to 'enabled'
+      description: (L1) Ensure 'domain member - digitally encrypt or sign secure channel data (always)' is set to 'enabled'
     domain_member_digitally_encrypt_secure_channel_data :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters\SealSecureChannel':
               tag: CIS-2.3.6.2
-              match_output: '4,1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'domain member - digitally encrypt secure channel data (when possible)' is set to 'enabled'
+      description: (L1) Ensure 'domain member - digitally encrypt secure channel data (when possible)' is set to 'enabled'
     domain_member_digitally_sign_secure_channel_data :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters\SignSecureChannel':
               tag: CIS-2.3.6.3
-              match_output: '4,1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'domain member - digitally sign secure channel data (when possible)' is set to 'enabled'
+      description: (L1) Ensure 'domain member - digitally sign secure channel data (when possible)' is set to 'enabled'
     domain_member_disable_machine_account_password_changes :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters\DisablePasswordChange':
               tag: CIS-2.3.6.4
-              match_output: '4,0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'domain member - disable machine account password changes' is set to 'disabled'
+      description: (L1) Ensure 'domain member - disable machine account password changes' is set to 'disabled'
     domain_member_maximum_machine_account_password_age :
       data:
         'Microsoft Windows Server 2012*':
@@ -427,31 +427,31 @@ win_secedit:
               tag: CIS-2.3.6.5
               match_output: '31'
               value_type: 'less'
-      description: (l1) ensure 'domain member - maximum machine account password age' is set to '30 or fewer days, but not 0'
+      description: (L1) Ensure 'domain member - maximum machine account password age' is set to '30 or fewer days, but not 0'
     domain_member_require_strong_session_key :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters\RequireStrongKey':
               tag: CIS-2.3.6.6
-              match_output: '4,1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'domain member - require strong (windows 2000 or later) session key' is set to 'enabled'
+      description: (L1) Ensure 'domain member - require strong (windows 2000 or later) session key' is set to 'enabled'
     interactive_logon_do_not_display_last_user_name :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\DontDisplayLastUserName':
               tag: CIS-2.3.7.1
-              match_output: '4,1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'interactive logon - do not display last user name' is set to 'enabled'
+      description: (L1) Ensure 'interactive logon - do not display last user name' is set to 'enabled'
     interactive_logon_do_not_require_ctrl+alt+del :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\DisableCAD':
               tag: CIS-2.3.7.2
-              match_output: '4,0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'interactive logon - do not require ctrl+alt+del' is set to 'disabled'
+      description: (L1) Ensure 'interactive logon - do not require ctrl+alt+del' is set to 'disabled'
     interactive_logon_machine_inactivity_limit :
       data:
         'Microsoft Windows Server 2012*':
@@ -459,21 +459,21 @@ win_secedit:
               tag: CIS-2.3.7.3
               match_output: '901'
               value_type: 'less'
-      description: (l1) ensure 'interactive logon - machine inactivity limit' is set to '900 or fewer second(s), but not 0'
-    interactive_logon_message_text_for_users_attempting_to_log_on :
+      description: (L1) Ensure 'interactive logon - machine inactivity limit' is set to '900 or fewer second(s), but not 0'
+    interactive_logon_message_text_for_users_attempting_to_log_on : #NOTE: Configure this
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\LegalNoticeText':
               tag: CIS-2.3.7.4
-              match_output: '' #NOTE: Change this to company standard
+              match_output: ''
               value_type: 'configured'
       description: (l1) configure 'interactive logon - message text for users attempting to log on'
-    interactive_logon_message_title_for_users_attempting_to_log_on :
+    interactive_logon_message_title_for_users_attempting_to_log_on : #NOTE: Configure this
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\LegalNoticeCaption':
               tag: CIS-2.3.7.5
-              match_output: '' #NOTE: Change this to company standard
+              match_output: ''
               value_type: 'configured'
       description: (l1) configure 'interactive logon - message title for users attempting to log on'
     interactive_logon_number_of_previous_logons_to_cache:
@@ -491,13 +491,13 @@ win_secedit:
               tag: CIS-2.3.7.7
               match_output: '15' # between 5 and 14
               value_type: 'less'
-      description: (l1) ensure 'interactive logon - prompt user to change password before expiration' is set to 'between 5 and 14 days'
+      description: (L1) Ensure 'interactive logon - prompt user to change password before expiration' is set to 'between 5 and 14 days'
     interactive_logon_require_domain_controller_authentication_to_unlock_workstation :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\ForceUnlockLogon':
               tag: CIS-2.3.7.8
-              match_output: '4,1'
+              match_output: 'Enabled'
               value_type: 'equal'
       description: 'Interactive logon Require Domain Controller Authentication to unlock workstation'
     interactive_logon_smart_card_removal_behavior :
@@ -507,31 +507,31 @@ win_secedit:
               tag: CIS-2.3.7.9
               match_output: 'Lock Workstation' # can be anything but No Action
               value_type: 'equal'
-      description: (l1) ensure 'interactive logon - smart card removal behavior' is set to 'lock workstation' or higher
-    microsoft_network_client_digitally_sign_communications_ :
+      description: (L1) Ensure 'interactive logon - smart card removal behavior' is set to 'lock workstation' or higher
+    microsoft_network_client_digitally_sign_communications_always :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters\RequireSecuritySignature':
               tag: CIS-2.3.8.1
-              match_output: '4,1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'microsoft network client - digitally sign communications (always)' is set to 'enabled'
-    microsoft_network_client_digitally_sign_communications_ :
+      description: (L1) Ensure 'microsoft network client - digitally sign communications (always)' is set to 'enabled'
+    microsoft_network_client_digitally_sign_communications_if_server_agrees :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters\EnableSecuritySignature':
               tag: CIS-2.3.8.2
-              match_output: '4,1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'microsoft network client - digitally sign communications (if server agrees)' is set to 'enabled'
+      description: (L1) Ensure 'microsoft network client - digitally sign communications (if server agrees)' is set to 'enabled'
     microsoft_network_client_send_unencrypted_password_to_third-party_smb_servers :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters\EnablePlainTextPassword':
               tag: CIS-2.3.8.3
-              match_output: '4,0'
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'microsoft network client - send unencrypted password to third-party smb servers' is set to 'disabled'
+      description: (L1) Ensure 'microsoft network client - send unencrypted password to third-party smb servers' is set to 'disabled'
     microsoft_network_server_amount_of_idle_time_required_before_suspending_session :
       data:
         'Microsoft Windows Server 2012*':
@@ -539,287 +539,279 @@ win_secedit:
               tag: CIS-2.3.9.1
               match_output: '16'
               value_type: 'less'
-      description: (l1) ensure 'microsoft network server - amount of idle time required before suspending session' is set to '15 or fewer minute(s), but not 0'
-    microsoft_network_server_digitally_sign_communications_ :
+      description: (L1) Ensure 'microsoft network server - amount of idle time required before suspending session' is set to '15 or fewer minute(s), but not 0'
+    microsoft_network_server_digitally_sign_communications_always :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\RequireSecuritySignature':
               tag: CIS-2.3.9.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'microsoft network server - digitally sign communications (always)' is set to 'enabled'
-    microsoft_network_server_digitally_sign_communications_ :
+      description: (L1) Ensure 'microsoft network server - digitally sign communications (always)' is set to 'enabled'
+    microsoft_network_server_digitally_sign_communications_if_client_agrees :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\EnableSecuritySignature':
               tag: CIS-2.3.9.3
-              match_output: '4,1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'microsoft network server - digitally sign communications (if client agrees)' is set to 'enabled'
+      description: (L1) Ensure 'microsoft network server - digitally sign communications (if client agrees)' is set to 'enabled'
     microsoft_network_server_disconnect_clients_when_logon_hours_expire :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\EnableForcedLogOff':
               tag: CIS-2.3.9.4
-              match_output: '4,1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'microsoft network server - disconnect clients when logon hours expire' is set to 'enabled'
+      description: (L1) Ensure 'microsoft network server - disconnect clients when logon hours expire' is set to 'enabled'
     microsoft_network_server_server_spn_target_name_validation_level :
       data:
         'Microsoft Windows Server 2012*':
-          - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\SmbServerNameHardeningLevel':
+          - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\SMBServerNameHardeningLevel':
               tag: CIS-2.3.9.5
-              match_output: '4,1'
+              match_output: 'Accept if provided by client'
               value_type: 'equal'
-      description: (l1) ensure 'microsoft network server - server spn target name validation level' is set to 'accept if provided by client' or higher
+      description: (L1) Ensure 'microsoft network server - server spn target name validation level' is set to 'accept if provided by client' or higher
     network_access_allow_anonymous_sid/name_translation :
       data:
         'Microsoft Windows Server 2012*':
           - 'LSAAnonymousNameLookup':
-              tag: CIS-2.3.10.1
-              match_output: '0'
+              tag: CIS-2.3.11.1
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'network access - allow anonymous sid/name translation' is set to 'disabled'
+      description: (L1) Ensure 'network access - allow anonymous sid/name translation' is set to 'disabled'
     network_access_do_not_allow_anonymous_enumeration_of_sam_accounts :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\RestrictAnonymousSAM':
-              tag: CIS-2.3.10.2
-              match_output: '4,1'
+              tag: CIS-2.3.11.2
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'network access - do not allow anonymous enumeration of sam accounts' is set to 'enabled'
+      description: (L1) Ensure 'network access - do not allow anonymous enumeration of sam accounts' is set to 'enabled'
     network_access_do_not_allow_anonymous_enumeration_of_sam_accounts_and_shares :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\RestrictAnonymous':
-              tag: CIS-2.3.10.3
-              match_output: '4,1'
+              tag: CIS-2.3.11.3
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'network access - do not allow anonymous enumeration of sam accounts and shares' is set to 'enabled'
-    network_access_do_not_allow_storage_of_passwords_and_credentials_for_network_authentication :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'MACHINE\System\CurrentControlSet\Control\Lsa\DisableDomainCreds':
-              tag: CIS-2.3.10.4
-              match_output: '4,0'
-              value_type: 'equal'
-      description: 'Network access Do not allow storage of passwords and credentials for network authentication'
+      description: (L1) Ensure 'network access - do not allow anonymous enumeration of sam accounts and shares' is set to 'enabled'
     network_access_let_everyone_persmissions_apply_to_anonymous_users :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\EveryoneIncludesAnonymous':
-              tag: CIS-2.3.10.5
-              match_output: '4,0'
+              tag: CIS-2.3.11.5
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'network access - let everyone permissions apply to anonymous users' is set to 'disabled'
+      description: (L1) Ensure 'network access - let everyone permissions apply to anonymous users' is set to 'disabled'
     network_access_remotely_accessible_registry_paths :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\SecurePipeServers\Winreg\AllowedExactPaths\Machine':
-              tag: CIS-2.3.10.7
-              match_output: '7,System\CurrentControlSet\Control\ProductOptions,System\CurrentControlSet\Control\Server Applications,Software\Microsoft\Windows NT\CurrentVersion'
+              tag: CIS-2.3.11.7
+              match_output: 'System\CurrentControlSet\Control\ProductOptions, System\CurrentControlSet\Control\Server Applications, Software\Microsoft\Windows NT\CurrentVersion'
               value_type: 'equal'
-      description: (l1) ensure 'network access - remotely accessible registry paths'
+      description: (L1) Ensure 'network access - remotely accessible registry paths'
     network_access_remotely_accessible_registry_paths_and_sub-paths :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\SecurePipeServers\Winreg\AllowedPaths\Machine':
-              tag: CIS-2.3.10.8
-              match_output: '7,System\CurrentControlSet\Control\Print\Printers,System\CurrentControlSet\Services\Eventlog,Software\Microsoft\OLAP Server,Software\Microsoft\Windows NT\CurrentVersion\Print,Software\Microsoft\Windows NT\CurrentVersion\Windows,System\CurrentControlSet\Control\ContentIndex,System\CurrentControlSet\Control\Terminal Server,System\CurrentControlSet\Control\Terminal Server\UserConfig,System\CurrentControlSet\Control\Terminal Server\DefaultUserConfiguration,Software\Microsoft\Windows NT\CurrentVersion\Perflib, System\CurrentControlSet\Services\SysmonLog'
+              tag: CIS-2.3.11.8
+              match_output: 'System\CurrentControlSet\Control\Print\Printers, System\CurrentControlSet\Services\Eventlog, Software\Microsoft\OLAP Server, Software\Microsoft\Windows NT\CurrentVersion\Print, Software\Microsoft\Windows NT\CurrentVersion\Windows, System\CurrentControlSet\Control\ContentIndex, System\CurrentControlSet\Control\Terminal Server, System\CurrentControlSet\Control\Terminal Server\UserConfig, System\CurrentControlSet\Control\Terminal Server\DefaultUserConfiguration, Software\Microsoft\Windows NT\CurrentVersion\Perflib, System\CurrentControlSet\Services\SysmonLog'
               value_type: 'equal'
-      description: (l1) ensure 'network access - remotely accessible registry paths and sub-paths'
+      description: (L1) Ensure 'network access - remotely accessible registry paths and sub-paths'
     network_access_restrict_anonymous_access_to_named_pipes_and_shares :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\RestrictNullSessAccess':
-              tag: CIS-2.3.10.9
-              match_output: '4,1'
+              tag: CIS-2.3.11.9
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'network access - restrict anonymous access to named pipes and shares' is set to 'enabled'
+      description: (L1) Ensure 'network access - restrict anonymous access to named pipes and shares' is set to 'enabled'
     network_access_sharing_and_security_model_for_local_accounts :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\ForceGuest':
-              tag: CIS-2.3.10.11
-              match_output: '4,0'
+              tag: CIS-2.3.11.11
+              match_output: 'Classic - local users authenticate as themselves'
               value_type: 'equal'
-      description: (l1) ensure 'network access - sharing and security model for local accounts' is set to 'classic - local users authenticate as themselves'
+      description: (L1) Ensure 'network access - sharing and security model for local accounts' is set to 'classic - local users authenticate as themselves'
     network_security_allow_local_system_to_use_computer_identity_for_ntlm :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\UseMachineId':
-              tag: CIS-2.3.11.1
-              match_output: '4,1'
+              tag: CIS-2.3.12.1
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'network security - allow local system to use computer identity for ntlm' is set to 'enabled'
+      description: (L1) Ensure 'network security - allow local system to use computer identity for ntlm' is set to 'enabled'
     network_security_allow_localsystem_null_session_fallback :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0\allownullsessionfallback':
-              tag: CIS-2.3.11.2
-              match_output: '4,0'
+              tag: CIS-2.3.12.2
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'network security - allow localsystem null session fallback' is set to 'disabled'
+      description: (L1) Ensure 'network security - allow localsystem null session fallback' is set to 'disabled'
     network_security_allow_pku2u_authentication_requests_to_this_computer_to_use_online_identities :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\pku2u\AllowOnlineID':
-              tag: CIS-2.3.11.3
-              match_output: '4,0'
+              tag: CIS-2.3.12.3
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'network security - allow pku2u authentication requests to this computer to use online identities' is set to 'disabled'
+      description: (L1) Ensure 'network security - allow pku2u authentication requests to this computer to use online identities' is set to 'disabled'
     network_security_configure_encryption_types_allowed_for_kerberos :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\Kerberos\Parameters\SupportedEncryptionTypes':
-              tag: CIS-2.3.11.4
-              match_output: '4,2147483644'
+              tag: CIS-2.3.12.4
+              match_output: 'RC4_HMAC_MD5, AES128_HMAC_SHA1, AES256_HMAC_SHA1, Future encryption types'
               value_type: 'equal'
-      description: (l1) ensure 'network security - configure encryption types allowed for kerberos' is set to 'rc4_hmac_md5, aes128_hmac_sha1, aes256_hmac_sha1, future encryption types'
+      description: (L1) Ensure 'network security - configure encryption types allowed for kerberos' is set to 'rc4_hmac_md5, aes128_hmac_sha1, aes256_hmac_sha1, future encryption types'
     network_security_do_not_store_lan_manager_hash_value_on_next_password_change :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\NoLMHash':
-              tag: CIS-2.3.11.5
-              match_output: '4,1'
+              tag: CIS-2.3.12.5
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'network security - do not store lan manager hash value on next password change' is set to 'enabled'
+      description: (L1) Ensure 'network security - do not store lan manager hash value on next password change' is set to 'enabled'
     network_security_force_logoff_when_logon_hours_expire :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\EnableForcedLogOff':
-              tag: CIS-2.3.11.6
-              match_output: '4,1'
+              tag: CIS-2.3.12.6
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'network security - force logoff when logon hours expire' is set to 'enabled'
+      description: (L1) Ensure 'network security - force logoff when logon hours expire' is set to 'enabled'
     network_security_lan_manager_authentication_level :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\LmCompatibilityLevel':
-              tag: CIS-2.3.11.7
-              match_output: '4,5'
+              tag: CIS-2.3.12.7
+              match_output: 'Send NTLMv2 response only. Refuse LM & NTLM'
               value_type: 'equal'
-      description: (l1) ensure 'network security - lan manager authentication level' is set to 'send ntlmv2 response only. refuse lm & ntlm'
+      description: (L1) Ensure 'network security - lan manager authentication level' is set to 'send ntlmv2 response only. refuse lm & ntlm'
     network_security_ldap_client_signing_requirements :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\LDAP\LDAPClientIntegrity':
-              tag: CIS-2.3.11.8
+              tag: CIS-2.3.12.8
               match_output: 'Negotiate signing'
               value_type: 'equal'
-      description: (l1) ensure 'network security - ldap client signing requirements' is set to 'negotiate signing' or higher
+      description: (L1) Ensure 'network security - ldap client signing requirements' is set to 'negotiate signing' or higher
     network_security_minimum_session_security_for_ntlm_ssp_based_clients :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0\NTLMMinClientSec':
-              tag: CIS-2.3.11.9
+              tag: CIS-2.3.12.9
               match_output: 'Require NTLMv2 session security, Require 128-bit encryption'
               value_type: 'equal'
-      description: (l1) ensure 'network security - minimum session security for ntlm ssp based (including secure rpc) clients' is set to 'require ntlmv2 session security, require 128-bit encryption'
+      description: (L1) Ensure 'network security - minimum session security for ntlm ssp based (including secure rpc) clients' is set to 'require ntlmv2 session security, require 128-bit encryption'
     network_security_minimum_session_security_for_ntlm_ssp_based_(including_secure_rpc_servers :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0\NTLMMinServerSec':
-              tag: CIS-2.3.11.10
+              tag: CIS-2.3.12.10
               match_output: 'Require NTLMv2 session security, Require 128-bit encryption'
               value_type: 'equal'
-      description: (l1) ensure 'network security - minimum session security for ntlm ssp based (including secure rpc) servers' is set to 'require ntlmv2 session security, require 128-bit encryption'
+      description: (L1) Ensure 'network security - minimum session security for ntlm ssp based (including secure rpc) servers' is set to 'require ntlmv2 session security, require 128-bit encryption'
     shutdown_allow_system_to_be_shut_down_without_having_to_log_on :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\ShutdownWithoutLogon':
-              tag: CIS-2.3.13.1
-              match_output: '4,0'
+              tag: CIS-2.3.14.1
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'shutdown - allow system to be shut down without having to log on' is set to 'disabled'
+      description: (L1) Ensure 'shutdown - allow system to be shut down without having to log on' is set to 'disabled'
     system_objects_require_case_insensitivity_for_non-windows_subsystems :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Session Manager\Kernel\ObCaseInsensitive':
-              tag: CIS-2.3.15.1
-              match_output: '4,1'
+              tag: CIS-2.3.16.1
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'system objects - require case insensitivity for non-windows subsystems' is set to 'enabled'
+      description: (L1) Ensure 'system objects - require case insensitivity for non-windows subsystems' is set to 'enabled'
     system_objects_strengthen_default_permissions_of_internal_system_objects_(e.g._symbolic_links :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Control\Session Manager\ProtectionMode':
-              tag: CIS-2.3.15.2
-              match_output: '4,1'
+              tag: CIS-2.3.16.2
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'system objects - strengthen default permissions of internal system objects (e.g. symbolic links)' is set to 'enabled'
+      description: (L1) Ensure 'system objects - strengthen default permissions of internal system objects (e.g. symbolic links)' is set to 'enabled'
     user_account_control_admin_approval_mode_for_the_built-in_administrator_account :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\FilterAdministratorToken':
-              tag: CIS-2.3.17.1
-              match_output: '4,1'
+              tag: CIS-2.3.18.1
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - admin approval mode for the built-in administrator account' is set to 'enabled'
+      description: (L1) Ensure 'user account control - admin approval mode for the built-in administrator account' is set to 'enabled'
     user_account_control_allow_uiaccess_applications_to_prompt_for_elevation_without_using_the_secure_desktop :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\EnableUIADesktopToggle':
-              tag: CIS-2.3.17.2
-              match_output: '4,0'
+              tag: CIS-2.3.18.2
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - allow uiaccess applications to prompt for elevation without using the secure desktop' is set to 'disabled'
+      description: (L1) Ensure 'user account control - allow uiaccess applications to prompt for elevation without using the secure desktop' is set to 'disabled'
     user_account_control_behavior_of_the_elevation_prompt_for_administrators_in_admin_approval_mode :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\ConsentPromptBehaviorAdmin':
-              tag: CIS-2.3.17.3
+              tag: CIS-2.3.18.3
               match_output: 'Prompt for consent on the secure desktop'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - behavior of the elevation prompt for administrators in admin approval mode' is set to 'prompt for consent on the secure desktop'
+      description: (L1) Ensure 'user account control - behavior of the elevation prompt for administrators in admin approval mode' is set to 'prompt for consent on the secure desktop'
     user_account_control_behavior_of_the_elevation_prompt_for_standard_users :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\ConsentPromptBehaviorUser':
-              tag: CIS-2.3.17.4
+              tag: CIS-2.3.18.4
               match_output: 'Automatically deny elevation requests'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - behavior of the elevation prompt for standard users' is set to 'automatically deny elevation requests'
+      description: (L1) Ensure 'user account control - behavior of the elevation prompt for standard users' is set to 'automatically deny elevation requests'
     user_account_control_detect_application_installations_and_prompt_for_elevation :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\EnableInstallerDetection':
-              tag: CIS-2.3.17.5
-              match_output: '4,1'
+              tag: CIS-2.3.18.5
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - detect application installations and prompt for elevation' is set to 'enabled'
+      description: (L1) Ensure 'user account control - detect application installations and prompt for elevation' is set to 'enabled'
     user_account_control_only_elevate_uiaccess_applications_that_are_installed_in_secure_locations :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\EnableSecureUIAPaths':
-              tag: CIS-2.3.17.6
-              match_output: '4,1'
+              tag: CIS-2.3.18.6
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - only elevate uiaccess applications that are installed in secure locations' is set to 'enabled'
+      description: (L1) Ensure 'user account control - only elevate uiaccess applications that are installed in secure locations' is set to 'enabled'
     user_account_control_run_all_administrators_in_admin_approval_mode :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\EnableLUA':
-              tag: CIS-2.3.17.7
-              match_output: '4,1'
+              tag: CIS-2.3.18.7
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - run all administrators in admin approval mode' is set to 'enabled'
+      description: (L1) Ensure 'user account control - run all administrators in admin approval mode' is set to 'enabled'
     user_account_control_switch_to_the_secure_desktop_when_prompting_for_elevation :
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\PromptOnSecureDesktop':
-              tag: CIS-2.3.17.8
-              match_output: '4,1'
+              tag: CIS-2.3.18.8
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - switch to the secure desktop when prompting for elevation' is set to 'enabled'
+      description: (L1) Ensure 'user account control - switch to the secure desktop when prompting for elevation' is set to 'enabled'
     user_account_control_virtualize_file_and_registry_write_failures_to_per-user_locations :
       data:
         'Microsoft Windows Server 2012*':
-          - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\EnableVirtualization':
-              tag: CIS-2.3.17.9
-              match_output: '4,1'
+          - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\':
+              tag: CIS-2.3.18.9
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'user account control - virtualize file and registry write failures to per-user locations' is set to 'enabled'
+      description: (L1) Ensure 'user account control - virtualize file and registry write failures to per-user locations' is set to 'enabled'
 
   blacklist:
     accounts_rename_administrator_account :
@@ -841,8 +833,8 @@ win_secedit:
     network_access_named_pipes_that_can_be_accessed_anonymously :
       data:
         'Microsoft Windows Server 2012*':
-          - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\':
-              tag: CIS-2.3.10.6
+          - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\NullSessionPipes':
+              tag: CIS-2.3.11.6
               match_output: ''
               value_type: 'equal'
       description: (l1) configure 'network access - named pipes that can be accessed anonymously'
@@ -850,10 +842,10 @@ win_secedit:
       data:
         'Microsoft Windows Server 2012*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\NullSessionShares':
-              tag: CIS-2.3.10.10
+              tag: CIS-2.3.11.10
               match_output: ''
               value_type: 'equal'
-      description: (l1) ensure 'network access - shares that can be accessed anonymously' is set to 'none'
+      description: (L1) Ensure 'network access - shares that can be accessed anonymously' is set to 'none'
     access_credential_manager:
       data:
         'Microsoft Windows Server 2012*':
@@ -861,7 +853,7 @@ win_secedit:
               tag: CIS-2.2.1
               match_output: 'No One'
               value_type: 'match'
-      description: (l1) ensure 'access credential manager as a trusted caller' is set to 'no one'
+      description: (L1) Ensure 'access credential manager as a trusted caller' is set to 'no one'
     act_as_operating_system:
       data:
         'Microsoft Windows Server 2012*':
@@ -869,7 +861,7 @@ win_secedit:
               tag: CIS-2.2.3
               match_output: 'No One'
               value_type: 'match'
-      description: (l1) ensure 'act as part of the operating system' is set to 'no one'
+      description: (L1) Ensure 'act as part of the operating system' is set to 'no one'
     create_a_token_object :
       data:
         'Microsoft Windows Server 2012*':
@@ -877,7 +869,7 @@ win_secedit:
               tag: CIS-2.2.12
               match_output: 'No One'
               value_type: 'account'
-      description: (l1) ensure 'create a token object' is set to 'no one'
+      description: (L1) Ensure 'create a token object' is set to 'no one'
     create_permanent_shared_objects :
       data:
         'Microsoft Windows Server 2012*':
@@ -885,7 +877,7 @@ win_secedit:
               tag: CIS-2.2.14
               match_output: 'No One'
               value_type: 'account'
-      description: (l1) ensure 'create permanent shared objects' is set to 'no one'
+      description: (L1) Ensure 'create permanent shared objects' is set to 'no one'
     enable_computer_and_user_accounts_to_be_trusted_for_delegation :
       data:
         'Microsoft Windows Server 2012*':
@@ -901,23 +893,15 @@ win_secedit:
               tag: CIS-2.2.28
               match_output: 'No One'
               value_type: 'account'
-      description: (l1) ensure 'lock pages in memory' is set to 'no one'
+      description: (L1) Ensure 'lock pages in memory' is set to 'no one'
     modify_an_object_label :
       data:
         'Microsoft Windows Server 2012*':
           - 'SeRelabelPrivilege':
-              tag: CIS-2.2.31
+              tag: CIS-2.2.30
               match_output: 'No One'
               value_type: 'account'
-      description: (l1) ensure 'modify an object label' is set to 'no one'
-    synchronize_directory_service_data :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'SeSyncAgentPrivilege':
-              tag: CIS-2.2.39
-              match_output: 'No One'
-              value_type: 'account'
-      description: (l1) ensure 'synchronize directory service data' is set to 'no one' (dc only)
+      description: (L1) Ensure 'modify an object label' is set to 'no one'
 
 win_firewall:
   whitelist:
@@ -928,7 +912,7 @@ win_firewall:
               tag: CIS-9.1.1
               match_output: 'True'
               value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - firewall state' is set to 'on (recommended)'
+      description: (L1) Ensure 'windows firewall - domain - firewall state' is set to 'on (recommended)'
     windows_firewall_domain_inbound_connections :
       data:
         'Microsoft Windows Server 2012*':
@@ -936,7 +920,7 @@ win_firewall:
               tag: CIS-9.1.2
               match_output: 'Block'
               value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - inbound connections' is set to 'block (default)'
+      description: (L1) Ensure 'windows firewall - domain - inbound connections' is set to 'block (default)'
     windows_firewall_domain_outbound_connections :
       data:
         'Microsoft Windows Server 2012*':
@@ -944,63 +928,71 @@ win_firewall:
               tag: CIS-9.1.3
               match_output: 'Allow'
               value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - outbound connections' is set to 'allow (default)'
+      description: (L1) Ensure 'windows firewall - domain - outbound connections' is set to 'allow (default)'
     windows_firewall_domain_settings_display_a_notification :
       data:
         'Microsoft Windows Server 2012*':
-          - 'NotifyOnListen':
+          - 'DisplayANotification':
               tag: CIS-9.1.4
               match_output: 'False'
               value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - settings - display a notification' is set to 'no'
+      description: (L1) Ensure 'windows firewall - domain - settings - display a notification' is set to 'no'
+    windows_firewall_domain_settings_allow_unicast_response :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'AllowUnicastResponse':
+              tag: CIS-9.1.5
+              match_output: 'False'
+              value_type: 'domain'
+      description: "(L1) Set 'Windows Firewall: Domain: Allow unicast response' to 'No'"
     windows_firewall_domain_settings_apply_local_firewall_rules :
       data:
         'Microsoft Windows Server 2012*':
           - 'AllowLocalFirewallRules':
-              tag: CIS-9.1.5
+              tag: CIS-9.1.6
               match_output: 'True'
               value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - settings - apply local firewall rules' is set to 'yes (default)'
+      description: (L1) Ensure 'windows firewall - domain - settings - apply local firewall rules' is set to 'yes (default)'
     windows_firewall_domain_settings_apply_local_connection_security_rules :
       data:
         'Microsoft Windows Server 2012*':
           - 'AllowLocalIPsecRules':
-              tag: CIS-9.1.6
+              tag: CIS-9.1.7
               match_output: 'True'
               value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - settings - apply local connection security rules' is set to 'yes (default)'
+      description: (L1) Ensure 'windows firewall - domain - settings - apply local connection security rules' is set to 'yes (default)'
     windows_firewall_domain_logging_name :
       data:
         'Microsoft Windows Server 2012*':
           - 'LogFileName':
-              tag: CIS-9.1.7
+              tag: CIS-9.1.8
               match_output: '%SYSTEMROOT%\System32\logfiles\firewall\domainfw.log'
               value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - logging - name' is set to '%systemroot%\system32\logfiles\firewall\domainfw.log'
+      description: (L1) Ensure 'windows firewall - domain - logging - name' is set to '%systemroot%\system32\logfiles\firewall\domainfw.log'
     windows_firewall_domain_logging_size_limit :
       data:
         'Microsoft Windows Server 2012*':
           - 'LogMaxSizeKilobytes':
-              tag: CIS-9.1.8
+              tag: CIS-9.1.9
               match_output: '16384'
               value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - logging - size limit (kb)' is set to '16,384 kb or greater'
+      description: (L1) Ensure 'windows firewall - domain - logging - size limit (kb)' is set to '16,384 kb or greater'
     windows_firewall_domain_logging_log_dropped_packets :
       data:
         'Microsoft Windows Server 2012*':
           - 'LogBlocked':
-              tag: CIS-9.1.9
+              tag: CIS-9.1.10
               match_output: 'True'
               value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - logging - log dropped packets' is set to 'yes'
+      description: (L1) Ensure 'windows firewall - domain - logging - log dropped packets' is set to 'yes'
     windows_firewall_domain_logging_log_successful_connections :
       data:
         'Microsoft Windows Server 2012*':
           - 'LogAllowed':
-              tag: CIS-9.1.10
+              tag: CIS-9.1.11
               match_output: 'True'
               value_type: 'domain'
-      description: (l1) ensure 'windows firewall - domain - logging - log successful connections' is set to 'yes'
+      description: (L1) Ensure 'windows firewall - domain - logging - log successful connections' is set to 'yes'
     windows_firewall_private_firewall_state :
       data:
         'Microsoft Windows Server 2012*':
@@ -1008,7 +1000,7 @@ win_firewall:
               tag: CIS-9.2.1
               match_output: 'True'
               value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - firewall state' is set to 'on (recommended)'
+      description: (L1) Ensure 'windows firewall - private - firewall state' is set to 'on (recommended)'
     windows_firewall_private_inbound_connections :
       data:
         'Microsoft Windows Server 2012*':
@@ -1016,7 +1008,7 @@ win_firewall:
               tag: CIS-9.2.2
               match_output: 'Block'
               value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - inbound connections' is set to 'block (default)'
+      description: (L1) Ensure 'windows firewall - private - inbound connections' is set to 'block (default)'
     windows_firewall_private_outbound_connections :
       data:
         'Microsoft Windows Server 2012*':
@@ -1024,63 +1016,71 @@ win_firewall:
               tag: CIS-9.2.3
               match_output: 'Allow'
               value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - outbound connections' is set to 'allow (default)'
+      description: (L1) Ensure 'windows firewall - private - outbound connections' is set to 'allow (default)'
     windows_firewall_private_settings_display_a_notification :
       data:
         'Microsoft Windows Server 2012*':
-          - 'NotifyOnListen':
+          - 'DisplayANotification':
               tag: CIS-9.2.4
               match_output: 'False'
               value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - settings - display a notification' is set to 'no'
+      description: (L1) Ensure 'windows firewall - private - settings - display a notification' is set to 'no'
+    windows_firewall_private_settings_allow_unicast_response :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'AllowUnicastResponse':
+              tag: CIS-9.2.5
+              match_output: 'False'
+              value_type: 'private'
+      description: "(L1) Set 'Windows Firewall: private: Allow unicast response' to 'No'"
     windows_firewall_private_settings_apply_local_firewall_rules :
       data:
         'Microsoft Windows Server 2012*':
           - 'AllowLocalFirewallRules':
-              tag: CIS-9.2.5
+              tag: CIS-9.2.6
               match_output: 'True'
               value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - settings - apply local firewall rules' is set to 'yes (default)'
+      description: (L1) Ensure 'windows firewall - private - settings - apply local firewall rules' is set to 'yes (default)'
     windows_firewall_private_settings_apply_local_connection_security_rules :
       data:
         'Microsoft Windows Server 2012*':
           - 'AllowLocalIPsecRules':
-              tag: CIS-9.2.6
+              tag: CIS-9.2.7
               match_output: 'True'
               value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - settings - apply local connection security rules' is set to 'yes (default)'
+      description: (L1) Ensure 'windows firewall - private - settings - apply local connection security rules' is set to 'yes (default)'
     windows_firewall_private_logging_name :
       data:
         'Microsoft Windows Server 2012*':
           - 'LogFileName':
-              tag: CIS-9.2.7
+              tag: CIS-9.2.8
               match_output: '%SYSTEMROOT%\System32\logfiles\firewall\privatefw.log'
               value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - logging - name' is set to '%systemroot%\system32\logfiles\firewall\privatefw.log'
+      description: (L1) Ensure 'windows firewall - private - logging - name' is set to '%systemroot%\system32\logfiles\firewall\privatefw.log'
     windows_firewall_private_logging_size_limit :
       data:
         'Microsoft Windows Server 2012*':
           - 'LogMaxSizeKilobytes':
-              tag: CIS-9.2.8
+              tag: CIS-9.2.9
               match_output: '16384'
               value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - logging - size limit (kb)' is set to '16,384 kb or greater'
+      description: (L1) Ensure 'windows firewall - private - logging - size limit (kb)' is set to '16,384 kb or greater'
     windows_firewall_private_logging_log_dropped_packets :
       data:
         'Microsoft Windows Server 2012*':
           - 'LogBlocked':
-              tag: CIS-9.2.9
+              tag: CIS-9.2.10
               match_output: 'True'
               value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - logging - log dropped packets' is set to 'yes'
+      description: (L1) Ensure 'windows firewall - private - logging - log dropped packets' is set to 'yes'
     windows_firewall_private_logging_log_successful_connections :
       data:
         'Microsoft Windows Server 2012*':
           - 'LogAllowed':
-              tag: CIS-9.2.10
+              tag: CIS-9.2.11
               match_output: 'True'
               value_type: 'private'
-      description: (l1) ensure 'windows firewall - private - logging - log successful connections' is set to 'yes'
+      description: (L1) Ensure 'windows firewall - private - logging - log successful connections' is set to 'yes'
     windows_firewall_public_firewall_state :
       data:
         'Microsoft Windows Server 2012*':
@@ -1088,7 +1088,7 @@ win_firewall:
               tag: CIS-9.3.1
               match_output: 'True'
               value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - firewall state' is set to 'on (recommended)'
+      description: (L1) Ensure 'windows firewall - public - firewall state' is set to 'on (recommended)'
     windows_firewall_public_inbound_connections :
       data:
         'Microsoft Windows Server 2012*':
@@ -1096,7 +1096,7 @@ win_firewall:
               tag: CIS-9.3.2
               match_output: 'Block'
               value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - inbound connections' is set to 'block (default)'
+      description: (L1) Ensure 'windows firewall - public - inbound connections' is set to 'block (default)'
     windows_firewall_public_outbound_connections :
       data:
         'Microsoft Windows Server 2012*':
@@ -1104,63 +1104,71 @@ win_firewall:
               tag: CIS-9.3.3
               match_output: 'Allow'
               value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - outbound connections' is set to 'allow (default)'
+      description: (L1) Ensure 'windows firewall - public - outbound connections' is set to 'allow (default)'
     windows_firewall_public_settings_display_a_notification :
       data:
         'Microsoft Windows Server 2012*':
-          - 'NotifyOnListen':
+          - 'DisplayANotification':
               tag: CIS-9.3.4
               match_output: 'True'
               value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - settings -  display a notification' is set to 'yes'
+      description: (L1) Ensure 'windows firewall - public - settings -  display a notification' is set to 'yes'
+    windows_firewall_public_settings_allow_unicast_response :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'AllowUnicastResponse':
+              tag: CIS-9.3.5
+              match_output: 'False'
+              value_type: 'public'
+      description: "(L1) Set 'Windows Firewall: Public: Allow unicast response' to 'No'"
     windows_firewall_public_settings_apply_local_firewall_rules :
       data:
         'Microsoft Windows Server 2012*':
           - 'AllowLocalFirewallRules':
-              tag: CIS-9.3.5
+              tag: CIS-9.3.6
               match_output: 'False'
               value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - settings -  apply local firewall rules' is set to 'no'
+      description: (L1) Ensure 'windows firewall - public - settings -  apply local firewall rules' is set to 'no'
     windows_firewall_public_settings_apply_local_connection_security_rules :
       data:
         'Microsoft Windows Server 2012*':
           - 'AllowLocalIPsecRules':
-              tag: CIS-9.3.6
+              tag: CIS-9.3.7
               match_output: 'False'
               value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - settings -  apply local connection security rules' is set to 'no'
+      description: (L1) Ensure 'windows firewall - public - settings -  apply local connection security rules' is set to 'no'
     windows_firewall_public_logging_name :
       data:
         'Microsoft Windows Server 2012*':
           - 'LogFileName':
-              tag: CIS-9.3.7
+              tag: CIS-9.3.8
               match_output: '%SYSTEMROOT%\System32\logfiles\firewall\publicfw.log'
               value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - logging -  name' is set to '%systemroot%\system32\logfiles\firewall\publicfw.log'
+      description: (L1) Ensure 'windows firewall - public - logging -  name' is set to '%systemroot%\system32\logfiles\firewall\publicfw.log'
     windows_firewall_public_logging_size_limit_(kb :
       data:
         'Microsoft Windows Server 2012*':
           - 'LogMaxSizeKilobytes':
-              tag: CIS-9.3.8
+              tag: CIS-9.3.9
               match_output: '16384'
               value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - logging -  size limit (kb)' is set to '16,384 kb or greater'
+      description: (L1) Ensure 'windows firewall - public - logging -  size limit (kb)' is set to '16,384 kb or greater'
     windows_firewall_public_logging_log_dropped_packets :
       data:
         'Microsoft Windows Server 2012*':
           - 'LogBlocked':
-              tag: CIS-9.3.9
+              tag: CIS-9.3.10
               match_output: 'True'
               value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - logging -  log dropped packets' is set to 'yes'
+      description: (L1) Ensure 'windows firewall - public - logging -  log dropped packets' is set to 'yes'
     windows_firewall_public_logging_log_successful_connections :
       data:
         'Microsoft Windows Server 2012*':
           - 'LogAllowed':
-              tag: CIS-9.3.10
+              tag: CIS-9.3.11
               match_output: 'True'
               value_type: 'public'
-      description: (l1) ensure 'windows firewall - public - logging -  log successful connections' is set to 'yes'
+      description: (L1) Ensure 'windows firewall - public - logging -  log successful connections' is set to 'yes'
 
 win_auditpol:
   whitelist:
@@ -1171,52 +1179,43 @@ win_auditpol:
               tag: CIS-17.1.1
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit credential validation' is set to 'success and failure'
-
-    Audit Application Group Management :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'Application Group Management':
-              tag: CIS-17.2.1
-              match_output: 'Success and Failure'
-              value_type: 'equal'
-      description: (l1) ensure 'audit application group management' is set to 'success and failure'
+      description: (L1) Ensure 'audit credential validation' is set to 'success and failure'
 
     Audit Computer Account Management :
       data:
         'Microsoft Windows Server 2012*':
           - 'Computer Account Management':
-              tag: CIS-17.2.2
+              tag: CIS-17.2.1
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit computer account management' is set to 'success and failure'
+      description: (L1) Ensure 'audit computer account management' is set to 'success and failure'
 
     Audit Other Account Management Events :
       data:
         'Microsoft Windows Server 2012*':
           - 'Other Account Management Events':
-              tag: CIS-17.2.4
+              tag: CIS-17.2.3
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit other account management events' is set to 'success and failure'
+      description: (L1) Ensure 'audit other account management events' is set to 'success and failure'
 
     Audit Security Group Management :
       data:
         'Microsoft Windows Server 2012*':
           - 'Security Group Management':
-              tag: CIS-17.2.5
+              tag: CIS-17.2.4
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit security group management' is set to 'success and failure'
+      description: (L1) Ensure 'audit security group management' is set to 'success and failure'
 
     Audit User Account Management :
       data:
         'Microsoft Windows Server 2012*':
           - 'User Account Management':
-              tag: CIS-17.2.6
+              tag: CIS-17.2.5
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit user account management' is set to 'success and failure'
+      description: (L1) Ensure 'audit User Account management' is set to 'success and failure'
 
     Audit Process Creation :
       data:
@@ -1225,7 +1224,7 @@ win_auditpol:
               tag: CIS-17.3.1
               match_output: 'Success'
               value_type: 'equal'
-      description: (l1) ensure 'audit process creation' is set to 'success'
+      description: (L1) Ensure 'audit process creation' is set to 'success'
 
     Audit Account Lockout :
       data:
@@ -1234,7 +1233,7 @@ win_auditpol:
               tag: CIS-17.5.1
               match_output: 'Success'
               value_type: 'equal'
-      description: (l1) ensure 'audit account lockout' is set to 'success'
+      description: (L1) Ensure 'audit account lockout' is set to 'success'
 
     Audit Logoff :
       data:
@@ -1243,7 +1242,7 @@ win_auditpol:
               tag: CIS-17.5.2
               match_output: 'Success'
               value_type: 'equal'
-      description: (l1) ensure 'audit logoff' is set to 'success'
+      description: (L1) Ensure 'audit logoff' is set to 'success'
 
     Audit Logon :
       data:
@@ -1252,7 +1251,7 @@ win_auditpol:
               tag: CIS-17.5.3
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit logon' is set to 'success and failure'
+      description: (L1) Ensure 'audit logon' is set to 'success and failure'
 
     Audit Other Logon/Logoff Events :
       data:
@@ -1261,7 +1260,7 @@ win_auditpol:
               tag: CIS-17.5.4
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit other logon/logoff events' is set to 'success and failure'
+      description: (L1) Ensure 'audit other logon/logoff events' is set to 'success and failure'
 
     Audit Special Logon :
       data:
@@ -1270,7 +1269,7 @@ win_auditpol:
               tag: CIS-17.5.5
               match_output: 'Success'
               value_type: 'equal'
-      description: (l1) ensure 'audit special logon' is set to 'success'
+      description: (L1) Ensure 'audit special logon' is set to 'success'
 
     Audit Removable Storage :
       data:
@@ -1279,7 +1278,7 @@ win_auditpol:
               tag: CIS-17.6.1
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit removable storage' is set to 'success and failure'
+      description: (L1) Ensure 'audit removable storage' is set to 'success and failure'
 
     Audit Audit Policy Change :
       data:
@@ -1288,7 +1287,7 @@ win_auditpol:
               tag: CIS-17.7.1
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit audit policy change' is set to 'success and failure'
+      description: (L1) Ensure 'audit audit policy change' is set to 'success and failure'
 
     Audit Authentication Policy Change :
       data:
@@ -1297,7 +1296,7 @@ win_auditpol:
               tag: CIS-17.7.2
               match_output: 'Success'
               value_type: 'equal'
-      description: (l1) ensure 'audit authentication policy change' is set to 'success'
+      description: (L1) Ensure 'audit authentication policy change' is set to 'success'
 
     Audit Sensitive Privilege Use :
       data:
@@ -1306,7 +1305,7 @@ win_auditpol:
               tag: CIS-17.8.1
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit sensitive privilege use' is set to 'success and failure'
+      description: (L1) Ensure 'audit sensitive privilege use' is set to 'success and failure'
 
     Audit IPsec Driver :
       data:
@@ -1315,7 +1314,7 @@ win_auditpol:
               tag: CIS-17.9.1
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit ipsec driver' is set to 'success and failure'
+      description: (L1) Ensure 'audit ipsec driver' is set to 'success and failure'
 
     Audit Other System Events :
       data:
@@ -1324,7 +1323,7 @@ win_auditpol:
               tag: CIS-17.9.2
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit other system events' is set to 'success and failure'
+      description: (L1) Ensure 'audit other system events' is set to 'success and failure'
 
     Audit Security State Change :
       data:
@@ -1333,7 +1332,7 @@ win_auditpol:
               tag: CIS-17.9.3
               match_output: 'Success'
               value_type: 'equal'
-      description: (l1) ensure 'audit security state change' is set to 'success'
+      description: (L1) Ensure 'audit security state change' is set to 'success'
 
     Audit Security System Extension :
       data:
@@ -1342,7 +1341,7 @@ win_auditpol:
               tag: CIS-17.9.4
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit security system extension' is set to 'success and failure'
+      description: (L1) Ensure 'audit security system extension' is set to 'success and failure'
 
     Audit System Integrity :
       data:
@@ -1351,7 +1350,7 @@ win_auditpol:
               tag: CIS-17.9.5
               match_output: 'Success and Failure'
               value_type: 'equal'
-      description: (l1) ensure 'audit system integrity' is set to 'success and failure'
+      description: (L1) Ensure 'audit system integrity' is set to 'success and failure'
 
 win_reg:
   whitelist:
@@ -1360,7 +1359,7 @@ win_reg:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Personalization\NoLockScreenCamera':
               tag: CIS-18.1.1.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
       description: 'Ensure Prevent enabling lock screen camera is set to Enabled'
     Prevent enabling lock screen slide show :
@@ -1368,772 +1367,597 @@ win_reg:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Personalization\NoLockScreenSlideshow':
               tag: CIS-18.1.1.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
       description: 'Ensure Prevent enabling lock screen slide show is set to Enabled'
-    Do not allow password expiration time longer than required by policy :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd\PwdExpirationProtectionEnabled':
-              tag: CIS-18.2.2
-              match_output: '1'
-              value_type: 'equal'
-      description: 'Ensure Do not allow password expiration time longer than required by policy is set to Enabled '
-    Enable Local Admin Password Management :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd\AdmPwdEnabled':
-              tag: CIS-18.2.3
-              match_output: '1'
-              value_type: 'equal'
-      description: 'Ensure Enable Local Admin Password Management is set to Enabled '
-    Password Settings_ Password Complexity :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd\PasswordComplexity':
-              tag: CIS-18.2.4
-              match_output: '4' 
-              value_type: 'equal'
-      description: 'Ensure Password Settings - Password Complexity is set to Enabled - Large letters + small letters + numbers + special characters '
-    Password Settings_ Password Length :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd\PasswordLength':
-              tag: CIS-18.2.5
-              match_output: '15'
-              value_type: 'more'
-      description: 'Ensure Password Settings - Password Length is set to Enabled - 15 or more '
-    Password Settings_ Password Age :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd\PasswordAgeDays':
-              tag: CIS-18.2.6
-              match_output: '30'
-              value_type: 'less'
-      description: 'Ensure Password Settings - Password Age is set to Enabled - 30 or fewer '
-    MSS_ Enable Automatic Logon :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\AutoAdminLogon':
-              tag: CIS-18.3.1
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'mss -  (autoadminlogon) enable automatic logon (not recommended)' is set to 'disabled'
+
     MSS_DisableIPSourceRouting IPv6 IP source routing protection level protects against packet spoofing :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip6\Parameters\DisableIPSourceRouting':
-              tag: CIS-18.3.2
-              match_output: '2'
+              tag: CIS-2.3.10.2
+              match_output: 'Enabled' #: Highest protection, source routing is completely disabled'
               value_type: 'equal'
-      description: (l1) ensure 'mss -  (disableipsourcerouting ipv6) ip source routing protection level (protects against packet spoofing)' is set to 'enabled -  highest protection, source routing is completely disabled'
+      description: (L1) Ensure 'mss -  (disableipsourcerouting ipv6) ip source routing protection level (protects against packet spoofing)' is set to 'enabled -  highest protection, source routing is completely disabled'
     MSS_ IP source routing protection level protects against packet spoofing :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip\Parameters\DisableIPSourceRouting':
-              tag: CIS-18.3.3
-              match_output: '2'
+              tag: CIS-2.3.10.3
+              match_output: 'Enabled' #: Highest protection, source routing is completely disabled'
               value_type: 'equal'
-      description: (l1) ensure 'mss -  (disableipsourcerouting) ip source routing protection level (protects against packet spoofing)' is set to 'enabled -  highest protection, source routing is completely disabled'
-    MSS_ Allow ICMP redirects to override OSPF generated routes :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip\Parameters\EnableICMPRedirect':
-              tag: CIS-18.3.4
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'mss -  (enableicmpredirect) allow icmp redirects to override ospf generated routes' is set to 'disabled'
-    MSS_ Allow the computer to ignore NetBIOS name release requests except from WINS servers :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\NetBT\Parameters\nonamereleaseondemand':
-              tag: CIS-18.3.6
-              match_output: '1'
-              value_type: 'equal'
-      description: (l1) ensure 'mss -  (nonamereleaseondemand) allow the computer to ignore netbios name release requests except from wins servers' is set to 'enabled'
+      description: (L1) Ensure 'mss -  (disableipsourcerouting) ip source routing protection level (protects against packet spoofing)' is set to 'enabled -  highest protection, source routing is completely disabled'ed'
     MSS_ Enable Safe DLL search mode :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\SafeDllSearchMode':
-              tag: CIS-18.3.8
-              match_output: '1'
+              tag: CIS-2.3.10.7
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'mss -  (safedllsearchmode) enable safe dll search mode (recommended)' is set to 'enabled'
+      description: (L1) Ensure 'mss -  (safedllsearchmode) enable safe dll search mode (recommended)' is set to 'enabled'
     MSS_ The time in seconds before the screen saver grace period expires :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\ScreenSaverGracePeriod':
-              tag: CIS-18.3.9
-              match_output: '5'
-              value_type: 'less'
-      description: (l1) ensure 'mss -  (screensavergraceperiod) the time in seconds before the screen saver grace period expires (0 recommended)' is set to 'enabled -  5 or fewer seconds'
+              tag: CIS-2.3.10.8
+              match_output: 'Enabled: 5 or fewer seconds'
+              value_type: 'equal'
+      description: (L1) Ensure 'mss -  (screensavergraceperiod) the time in seconds before the screen saver grace period expires (0 recommended)' is set to 'enabled -  5 or fewer seconds'
     MSS_ Percentage threshold for the security event log at which the system will generate a warning :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security\WarningLevel':
-              tag: CIS-18.3.12
-              match_output: '90'
+              tag: CIS-2.3.10.11
+              match_output: 'Enabled' #Enabled: 90% or less
               value_type: 'less'
-      description: (l1) ensure 'mss -  (warninglevel) percentage threshold for the security event log at which the system will generate a warning' is set to 'enabled -  90% or less'
+      description: (L1) Ensure 'mss -  (warninglevel) percentage threshold for the security event log at which the system will generate a warning' is set to 'enabled -  90% or less'
     Prohibit installation and configuration of Network Bridge on your DNS domain network :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections\NC_AllowNetBridge_NLA':
-              tag: CIS-18.4.10.2
-              match_output: '0'
+              tag: CIS-18.3.10.2
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'prohibit installation and configuration of network bridge on your dns domain network' is set to 'enabled'
+      description: (L1) Ensure 'prohibit installation and configuration of network bridge on your dns domain network' is set to 'enabled'
     Require domain users to elevate when setting a network :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Network Connections\NC_StdDomainUserSetLocation':
-              tag: CIS-18.4.10.3
-              match_output: '1'
+              tag: CIS-18.3.10.3
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'require domain users to elevate when setting a network's location' is set to 'enabled'
+      description: (L1) Ensure 'require domain users to elevate when setting a network's location' is set to 'enabled'
     Hardened UNC Paths :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths\\*\NETLOGON':
-              tag: CIS-18.4.13.1
-              match_output: 'RequireMutualAuthentication=1,RequireIntegrity=1'
+              tag: CIS-18.3.13.1
+              match_output: 'Enabled' #with "Require Mutual Authentication" and "Require Integrity" set for all NETLOGON and SYSVOL shares'
               value_type: 'equal'
-      description: (l1) ensure 'hardened unc paths' is set to 'enabled, with "require mutual authentication" and "require integrity" set for all netlogon and sysvol shares'
-    Disable IPv6 :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP6\Parameters\DisabledComponents':
-              tag: CIS-18.4.18.2.1
-              match_output: '255'
-              value_type: 'equal'
-      description: 'Disable IPv6 - Ensure TCPIP6 Parameter DisabledComponents is set to 0xff (255)'
-    Minimize the number of simultaneous connections to the Internet or a Windows Domain :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WcmSvc\GroupPolicy\fMinimizeConnections':
-              tag: CIS-18.4.20.1
-              match_output: '1'
-              value_type: 'equal'
-      description: (l1) ensure 'minimize the number of simultaneous connections to the internet or a windows domain' is set to 'enabled'
+      description: (L1) Ensure 'hardened unc paths' is set to 'enabled, with "require mutual authentication" and "require integrity" set for all netlogon and sysvol shares'
     Apply UAC restrictions to local accounts on network logons :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\LocalAccountTokenFilterPolicy':
-              tag: CIS-18.6.1
-              match_output: '1'
+              tag: CIS-18.5.1
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: 'Ensure Apply UAC restrictions to local accounts on network logons is set to 1'
-    WDigest Authentication :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest\UseLogonCredential':
-              tag: CIS-18.6.2
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'wdigest authentication' is set to 'disabled'
-    Ensure Include command line in process creation events is Disabled:
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit\ProcessCreationIncludeCmdLine_Enabled':
-              tag: CIS-18.8.2.1
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'include command line in process creation events' is set to 'disabled'
+      description: 'Ensure Apply UAC restrictions to local accounts on network logons is set to Enabled '
     Boot-Start Driver Initialization Policy :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Policies\EarlyLaunch\DriverLoadPolicy':
-              tag: CIS-18.8.11.1
-              match_output: '3' 
+              tag: CIS-18.7.11.1
+              match_output: 'Enabled' #: Good, unknown and bad but critical'
               value_type: 'equal'
-      description: (l1) ensure 'boot-start driver initialization policy' is set to 'enabled -  good, unknown and bad but critical'
+      description: (L1) Ensure 'boot-start driver initialization policy' is set to 'enabled -  good, unknown and bad but critical'
     Configure registry policy processing_ Do not apply during periodic background processing :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}\NoBackgroundPolicy':
-              tag: CIS-18.8.18.2
-              match_output: '0'
+              tag: CIS-18.7.18.2
+              match_output: 'Enabled'# : FALSE'
               value_type: 'equal'
-      description: (l1) ensure 'configure registry policy processing - do not apply during periodic background processing' is set to 'enabled -  false'
+      description: (L1) Ensure 'configure registry policy processing - do not apply during periodic background processing' is set to 'enabled -  false'
     Configure registry policy processing_ Process even if the Group Policy objects have not changed :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}\NoGPOListChanges':
-              tag: CIS-18.8.18.3
-              match_output: '0'
+              tag: CIS-18.7.18.3
+              match_output: 'Enabled' #: TRUE'
               value_type: 'equal'
-      description: (l1) ensure 'configure registry policy processing - process even if the group policy objects have not changed' is set to 'enabled -  true'
+      description: (L1) Ensure 'configure registry policy processing - process even if the group policy objects have not changed' is set to 'enabled -  true'
     Do not display network selection UI :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System\DontDisplayNetworkSelectionUI':
-              tag: CIS-18.8.24.1
-              match_output: '1'
+              tag: CIS-18.7.24.1
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'do not display network selection ui' is set to 'enabled'
+      description: (L1) Ensure 'do not display network selection ui' is set to 'enabled'
     Do not enumerate connected users on domain-joined computers :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System\DontEnumerateConnectedUsers':
-              tag: CIS-18.8.24.2
-              match_output: '1'
+              tag: CIS-18.7.24.2
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'do not enumerate connected users on domain-joined computers' is set to 'enabled'
-    Enumerate local users on domain-joined computers :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System\EnumerateLocalUsers':
-              tag: CIS-18.8.24.3
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'enumerate local users on domain-joined computers' is set to 'disabled'
+      description: (L1) Ensure 'do not enumerate connected users on domain-joined computers' is set to 'enabled'
     Turn off app notifications on the lock screen :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System\DisableLockScreenAppNotifications':
-              tag: CIS-18.8.24.4
-              match_output: '1'
+              tag: CIS-18.7.24.4
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'turn off app notifications on the lock screen' is set to 'enabled'
-    Turn on convenience PIN sign-in :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System\AllowDomainPINLogon':
-              tag: CIS-18.8.24.5
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'turn on convenience pin sign-in' is set to 'disabled'
-    Configure Offer Remote Assistance :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\policies\Microsoft\Windows NT\Terminal Services\fAllowUnsolicited':
-              tag: CIS-18.8.30.1
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'configure offer remote assistance' is set to 'disabled'
-    Configure Solicited Remote Assistance :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\policies\Microsoft\Windows NT\Terminal Services\fAllowToGetHelp':
-              tag: CIS-18.8.30.2
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'configure solicited remote assistance' is set to 'disabled'
+      description: (L1) Ensure 'turn off app notifications on the lock screen' is set to 'enabled'
     Enable RPC Endpoint Mapper Client Authentication :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Rpc\EnableAuthEpResolution':
-              tag: CIS-18.8.31.1
-              match_output: '1'
+              tag: CIS-18.7.31.1
+              match_output: 'Enabled'
               value_type: 'equal'
       description: 'Ensure Enable RPC Endpoint Mapper Client Authentication is set to Enabled '
     Allow Microsoft accounts to be optional :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\MSAOptional':
-              tag: CIS-18.9.6.1
-              match_output: '1'
+              tag: CIS-18.8.5.1
+              match_output: 'Enabled'
               value_type: 'equal'
       description: 'Ensure Allow Microsoft accounts to be optional is set to Enabled'
-    Disallow Autoplay for non-volume devices :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Explorer\NoAutoplayfornonVolume':
-              tag: CIS-18.9.8.1
-              match_output: '1'
-              value_type: 'equal'
-      description: (l1) ensure 'disallow autoplay for non-volume devices' is set to 'enabled'
-    Set the default behavior for AutoRun :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\NoAutorun':
-              tag: CIS-18.9.8.2
-              match_output: '1' # : Do not execute any autorun commands'
-              value_type: 'equal'
-      description: (l1) ensure 'set the default behavior for autorun' is set to 'enabled -  do not execute any autorun commands'
     Turn off Autoplay :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\NoDriveTypeAutoRun':
-              tag: CIS-18.9.8.3
-              match_output: '255'
+              tag: CIS-18.8.7.2
+              match_output: 'Enabled: All drives'
               value_type: 'equal'
-      description: (l1) ensure 'turn off autoplay' is set to 'enabled -  all drives'
+      description: (L1) Ensure 'turn off autoplay' is set to 'enabled -  all drives'
     Do not display the password reveal button :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CredUI\DisablePasswordReveal':
-              tag: CIS-18.9.13.1
-              match_output: '1'
+              tag: CIS-18.8.11.1
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'do not display the password reveal button' is set to 'enabled'
-    Enumerate administrator accounts on elevation :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\CredUI\EnumerateAdministrators':
-              tag: CIS-18.9.13.2
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'enumerate administrator accounts on elevation' is set to 'disabled'
-    Do not preserve zone information in file attachments :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_USERS\<SID>\Software\Microsoft\Windows\CurrentVersion\Policies\Attachments\SaveZoneInformation':
-              tag: CIS-19.7.4.1
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'do not preserve zone information in file attachments' is set to 'disabled'
-    Always install with elevated privileges :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_USERS\<SID>\Software\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated':
-              tag: CIS-19.7.37.1
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'always install with elevated privileges' is set to 'disabled'
-
-    Default Action and Mitigation Settings :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\SysSettings\AntiDetours':
-              tag: CIS-18.9.22.2
-              match_output: '1'
-              value_type: 'equal'
-      description: (l1) ensure 'default action and mitigation settings' is set to 'enabled' (plus subsettings)
+      description: (L1) Ensure 'do not display the password reveal button' is set to 'enabled'
     Default Protections for Internet Explorer :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\Defaults\IE':
-              tag: CIS-18.9.22.3
-              match_output: '1'
+              tag: CIS-18.8.20.2
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'default protections for internet explorer' is set to 'enabled'
+      description: (L1) Ensure 'default protections for internet explorer' is set to 'enabled'
     Default Protections for Popular Software :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\Defaults':
-              tag: CIS-18.9.22.4
-              match_output: '1'
+              tag: CIS-18.8.20.3
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'default protections for popular software' is set to 'enabled'
+      description: (L1) Ensure 'default protections for popular software' is set to 'enabled'
     Default Protections for Recommended Software :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\Defaults':
-              tag: CIS-18.9.22.5
-              match_output: '1'
+              tag: CIS-18.8.20.4
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'default protections for recommended software' is set to 'enabled'
+      description: (L1) Ensure 'default protections for recommended software' is set to 'enabled'
     System ASLR :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\SysSettings\ASLR':
-              tag: CIS-18.9.22.6
-              match_output: '1'#: Application Opt-In'
+              tag: CIS-18.8.20.5
+              match_output: 'Enabled'#: Application Opt-In'
               value_type: 'equal'
-      description: (l1) ensure 'system aslr' is set to 'enabled -  application opt-in'
+      description: (L1) Ensure 'system aslr' is set to 'enabled -  application opt-in'
     System DEP :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\SysSettings\DEP':
-              tag: CIS-18.9.22.7
-              match_output: '1'#: Application Opt-Out'
+              tag: CIS-18.8.20.6
+              match_output: 'Enabled'#: Application Opt-Out'
               value_type: 'equal'
-      description: (l1) ensure 'system dep' is set to 'enabled -  application opt-out'
+      description: (L1) Ensure 'system dep' is set to 'enabled -  application opt-out'
     System SEHOP :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\EMET\SysSettings\SEHOP':
-              tag: CIS-18.9.22.8
-              match_output: '2'
+              tag: CIS-18.8.20.7
+              match_output: 'Enabled'#: Application Opt-Out'
               value_type: 'equal'
-      description: (l1) ensure 'system sehop' is set to 'enabled -  application opt-out'
-    Application_ Control Event Log behavior when the log file reaches its maximum size :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Application\Retention':
-              tag: CIS-18.9.24.1.1
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'application - control event log behavior when the log file reaches its maximum size' is set to 'disabled'
+      description: (L1) Ensure 'system sehop' is set to 'enabled -  application opt-out'
     Application_ Specify the maximum log file size  :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Application\MaxSize':
-              tag: CIS-18.9.24.1.2
-              match_output: '32768' #_ 32768 or greater
-              value_type: 'more'
-      description: (l1) ensure 'application - specify the maximum log file size (kb)' is set to 'enabled -  32,768 or greater'
-    Security_ Control Event Log behavior when the log file reaches its maximum size :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Security\Retention':
-              tag: CIS-18.9.24.2.1
-              match_output: '0'
+              tag: CIS-18.8.22.1.2
+              match_output: 'Enabled'#_ 32768 or greater'
               value_type: 'equal'
-      description: (l1) ensure 'security - control event log behavior when the log file reaches its maximum size' is set to 'disabled'
+      description: (L1) Ensure 'application - specify the maximum log file size (kb)' is set to 'enabled -  32,768 or greater'
     Security_ Specify the maximum log file size  :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Security\MaxSize':
-              tag: CIS-18.9.24.2.2
-              match_output: '196608'
-              value_type: 'more'
-      description: (l1) ensure 'security - specify the maximum log file size (kb)' is set to 'enabled -  196,608 or greater'
-    Setup_ Control Event Log behavior when the log file reaches its maximum size :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Setup\Retention':
-              tag: CIS-18.9.24.3.1
-              match_output: '0'
+              tag: CIS-18.8.22.2.2
+              match_output: 'Enabled'#_ 196608 or greater'
               value_type: 'equal'
-      description: (l1) ensure 'setup - control event log behavior when the log file reaches its maximum size' is set to 'disabled'
+      description: (L1) Ensure 'security - specify the maximum log file size (kb)' is set to 'enabled -  196,608 or greater'
     Setup_ Specify the maximum log file size  :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Setup\MaxSize':
-              tag: CIS-18.9.24.3.2
-              match_output: '32768'
-              value_type: 'more'
-      description: (l1) ensure 'setup - specify the maximum log file size (kb)' is set to 'enabled -  32,768 or greater'
-    System_ Control Event Log behavior when the log file reaches its maximum size :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\System\Retention':
-              tag: CIS-18.9.24.4.1
-              match_output: '0'
+              tag: CIS-18.8.22.3.2
+              match_output: 'Enabled' # 32,768 or greater'
               value_type: 'equal'
-      description: (l1) ensure 'system - control event log behavior when the log file reaches its maximum size' is set to 'disabled'
+      description: (L1) Ensure 'setup - specify the maximum log file size (kb)' is set to 'enabled -  32,768 or greater'
     System_ Specify the maximum log file size  :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\System\MaxSize':
-              tag: CIS-18.9.24.4.2
-              match_output: '32768'
-              value_type: 'more'
-      description: (l1) ensure 'system - specify the maximum log file size (kb)' is set to 'enabled -  32,768 or greater'
+              tag: CIS-18.8.22.4.2
+              match_output: 'Enabled'#_ 32768 or greater'
+              value_type: 'equal'
+      description: (L1) Ensure 'system - specify the maximum log file size (kb)' is set to 'enabled -  32,768 or greater'
     Configure Windows SmartScreen :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System\EnableSmartScreen':
-              tag: CIS-18.9.28.2
-              match_output: '2'
+              tag: CIS-18.8.26.2
+              match_output: 'Enabled: Require approval from an administrator before running downloaded unknown software'
               value_type: 'equal'
-      description: (l1) ensure 'configure windows smartscreen' is set to 'enabled -  require approval from an administrator before running downloaded unknown software'
-    Turn off Data Execution Prevention for Explorer :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Explorer\NoDataExecutionPrevention':
-              tag: CIS-18.9.28.3
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'turn off data execution prevention for explorer' is set to 'disabled'
-    Turn off heap termination on corruption :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Explorer\NoHeapTerminationOnCorruption':
-              tag: CIS-18.9.28.4
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'turn off heap termination on corruption' is set to 'disabled'
-    Turn off shell protocol protected mode :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\PreXPSP2ShellProtocolBehavior':
-              tag: CIS-18.9.28.5
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'turn off shell protocol protected mode' is set to 'disabled'
+      description: (L1) Ensure 'configure windows smartscreen' is set to 'enabled -  require approval from an administrator before running downloaded unknown software'
     Do not allow passwords to be saved :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\DisablePasswordSaving':
-              tag: CIS-18.9.48.2.2
-              match_output: '1'
+              tag: CIS-18.8.45.2.2
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'do not allow passwords to be saved' is set to 'enabled'
+      description: (L1) Ensure 'do not allow passwords to be saved' is set to 'enabled'
     Do not allow drive redirection :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\fDisableCdm':
-              tag: CIS-18.9.48.3.3.2
-              match_output: '1'
+              tag: CIS-18.8.45.3.3.2
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'do not allow drive redirection' is set to 'enabled'
+      description: (L1) Ensure 'do not allow drive redirection' is set to 'enabled'
     Always prompt for password upon connection :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\fPromptForPassword':
-              tag: CIS-18.9.48.3.9.1
-              match_output: '1'
+              tag: CIS-18.8.45.3.9.1
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'always prompt for password upon connection' is set to 'enabled'
+      description: (L1) Ensure 'always prompt for password upon connection' is set to 'enabled'
     Require secure RPC communication :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services\fEncryptRPCTraffic':
-              tag: CIS-18.9.48.3.9.2
-              match_output: '1'
+              tag: CIS-18.8.45.3.9.2
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'require secure rpc communication' is set to 'enabled'
+      description: (L1) Ensure 'require secure rpc communication' is set to 'enabled'
     Set client connection encryption level :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\MinEncryptionLevel':
-              tag: CIS-18.9.48.3.9.3
-              match_output: '3'
+              tag: CIS-18.8.45.3.9.3
+              match_output: 'Enabled'#: High Level'
               value_type: 'equal'
-      description: (l1) ensure 'set client connection encryption level' is set to 'enabled -  high level'
-    Do not delete temp folders upon exit :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\DeleteTempDirsOnExit':
-              tag: CIS-18.9.48.3.11.1
-              match_output: '1'
-              value_type: 'equal'
-      description: (l1) ensure 'do not delete temp folders upon exit' is set to 'disabled'
-    Do not use temporary folders per session :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services\PerSessionTempDir':
-              tag: CIS-18.9.48.3.11.2
-              match_output: '1'
-              value_type: 'equal'
-      description: (l1) ensure 'do not use temporary folders per session' is set to 'disabled'
-    Prevent downloading of enclosures :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Internet Explorer\Feeds\DisableEnclosureDownload':
-              tag: CIS-18.9.49.1
-              match_output: '1'
-              value_type: 'equal'
-      description: (l1) ensure 'prevent downloading of enclosures' is set to 'enabled'
-    Allow indexing of encrypted files :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search\AllowIndexingEncryptedStoresOrItems':
-              tag: CIS-18.9.50.2
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'allow indexing of encrypted files' is set to 'disabled'
+      description: (L1) Ensure 'set client connection encryption level' is set to 'enabled -  high level'
     Prevent the usage of SkyDrive for file storage :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Skydrive\DisableFileSync':
-              tag: CIS-18.9.54.1
-              match_output: '1'
+              tag: CIS-18.8.40.1
+              match_output: 'Enabled'
               value_type: 'equal'
       description: 'Ensure Prevent the usage of SkyDrive for file storage is set to Enabled'
-    Turn off Automatic Download and Install of updates :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore\AutoDownload':
-              tag: CIS-18.9.58.1
-              match_output: '4'
-              value_type: 'equal'
-      description: (l1) ensure 'turn off automatic download of updates on win8 machines' is set to 'disabled'
-    Turn off the offer to update to the latest version of Windows :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore\DisableOSUpgrade':
-              tag: CIS-18.9.58.2
-              match_output: '1'
-              value_type: 'equal'
-      description: (l1) ensure 'turn off the offer to update to the latest version of windows' is set to 'enabled'
-    Configure Default consent :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting\Consent\DefaultConsent':
-              tag: CIS-18.9.67.2.1
-              match_output: '1' #: Always ask before sending data'
-              value_type: 'equal'
-      description: (l1) ensure 'configure default consent' is set to 'enabled -  always ask before sending data'
-    Automatically send memory dumps for OS-generated error reports :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Policies\Microsoft\Windows\Windows Error Reporting\AutoApproveOSDumps':
-              tag: CIS-18.9.67.3
-              match_output: '0'
-              value_type: 'equal'
-      description: 'Ensure Automatically send memory dumps for OS-generated error reports is set to Disabled'
-    Allow user control over installs :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Installer\EnableUserControl':
-              tag: CIS-18.9.69.1
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'allow user control over installs' is set to 'disabled'
-    Always install with elevated privileges :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated':
-              tag: CIS-18.9.69.2
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'always install with elevated privileges' is set to 'disabled'
-    Sign-in last interactive user automatically after a system-initiated restart :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\DisableAutomaticRestartSignOn':
-              tag: CIS-18.9.70.1
-              match_output: '1'
-              value_type: 'equal'
-      description: 'Ensure Sign-in last interactive user automatically after a system-initiated restart is set to Disabled'
-    Turn on PowerShell Script Block Logging :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging\EnableScriptBlockLogging':
-              tag: CIS-18.9.79.1
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'turn on powershell script block logging' is set to 'disabled'
-    Turn on PowerShell Transcription :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription\EnableTranscripting':
-              tag: CIS-18.9.79.2
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'turn on powershell transcription' is set to 'disabled'
-    Allow Basic authentication :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client\AllowBasic':
-              tag: CIS-18.9.81.1.1
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'allow basic authentication' is set to 'disabled'
-    Allow unencrypted traffic :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client\AllowUnencryptedTraffic':
-              tag: CIS-18.9.81.1.2
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'allow unencrypted traffic' is set to 'disabled'
     Disallow Digest authentication :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client\AllowDigest':
-              tag: CIS-18.9.81.1.3
-              match_output: '0'
+              tag: CIS-18.8.77.1.3
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'disallow digest authentication' is set to 'enabled'
-    Allow Basic authentication :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service\AllowBasic':
-              tag: CIS-18.9.81.2.1
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'allow basic authentication' is set to 'disabled'
-    Allow unencrypted traffic :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service\AllowUnencryptedTraffic':
-              tag: CIS-18.9.81.2.2
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'allow unencrypted traffic' is set to 'disabled'
+      description: (L1) Ensure 'disallow digest authentication' is set to 'enabled'
     Disallow WinRM from storing RunAs credentials :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service\DisableRunAs':
-              tag: CIS-18.9.81.2.3
-              match_output: '1'
+              tag: CIS-18.8.77.2.3
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'disallow winrm from storing runas credentials' is set to 'enabled'
+      description: (L1) Ensure 'disallow winrm from storing runas credentials' is set to 'enabled'
     Configure Automatic Updates :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU\NoAutoUpdate':
-              tag: CIS-18.9.85.1
-              match_output: '0'
+              tag: CIS-18.8.81.1
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'configure automatic updates' is set to 'enabled'
+      description: (L1) Ensure 'configure automatic updates' is set to 'enabled'
     Configure Automatic Updates_ Scheduled install day :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU\ScheduledInstallDay':
-              tag: CIS-18.9.85.2
-              match_output: '0' # - Every day'
+              tag: CIS-18.8.81.2
+              match_output: '0'# - Every day'
               value_type: 'equal'
-      description: (l1) ensure 'configure automatic updates - scheduled install day' is set to '0 - every day'
-    No auto-restart with logged on users for scheduled automatic updates installations :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU\NoAutoRebootWithLoggedOnUsers':
-              tag: CIS-18.9.85.3
-              match_output: '0'
-              value_type: 'equal'
-      description: (l1) ensure 'no auto-restart with logged on users for scheduled automatic updates installations' is set to 'disabled'
+      description: (L1) Ensure 'configure automatic updates - scheduled install day' is set to '0 - every day'
     Enable screen saver :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_USERS\<SID>\Software\Policies\Microsoft\Windows\Control Panel\Desktop\ScreenSaveActive':
               tag: CIS-19.1.3.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'enable screen saver' is set to 'enabled'
+      description: (L1) Ensure 'enable screen saver' is set to 'enabled'
     Force specific screen saver_ Screen saver executable name :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_USERS\<SID>\Software\Policies\Microsoft\Windows\Control Panel\Desktop\SCRNSAVE.EXE':
               tag: CIS-19.1.3.2
-              match_output: '1'
+              match_output: 'Enabled'#: scrnsave.scr'
               value_type: 'equal'
-      description: (l1) ensure 'force specific screen saver - screen saver executable name' is set to 'enabled -  scrnsave.scr'
+      description: (L1) Ensure 'force specific screen saver - screen saver executable name' is set to 'enabled -  scrnsave.scr'
     Password protect the screen saver :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_USERS\<SID>\Software\Policies\Microsoft\Windows\Control Panel\Desktop\ScreenSaverIsSecure':
               tag: CIS-19.1.3.3
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'password protect the screen saver' is set to 'enabled'
+      description: (L1) Ensure 'password protect the screen saver' is set to 'enabled'
     Screen saver timeout :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_USERS\<SID>\Software\Policies\Microsoft\Windows\Control Panel\Desktop\ScreenSaveTimeOut':
               tag: CIS-19.1.3.4
-              match_output: '900'
-              value_type: 'less'
-      description: (l1) ensure 'screen saver timeout' is set to 'enabled -  900 seconds or fewer, but not 0'
+              match_output: 'Enabled'#: 900 seconds or fewer, but not 0'
+              value_type: 'equal'
+      description: (L1) Ensure 'screen saver timeout' is set to 'enabled -  900 seconds or fewer, but not 0'
     Turn off toast notifications on the lock screen :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_USERS\<SID>\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\PushNotifications\NoToastApplicationNotificationOnLockScreen':
               tag: CIS-19.5.1.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'turn off toast notifications on the lock screen' is set to 'enabled'
+      description: (L1) Ensure 'turn off toast notifications on the lock screen' is set to 'enabled'
     Notify antivirus programs when opening attachments :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_USERS\<SID>\Software\Microsoft\Windows\CurrentVersion\Policies\Attachments\ScanWithAntiVirus':
               tag: CIS-19.7.4.2
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'notify antivirus programs when opening attachments' is set to 'enabled'
+      description: (L1) Ensure 'notify antivirus programs when opening attachments' is set to 'enabled'
     Prevent users from sharing files within their profile. :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_USERS\[USER SID]\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\NoInplaceSharing':
               tag: CIS-19.7.25.1
-              match_output: '1'
+              match_output: 'Enabled'
               value_type: 'equal'
-      description: (l1) ensure 'prevent users from sharing files within their profile.' is set to 'enabled'
+      description: (L1) Ensure 'prevent users from sharing files within their profile.' is set to 'enabled'
 
   blacklist:
+    MSS_ Enable Automatic Logon :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\AutoAdminLogon':
+              tag: CIS-2.3.10.1
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'mss -  (autoadminlogon) enable automatic logon (not recommended)' is set to 'disabled'
+    WDigest Authentication :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest\UseLogonCredential':
+              tag: CIS-18.5.2
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'wdigest authentication' is set to 'disabled'
+    Ensure Include command line in process creation events is Disabled:
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit\ProcessCreationIncludeCmdLine_Enabled':
+              tag: CIS-18.7.2.1
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'include command line in process creation events' is set to 'disabled'
     Turn off background refresh of Group Policy :
       data:
         'Microsoft Windows Server 2012*':
           - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\DisableBkGndGroupPolicy':
-              tag: CIS-18.8.18.4
-              match_output: '0'
+              tag: CIS-18.7.18.4
+              match_output: 'Disabled'
               value_type: 'equal'
-      description: (l1) ensure 'turn off background refresh of group policy' is set to 'disabled'
+      description: (L1) Ensure 'turn off background refresh of group policy' is set to 'disabled'
+    Enumerate local users on domain-joined computers :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System\EnumerateLocalUsers':
+              tag: CIS-18.7.24.3
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'enumerate local users on domain-joined computers' is set to 'disabled'
+    Turn on convenience PIN sign-in :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System\AllowDomainPINLogon':
+              tag: CIS-18.7.24.5
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'turn on convenience pin sign-in' is set to 'disabled'
+    Configure Offer Remote Assistance :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\policies\Microsoft\Windows NT\Terminal Services\fAllowUnsolicited':
+              tag: CIS-18.7.30.1
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'configure offer remote assistance' is set to 'disabled'
+    Configure Solicited Remote Assistance :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\policies\Microsoft\Windows NT\Terminal Services\fAllowToGetHelp':
+              tag: CIS-18.7.30.2
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'configure solicited remote assistance' is set to 'disabled'
+    Enumerate administrator accounts on elevation :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\CredUI\EnumerateAdministrators':
+              tag: CIS-18.8.11.2
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'enumerate administrator accounts on elevation' is set to 'disabled'
+    Application_ Control Event Log behavior when the log file reaches its maximum size :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Application\Retention':
+              tag: CIS-18.8.22.1.1
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'application - control event log behavior when the log file reaches its maximum size' is set to 'disabled'
+    Security_ Control Event Log behavior when the log file reaches its maximum size :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Security\Retention':
+              tag: CIS-18.8.22.2.1
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'security - control event log behavior when the log file reaches its maximum size' is set to 'disabled'
+    Setup_ Control Event Log behavior when the log file reaches its maximum size :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Setup\Retention':
+              tag: CIS-18.8.22.3.1
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'setup - control event log behavior when the log file reaches its maximum size' is set to 'disabled'
+    System_ Control Event Log behavior when the log file reaches its maximum size :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\System\Retention':
+              tag: CIS-18.8.22.4.1
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'system - control event log behavior when the log file reaches its maximum size' is set to 'disabled'
+    Turn off Data Execution Prevention for Explorer :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Explorer\NoDataExecutionPrevention':
+              tag: CIS-18.8.26.3
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'turn off data execution prevention for explorer' is set to 'disabled'
+    Turn off shell protocol protected mode :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\PreXPSP2ShellProtocolBehavior':
+              tag: CIS-18.8.26.5
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'turn off shell protocol protected mode' is set to 'disabled'
+    Do not use temporary folders per session :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services\PerSessionTempDir':
+              tag: CIS-18.8.45.3.11.1
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'do not use temporary folders per session' is set to 'disabled'
+    Allow indexing of encrypted files :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search\AllowIndexingEncryptedStoresOrItems':
+              tag: CIS-18.8.47.2
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'allow indexing of encrypted files' is set to 'disabled'
+    Always install with elevated privileges system:
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated':
+              tag: CIS-18.8.65.1
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'always install with elevated privileges' is set to 'disabled'
+    Sign-in last interactive user automatically after a system-initiated restart :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\DisableAutomaticRestartSignOn':
+              tag: CIS-18.8.66.1
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: 'Ensure Sign-in last interactive user automatically after a system-initiated restart is set to Disabled'
+    Allow Basic authentication winrm client:
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client\AllowBasic':
+              tag: CIS-18.8.77.1.1
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'allow basic authentication' is set to 'disabled'
+    Allow unencrypted traffic winrm client:
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client\AllowUnencryptedTraffic':
+              tag: CIS-18.8.77.1.2
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'allow unencrypted traffic' is set to 'disabled'
+    Allow Basic authentication winrm service:
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service\AllowBasic':
+              tag: CIS-18.8.77.2.1
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'allow basic authentication' is set to 'disabled'
+    Allow unencrypted traffic winrm service:
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service\AllowUnencryptedTraffic':
+              tag: CIS-18.8.77.2.2
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'allow unencrypted traffic' is set to 'disabled'
+    No auto-restart with logged on users for scheduled automatic updates installations :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU\NoAutoRebootWithLoggedOnUsers':
+              tag: CIS-18.8.81.5
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'no auto-restart with logged on users for scheduled automatic updates installations' is set to 'disabled'
+    Do not preserve zone information in file attachments :
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_USERS\<SID>\Software\Microsoft\Windows\CurrentVersion\Policies\Attachments\SaveZoneInformation':
+              tag: CIS-19.7.4.1
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'do not preserve zone information in file attachments' is set to 'disabled'
+    Always install with elevated privileges user:
+      data:
+        'Microsoft Windows Server 2012*':
+          - 'HKEY_USERS\<SID>\Software\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated':
+              tag: CIS-19.7.37.1
+              match_output: 'Disabled'
+              value_type: 'equal'
+      description: (L1) Ensure 'always install with elevated privileges' is set to 'disabled'
+
 
 win_pkg:
   whitelist:
@@ -2141,15 +1965,7 @@ win_pkg:
       data:
         'Microsoft Windows Server 2012*':
           - 'EMET':
-              tag: CIS-18.9.22.1
+              tag: CIS-18.8.20.1
               match_output: '5.4'
               value_type: 'more'
-      description: (l1) ensure 'emet 5.5' or higher is installed
-    LAPS AdmPwd GPO Extension / CSE is installed :
-      data:
-        'Microsoft Windows Server 2012*':
-          - 'Navigate to Control Panel\Program\Programs and Features and confirm "lAPS" is listed in the Name column.':
-              tag: CIS-18.2.1
-              match_output: 'Local Administrator Password Solution'
-              value_type: 'equal'
-      description: 'Ensure LAPS AdmPwd GPO Extension / CSE is installed '
+      description: (L1) Ensure 'emet 5.5' or higher is installed


### PR DESCRIPTION
MaxAuthRetries relates to CentOS/RHEL CIS-5.2.5 but appears in other OS'.  Not only does the current implementation produce false positives as indicated in Issue #82, but it also produces false negatives if the number is, say 40 or 4444.

I tried to do as many OS' as possible; for OS with more than two versions, only the last two (judged by version numerals) are changed; for any profile with more than one CIS versions, only the last version is changed.
	modified:   hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
	modified:   hubblestack_nova_profiles/cis/coreos-level-1.yaml
	modified:   hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/debian-9.yaml
	modified:   hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
	modified:   hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
	modified:   hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
	modified:   hubblestack_nova_profiles/cis/ubuntu-1204-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/windows-2008r2-level-1-scored-v3-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/windows-2012r2-level-1-scored-v2-0-0.yaml