### PR TITLE
Issue #82: Fix false positives + false negatives in sshd MaxAuthTries

### DIFF
--- a/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
@@ -637,7 +637,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: 'Set SSH MaxAuthTries to 4 or Less (Scored)'
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
@@ -637,7 +637,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: 'Set SSH MaxAuthTries to 4 or Less (Scored)'
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
@@ -562,8 +562,9 @@ grep:
       data:
         'Amazon Linux*':
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
@@ -675,7 +675,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: 'Set SSH MaxAuthTries to 4 or Less'
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
@@ -723,7 +723,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.5
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: Ensure SSH MaxAuthTries is set to 4 or less
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
@@ -333,8 +333,9 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-6.2.5
       description: Set SSH MaxAuthTries to 4 or Less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
@@ -598,8 +598,9 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -601,8 +601,9 @@ h.com'
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -512,6 +512,16 @@ grep:
             pattern: Ciphers
             tag: CIS-5.2.11
       description: Ensure only approved ciphers are used
+    sshd_approved_macs:
+      data:
+        CentOS Linux-7:
+        - /etc/ssh/sshd_config:
+            match_output: 'MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@
+openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openss
+h.com'
+            pattern: MACs
+            tag: CIS-5.2.12
+      description: Ensure only approved MAC algorithms are used
     sshd_banner:
       data:
         CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/coreos-level-1.yaml
+++ b/hubblestack_nova_profiles/cis/coreos-level-1.yaml
@@ -549,8 +549,9 @@ grep:
       data:
         '*CoreOS*':
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/debian-7.yaml
+++ b/hubblestack_nova_profiles/cis/debian-7.yaml
@@ -183,7 +183,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: Set SSH MaxAuthTries to 4 or Less
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
@@ -204,7 +204,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: Set SSH MaxAuthTries to 4 or Less
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/debian-9.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9.yaml
@@ -192,7 +192,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.5'
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: Set SSH MaxAuthTries to 4 or Less
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
@@ -352,8 +352,9 @@ grep:
       data:
         Red Hat Enterprise Linux Server-5:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-6.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
@@ -339,8 +339,9 @@ grep:
       data:
         Red Hat Enterprise Linux Server-6:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-6.2.5
       description: Set SSH MaxAuthTries to 4 or Less (Scored)
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
@@ -723,7 +723,8 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.5
               pattern: "^MaxAuthTries"
-              match_output: "MaxAuthTries 4"
+              match_output_regex: True
+              match_output: "^MaxAuthTries +[1-4]$"
       description: Ensure SSH MaxAuthTries is set to 4 or less
 
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
@@ -333,8 +333,9 @@ grep:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-6.2.5
       description: Set SSH MaxAuthTries to 4 or Less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -591,8 +591,9 @@ grep:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -581,8 +581,9 @@ grep:
       data:
         Red Hat Enterprise Linux Workstation-7:
         - /etc/ssh/sshd_config:
-            match_output: MaxAuthTries 4
+            match_output: "^MaxAuthTries +[1-4]$"
             pattern: ^MaxAuthTries
+            match_output_regex: True
             tag: CIS-5.2.5
       description: Ensure SSH MaxAuthTries is set to 4 or less
     sshd_permit_empty_passwords:

--- a/hubblestack_nova_profiles/cis/ubuntu-1204-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1204-level-1-scored-v1-0-0.yaml
@@ -230,7 +230,8 @@ grep:
         Ubuntu-12.04:
         - /etc/ssh/sshd_config:
             pattern: MaxAuthTries
-            match: '4'
+            match_output_regex: True
+            match_output: "^MaxAuthTries +[1-4]$"
             tag: CIS-9.3.5
       description: Set SSH MaxAuthTries to 4 or Less
     ssh_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
@@ -253,7 +253,8 @@ grep:
         Ubuntu-14.04:
         - /etc/ssh/sshd_config:
             pattern: MaxAuthTries
-            match: '4'
+            match_output_regex: True
+            match_output: "^MaxAuthTries +[1-4]$"
             tag: CIS-9.3.5
       description: Set SSH MaxAuthTries to 4 or Less
     ssh_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
@@ -230,7 +230,8 @@ grep:
         Ubuntu-16.04:
         - /etc/ssh/sshd_config:
             pattern: MaxAuthTries
-            match: '4'
+            match_output_regex: True
+            match_output: "^MaxAuthTries +[1-4]$"
             tag: CIS-9.3.5
       description: Set SSH MaxAuthTries to 4 or Less
     ssh_ignore_rhosts:


### PR DESCRIPTION
Revision to #49 without inadvertent rollback.  This time, I just used sed to edit every file. (Request #52 is included.)
```
for file in `fgrep -l sshd_conf *.yaml`; do echo $file ----; sed -i~ '/ssh.*auth_retries/,/description/{s/match_output:.*/match_output: "^MaxAuthTries +[1-4]$"/;s/match:.*/match_output: "^MaxAuthTries +[1-4]$"/;/pattern:/a\
\            match_output_regex: True
;}' $file; done 
```
A lot of time is spent dealing with inconsistent symbols, such as "sshd_max_auth_retries" vs "ssh_auth_retries", "match_output" vs "match", even different indents. (Indents are readjusted manually  not for consistence as there is none, but for in-file aesthetics.). Is the syntaxes "match_output" and "match" redundant?