### PR TITLE
Issue #165: Check FS options in /proc/mounts

### DIFF
--- a/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
@@ -432,45 +432,45 @@ sysctl:
 grep:
   whitelist:
 
-    fstab_tmp_partition:
+    mounts_tmp_partition:
       data:
         Amazon Linux AMI-2014:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.1'
               pattern: '/tmp'
       description: 'Create Separate Partition for /tmp (Scored)'
 
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         Amazon Linux AMI-2014:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.2'
               pattern: '/tmp'
               match_output: 'nodev'
       description: 'Set nodev option for /tmp Partition (Scored)'
 
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         Amazon Linux AMI-2014:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.3'
               pattern: '/tmp'
               match_output: 'nosuid'
       description: 'Set nosuid option for /tmp Partition (Scored)'
 
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         Amazon Linux AMI-2014:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.4'
               pattern: '/tmp'
               match_output: 'noexec'
       description: 'Set noexec option for /tmp Partition (Scored)'
 
-    fstab_var_partition:
+    mounts_var_partition:
       data:
         Amazon Linux AMI-2014:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.5'
               pattern: '/var'
       description: 'Create Separate Partition for /var (Scored)'
@@ -484,61 +484,61 @@ grep:
               match_output: '/var/tmp'
       description: 'Bind Mount the /var/tmp directory to /tmp (Scored)'
 
-    fstab_var_log_partition:
+    mounts_var_log_partition:
       data:
         Amazon Linux AMI-2014:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.7'
               pattern: '/var/log'
       description: 'Create Separate Partition for /var/log (Scored)'
 
-    fstab_var_log_audit_partition:
+    mounts_var_log_audit_partition:
       data:
         Amazon Linux AMI-2014:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.8'
               pattern: '/var/log/audit'
       description: 'Create Separate Partition for /var/log/audit (Scored)'
 
-    fstab_home_partition:
+    mounts_home_partition:
       data:
         Amazon Linux AMI-2014:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.9'
               pattern: '/home'
       description: 'Create Separate Partition for /home (Scored)'
 
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         Amazon Linux AMI-2014:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.10'
               pattern: '/home'
               match_output: 'nodev'
       description: 'Add nodev Option to /home (Scored)'
 
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         Amazon Linux AMI-2014:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.14'
               pattern: '/dev/shm'
               match_output: 'nodev'
       description: 'Add nodev Option to /dev/shm Partition (Scored)'
 
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         Amazon Linux AMI-2014:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.15'
               pattern: '/dev/shm'
               match_output: 'nosuid'
       description: 'Add nosuid Option to /dev/shm Partition (Scored)'
 
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         Amazon Linux AMI-2014:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.16'
               pattern: '/dev/shm'
               match_output: 'noexec'

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
@@ -432,45 +432,45 @@ sysctl:
 grep:
   whitelist:
 
-    fstab_tmp_partition:
+    mounts_tmp_partition:
       data:
         Amazon Linux*:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.1'
               pattern: '/tmp'
       description: 'Create Separate Partition for /tmp (Scored)'
 
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         Amazon Linux*:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.2'
               pattern: '/tmp'
               match_output: 'nodev'
       description: 'Set nodev option for /tmp Partition (Scored)'
 
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         Amazon Linux*:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.3'
               pattern: '/tmp'
               match_output: 'nosuid'
       description: 'Set nosuid option for /tmp Partition (Scored)'
 
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         Amazon Linux*:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.4'
               pattern: '/tmp'
               match_output: 'noexec'
       description: 'Set noexec option for /tmp Partition (Scored)'
 
-    fstab_var_partition:
+    mounts_var_partition:
       data:
         Amazon Linux*:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.5'
               pattern: '/var'
       description: 'Create Separate Partition for /var (Scored)'
@@ -484,61 +484,61 @@ grep:
               match_output: '/var/tmp'
       description: 'Bind Mount the /var/tmp directory to /tmp (Scored)'
 
-    fstab_var_log_partition:
+    mounts_var_log_partition:
       data:
         Amazon Linux*:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.7'
               pattern: '/var/log'
       description: 'Create Separate Partition for /var/log (Scored)'
 
-    fstab_var_log_audit_partition:
+    mounts_var_log_audit_partition:
       data:
         Amazon Linux*:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.8'
               pattern: '/var/log/audit'
       description: 'Create Separate Partition for /var/log/audit (Scored)'
 
-    fstab_home_partition:
+    mounts_home_partition:
       data:
         Amazon Linux*:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.9'
               pattern: '/home'
       description: 'Create Separate Partition for /home (Scored)'
 
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         Amazon Linux*:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.10'
               pattern: '/home'
               match_output: 'nodev'
       description: 'Add nodev Option to /home (Scored)'
 
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         Amazon Linux*:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.14'
               pattern: '/dev/shm'
               match_output: 'nodev'
       description: 'Add nodev Option to /dev/shm Partition (Scored)'
 
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         Amazon Linux*:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.15'
               pattern: '/dev/shm'
               match_output: 'nosuid'
       description: 'Add nosuid Option to /dev/shm Partition (Scored)'
 
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         Amazon Linux*:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.16'
               pattern: '/dev/shm'
               match_output: 'noexec'

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
@@ -206,82 +206,82 @@ grep:
               - '-r'
             tag: CIS-1.1.1.8
       description: Ensure mounting of FAT filesystems is disabled
-    fstab_var_tmp_partition_nodev:
+    mounts_var_tmp_partition_nodev:
       data:
         'Amazon Linux*':
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /var/tmp
             tag: CIS-1.1.8
       description: Ensure nodev option set on /var/tmp partition
-    fstab_var_tmp_partition_nosuid:
+    mounts_var_tmp_partition_nosuid:
       data:
         'Amazon Linux*':
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /var/tmp
             tag: CIS-1.1.9
       description: Ensure nosuid option set on /var/tmp partition
-    fstab_var_tmp_partition_noexec:
+    mounts_var_tmp_partition_noexec:
       data:
         'Amazon Linux*':
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /var/tmp
             tag: CIS-1.1.10
       description: Ensure noexec option set on /var/tmp partition
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         'Amazon Linux*':
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /dev/shm
             tag: CIS-1.1.15
       description: Ensure nodev option set on /dev/shm partition
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         'Amazon Linux*':
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /dev/shm
             tag: CIS-1.1.17
       description: Ensure noexec option set on /dev/shm partition
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         'Amazon Linux*':
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /dev/shm
             tag: CIS-1.1.16
       description: Ensure nosuid option set on /dev/shm partition
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         'Amazon Linux*':
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /home
             tag: CIS-1.1.14
       description: Ensure nodev option set on /home partition
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         'Amazon Linux*':
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /tmp
             tag: CIS-1.1.3
       description: Ensure nodev option set on /tmp partition
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         'Amazon Linux*':
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /tmp
             tag: CIS-1.1.5
       description: Ensure noexec option set on /tmp partition
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         'Amazon Linux*':
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-1.1.4

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
@@ -470,45 +470,45 @@ sysctl:
 grep:
   whitelist:
 
-    fstab_tmp_partition:
+    mounts_tmp_partition:
       data:
         CentOS-6:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.1'
               pattern: '/tmp'
       description: 'Create Separate Partition for /tmp'
 
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         CentOS-6:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.2'
               pattern: '/tmp'
               match_output: 'nodev'
       description: 'Set nodev option for /tmp Partition'
 
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         CentOS-6:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.3'
               pattern: '/tmp'
               match_output: 'nosuid'
       description: 'Set nosuid option for /tmp Partition'
 
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         CentOS-6:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.4'
               pattern: '/tmp'
               match_output: 'noexec'
       description: 'Set noexec option for /tmp Partition'
 
-    fstab_var_partition:
+    mounts_var_partition:
       data:
         CentOS-6:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.5'
               pattern: '/var'
       description: 'Create Separate Partition for /var'
@@ -522,61 +522,61 @@ grep:
               match_output: '/var/tmp'
       description: 'Bind Mount the /var/tmp directory to /tmp'
 
-    fstab_var_log_partition:
+    mounts_var_log_partition:
       data:
         CentOS-6:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.7'
               pattern: '/var/log'
       description: 'Create Separate Partition for /var/log'
 
-    fstab_var_log_audit_partition:
+    mounts_var_log_audit_partition:
       data:
         CentOS-6:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.8'
               pattern: '/var/log/audit'
       description: 'Create Separate Partition for /var/log/audit'
 
-    fstab_home_partition:
+    mounts_home_partition:
       data:
         CentOS-6:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.9'
               pattern: '/home'
       description: 'Create Separate Partition for /home'
 
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         CentOS-6:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.10'
               pattern: '/home'
               match_output: 'nodev'
       description: 'Add nodev Option to /home'
 
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         CentOS-6:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.14'
               pattern: '/dev/shm'
               match_output: 'nodev'
       description: 'Add nodev Option to /dev/shm Partition'
 
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         CentOS-6:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.15'
               pattern: '/dev/shm'
               match_output: 'nosuid'
       description: 'Add nosuid Option to /dev/shm Partition'
 
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         CentOS-6:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-1.1.16'
               pattern: '/dev/shm'
               match_output: 'noexec'

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
@@ -541,91 +541,91 @@ grep:
               - '-r'
             tag: CIS-1.1.1.8
       description: Ensure mounting of FAT filesystems is disabled
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         'CentOS-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.3
               pattern: '/tmp'
               match_output: 'nodev'
       description: Ensure nodev option set on /tmp partition
 
-    fstab_var_tmp_partition_nodev:
+    mounts_var_tmp_partition_nodev:
       data:
         'CentOS-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.8
               pattern: '/var/tmp'
               match_output: 'nodev'
       description: Ensure nodev option set on /var/tmp partition
 
-    fstab_var_tmp_partition_nosuid:
+    mounts_var_tmp_partition_nosuid:
       data:
         'CentOS-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.9
               pattern: '/var/tmp'
               match_output: 'nosuid'
       description: Ensure nosuid option set on /var/tmp partition
 
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         'CentOS-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.4
               pattern: '/tmp'
               match_output: 'nosuid'
       description: Ensure nosuid option set on /tmp partition
 
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         'CentOS-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.5
               pattern: '/tmp'
               match_output: 'noexec'
       description: Ensure noexec option set on /tmp partition
 
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         'CentOS-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.14
               pattern: '/home'
               match_output: 'nodev'
       description: Ensure nodev option set on /home partition
 
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         'CentOS-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.15
               pattern: '/dev/shm'
               match_output: 'nodev'
       description: Ensure nodev option set on /dev/shm partition
 
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         'CentOS-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.16
               pattern: '/dev/shm'
               match_output: 'nosuid'
       description: Ensure nosuid option set on /dev/shm partition
 
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         'CentOS-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.17
               pattern: '/dev/shm'
               match_output: 'noexec'
       description: Ensure noexec option set on /dev/shm partition
 
-    fstab_var_tmp_partition_noexec:
+    mounts_var_tmp_partition_noexec:
       data:
         'CentOS-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.10
               pattern: '/var/tmp'
               match_output: 'noexec'

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
@@ -86,94 +86,94 @@ grep:
             pattern: ^umask 077
             tag: CIS-7.4
       description: Set Default umask for Users
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /dev/shm
             tag: CIS-1.1.14
       description: Add nodev Option to /dev/shm Partition
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /dev/shm
             tag: CIS-1.1.16
       description: Add noexec Option to /dev/shm Partition
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /dev/shm
             tag: CIS-1.1.15
       description: Add nosuid Option to /dev/shm Partition
-    fstab_home_partition:
+    mounts_home_partition:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /home
             tag: CIS-1.1.9
       description: Create Separate Partition for /home
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /home
             tag: CIS-1.1.10
       description: Add nodev Option to /home
-    fstab_tmp_partition:
+    mounts_tmp_partition:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /tmp
             tag: CIS-1.1.1
       description: Create Separate Partition for /tmp
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /tmp
             tag: CIS-1.1.2
       description: Set nodev option for /tmp Partition
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /tmp
             tag: CIS-1.1.4
       description: Set noexec option for /tmp Partition
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-1.1.3
       description: Set nosuid option for /tmp Partition
-    fstab_var_log_audit_partition:
+    mounts_var_log_audit_partition:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var/log/audit
             tag: CIS-1.1.8
       description: Create Separate Partition for /var/log/audit
-    fstab_var_log_partition:
+    mounts_var_log_partition:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var/log
             tag: CIS-1.1.7
       description: Create Separate Partition for /var/log
-    fstab_var_partition:
+    mounts_var_partition:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var
             tag: CIS-1.1.5
       description: Create Separate Partition for /var

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
@@ -259,82 +259,82 @@ grep:
               - '-r'
             tag: CIS-1.1.1.8
       description: Ensure mounting of FAT filesystems is disabled
-    fstab_var_tmp_partition_nodev:
+    mounts_var_tmp_partition_nodev:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /var/tmp
             tag: CIS-1.1.8
       description: Ensure nodev option set on /var/tmp partition
-    fstab_var_tmp_partition_nosuid:
+    mounts_var_tmp_partition_nosuid:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /var/tmp
             tag: CIS-1.1.9
       description: Ensure nosuid option set on /var/tmp partition
-    fstab_var_tmp_partition_noexec:
+    mounts_var_tmp_partition_noexec:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /var/tmp
             tag: CIS-1.1.10
       description: Ensure noexec option set on /var/tmp partition
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /dev/shm
             tag: CIS-1.1.15
       description: Ensure nodev option set on /dev/shm partition
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /dev/shm
             tag: CIS-1.1.17
       description: Ensure noexec option set on /dev/shm partition
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /dev/shm
             tag: CIS-1.1.16
       description: Ensure nosuid option set on /dev/shm partition
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /home
             tag: CIS-1.1.14
       description: Ensure nodev option set on /home partition
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /tmp
             tag: CIS-1.1.3
       description: Ensure nodev option set on /tmp partition
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /tmp
             tag: CIS-1.1.5
       description: Ensure noexec option set on /tmp partition
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-1.1.4

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -253,82 +253,82 @@ grep:
               - '-r'
             tag: CIS-1.1.1.8
       description: Ensure mounting of FAT filesystems is disabled
-    fstab_var_tmp_partition_nodev:
+    mounts_var_tmp_partition_nodev:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /var/tmp
             tag: CIS-1.1.8
       description: Ensure nodev option set on /var/tmp partition
-    fstab_var_tmp_partition_nosuid:
+    mounts_var_tmp_partition_nosuid:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /var/tmp
             tag: CIS-1.1.9
       description: Ensure nosuid option set on /var/tmp partition
-    fstab_var_tmp_partition_noexec:
+    mounts_var_tmp_partition_noexec:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /var/tmp
             tag: CIS-1.1.10
       description: Ensure noexec option set on /var/tmp partition
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /dev/shm
             tag: CIS-1.1.15
       description: Ensure nodev option set on /dev/shm partition
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /dev/shm
             tag: CIS-1.1.17
       description: Ensure noexec option set on /dev/shm partition
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /dev/shm
             tag: CIS-1.1.16
       description: Ensure nosuid option set on /dev/shm partition
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /home
             tag: CIS-1.1.14
       description: Ensure nodev option set on /home partition
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /tmp
             tag: CIS-1.1.3
       description: Ensure nodev option set on /tmp partition
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /tmp
             tag: CIS-1.1.5
       description: Ensure noexec option set on /tmp partition
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         CentOS Linux-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-1.1.4

--- a/hubblestack_nova_profiles/cis/debian-7.yaml
+++ b/hubblestack_nova_profiles/cis/debian-7.yaml
@@ -13,45 +13,45 @@ grep:
               pattern: "^dc_local_interfaces = '127.0.0.1'"
       description: Configure Mail Transfer Agent for Local-Only Mode
 
-    fstab_tmp_partition:
+    mounts_tmp_partition:
       data:
         Debian*7:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.1'
               pattern: '/tmp'
       description: Create Separate Partition for /tmp
 
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         Debian*7:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.2'
               pattern: '/tmp'
               match_output: 'nodev'
       description: Set nodev option for /tmp Partition
 
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         Debian*7:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.3'
               pattern: '/tmp'
               match_output: 'nosuid'
       description: Set nosuid option for /tmp Partition
 
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         Debian*7:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.4'
               pattern: '/tmp'
               match_output: 'nosuid'
       description: Set noexec option for /tmp Partition
 
-    fstab_var_partition:
+    mounts_var_partition:
       data:
         Debian*7:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.5'
               pattern: '/var'
       description: Create Separate Partition for /var
@@ -65,61 +65,61 @@ grep:
               match_output: '/var/tmp'
       description: Bind Mount the /var/tmp directory to /tmp
 
-    fstab_var_log_partition:
+    mounts_var_log_partition:
       data:
         Debian*7:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.7'
               pattern: '/var/log'
       description: Create Separate Partition for /var/log
 
-    fstab_var_log_audit_partition:
+    mounts_var_log_audit_partition:
       data:
         Debian*7:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.8'
               pattern: '/var/log/audit'
       description: Create Separate Partition for /var/log/audit
 
-    fstab_home_partition:
+    mounts_home_partition:
       data:
         Debian*7:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.9'
               pattern: '/home'
       description: Create Separate Partition for /home
 
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         Debian*7:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.10'
               pattern: '/home'
               match_output: 'nodev'
       description: Add nodev Option to /home
 
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         Debian*7:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.14'
               pattern: '/dev/shm'
               match_output: 'nodev'
       description: Add nodev Option to /run/shm Partition
 
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         Debian*7:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.15'
               pattern: '/dev/shm'
               match_output: 'nosuid'
       description: Add nosuid Option to /run/shm Partition
 
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         Debian*7:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.16'
               pattern: '/dev/shm'
               match_output: 'noexec'

--- a/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
@@ -34,45 +34,45 @@ grep:
               pattern: "^dc_local_interfaces = '127.0.0.1'"
       description: Configure Mail Transfer Agent for Local-Only Mode
 
-    fstab_tmp_partition:
+    mounts_tmp_partition:
       data:
         Debian*8:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.1'
               pattern: '/tmp'
       description: Create Separate Partition for /tmp
 
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         Debian*8:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.2'
               pattern: '/tmp'
               match_output: 'nodev'
       description: Set nodev option for /tmp Partition
 
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         Debian*8:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.3'
               pattern: '/tmp'
               match_output: 'nosuid'
       description: Set nosuid option for /tmp Partition
 
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         Debian*8:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.4'
               pattern: '/tmp'
               match_output: 'nosuid'
       description: Set noexec option for /tmp Partition
 
-    fstab_var_partition:
+    mounts_var_partition:
       data:
         Debian*8:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.5'
               pattern: '/var'
       description: Create Separate Partition for /var
@@ -86,61 +86,61 @@ grep:
               match_output: '/var/tmp'
       description: Bind Mount the /var/tmp directory to /tmp
 
-    fstab_var_log_partition:
+    mounts_var_log_partition:
       data:
         Debian*8:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.7'
               pattern: '/var/log'
       description: Create Separate Partition for /var/log
 
-    fstab_var_log_audit_partition:
+    mounts_var_log_audit_partition:
       data:
         Debian*8:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.8'
               pattern: '/var/log/audit'
       description: Create Separate Partition for /var/log/audit
 
-    fstab_home_partition:
+    mounts_home_partition:
       data:
         Debian*8:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.9'
               pattern: '/home'
       description: Create Separate Partition for /home
 
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         Debian*8:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.10'
               pattern: '/home'
               match_output: 'nodev'
       description: Add nodev Option to /home
 
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         Debian*8:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.14'
               pattern: '/dev/shm'
               match_output: 'nodev'
       description: Add nodev Option to /run/shm Partition
 
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         Debian*8:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.15'
               pattern: '/dev/shm'
               match_output: 'nosuid'
       description: Add nosuid Option to /run/shm Partition
 
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         Debian*8:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.16'
               pattern: '/dev/shm'
               match_output: 'noexec'

--- a/hubblestack_nova_profiles/cis/debian-9.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9.yaml
@@ -13,45 +13,45 @@ grep:
               pattern: "^dc_local_interfaces = '127.0.0.1'"
       description: Configure Mail Transfer Agent for Local-Only Mode
 
-    fstab_tmp_partition:
+    mounts_tmp_partition:
       data:
         Debian*9:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.1'
               pattern: '/tmp'
       description: Create Separate Partition for /tmp
 
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         Debian*9:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.2'
               pattern: '/tmp'
               match_output: 'nodev'
       description: Set nodev option for /tmp Partition
 
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         Debian*9:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.3'
               pattern: '/tmp'
               match_output: 'nosuid'
       description: Set nosuid option for /tmp Partition
 
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         Debian*9:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.4'
               pattern: '/tmp'
               match_output: 'nosuid'
       description: Set noexec option for /tmp Partition
 
-    fstab_var_partition:
+    mounts_var_partition:
       data:
         Debian*9:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.5'
               pattern: '/var'
       description: Create Separate Partition for /var
@@ -65,61 +65,61 @@ grep:
               match_output: '/var/tmp'
       description: Bind Mount the /var/tmp directory to /tmp
 
-    fstab_var_log_partition:
+    mounts_var_log_partition:
       data:
         Debian*9:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.7'
               pattern: '/var/log'
       description: Create Separate Partition for /var/log
 
-    fstab_var_log_audit_partition:
+    mounts_var_log_audit_partition:
       data:
         Debian*9:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.8'
               pattern: '/var/log/audit'
       description: Create Separate Partition for /var/log/audit
 
-    fstab_home_partition:
+    mounts_home_partition:
       data:
         Debian*9:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.9'
               pattern: '/home'
       description: Create Separate Partition for /home
 
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         Debian*9:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.10'
               pattern: '/home'
               match_output: 'nodev'
       description: Add nodev Option to /home
 
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         Debian*9:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.14'
               pattern: '/dev/shm'
               match_output: 'nodev'
       description: Add nodev Option to /run/shm Partition
 
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         Debian*9:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.15'
               pattern: '/dev/shm'
               match_output: 'nosuid'
       description: Add nosuid Option to /run/shm Partition
 
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         Debian*9:
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: 'CIS-2.16'
               pattern: '/dev/shm'
               match_output: 'noexec'

--- a/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
@@ -76,94 +76,94 @@ grep:
             pattern: ^umask 077
             tag: CIS-7.4
       description: Set Default umask for Users (Scored)
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         Red Hat Enterprise Linux Server-5:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /dev/shm
             tag: CIS-1.1.14
       description: Ensure nodev option set on /dev/shm partition
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         Red Hat Enterprise Linux Server-5:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /dev/shm
             tag: CIS-1.1.16
       description: Ensure noexec option set on /dev/shm partition
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         Red Hat Enterprise Linux Server-5:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /dev/shm
             tag: CIS-1.1.15
       description: Ensure nosuid option set on /dev/shm partition
-    fstab_home_partition:
+    mounts_home_partition:
       data:
         Red Hat Enterprise Linux Server-5:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /home
             tag: CIS-1.1.9
       description: Create Separate Partition for /home (Scored)
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         Red Hat Enterprise Linux Server-5:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /home
             tag: CIS-1.1.10
       description: Ensure nodev option set on /home partition
-    fstab_tmp_partition:
+    mounts_tmp_partition:
       data:
         Red Hat Enterprise Linux Server-5:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /tmp
             tag: CIS-1.1.1
       description: Create Separate Partition for /tmp (Scored)
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         Red Hat Enterprise Linux Server-5:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /tmp
             tag: CIS-1.1.2
       description: Ensure nodev option set on /tmp partition
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         Red Hat Enterprise Linux Server-5:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /tmp
             tag: CIS-1.1.4
       description: Ensure noexec option set on /tmp partition
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         Red Hat Enterprise Linux Server-5:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-1.1.3
       description: Ensure nosuid option set on /tmp partition
-    fstab_var_log_audit_partition:
+    mounts_var_log_audit_partition:
       data:
         Red Hat Enterprise Linux Server-5:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var/log/audit
             tag: CIS-1.1.8
       description: Create Separate Partition for /var/log/audit (Scored)
-    fstab_var_log_partition:
+    mounts_var_log_partition:
       data:
         Red Hat Enterprise Linux Server-5:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var/log
             tag: CIS-1.1.7
       description: Create Separate Partition for /var/log (Scored)
-    fstab_var_partition:
+    mounts_var_partition:
       data:
         Red Hat Enterprise Linux Server-5:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var
             tag: CIS-1.1.5
       description: Create Separate Partition for /var (Scored)

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
@@ -63,94 +63,94 @@ grep:
             pattern: ^umask 077
             tag: CIS-7.4
       description: Set Default umask for Users (Scored)
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /dev/shm
             tag: CIS-1.1.14
       description: Add nodev Option to /dev/shm Partition (Scored)
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /dev/shm
             tag: CIS-1.1.16
       description: Add noexec Option to /dev/shm Partition (Scored)
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /dev/shm
             tag: CIS-1.1.15
       description: Add nosuid Option to /dev/shm Partition (Scored)
-    fstab_home_partition:
+    mounts_home_partition:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /home
             tag: CIS-1.1.9
       description: Create Separate Partition for /home (Scored)
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /home
             tag: CIS-1.1.10
       description: Add nodev Option to /home (Scored)
-    fstab_tmp_partition:
+    mounts_tmp_partition:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /tmp
             tag: CIS-1.1.1
       description: Create Separate Partition for /tmp (Scored)
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /tmp
             tag: CIS-1.1.2
       description: Set nodev option for /tmp Partition (Scored)
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /tmp
             tag: CIS-1.1.4
       description: Set noexec option for /tmp Partition (Scored)
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-1.1.3
       description: Set nosuid option for /tmp Partition (Scored)
-    fstab_var_log_audit_partition:
+    mounts_var_log_audit_partition:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var/log/audit
             tag: CIS-1.1.8
       description: Create Separate Partition for /var/log/audit (Scored)
-    fstab_var_log_partition:
+    mounts_var_log_partition:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var/log
             tag: CIS-1.1.7
       description: Create Separate Partition for /var/log (Scored)
-    fstab_var_partition:
+    mounts_var_partition:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var
             tag: CIS-1.1.5
       description: Create Separate Partition for /var (Scored)

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
@@ -541,91 +541,91 @@ grep:
               - '-r'
             tag: CIS-1.1.1.8
       description: Ensure mounting of FAT filesystems is disabled
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         'Red Hat Enterprise Linux Server-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.3
               pattern: '/tmp'
               match_output: 'nodev'
       description: Ensure nodev option set on /tmp partition
 
-    fstab_var_tmp_partition_nodev:
+    mounts_var_tmp_partition_nodev:
       data:
         'Red Hat Enterprise Linux Server-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.8
               pattern: '/var/tmp'
               match_output: 'nodev'
       description: Ensure nodev option set on /var/tmp partition
 
-    fstab_var_tmp_partition_nosuid:
+    mounts_var_tmp_partition_nosuid:
       data:
         'Red Hat Enterprise Linux Server-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.9
               pattern: '/var/tmp'
               match_output: 'nosuid'
       description: Ensure nosuid option set on /var/tmp partition
 
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         'Red Hat Enterprise Linux Server-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.4
               pattern: '/tmp'
               match_output: 'nosuid'
       description: Ensure nosuid option set on /tmp partition
 
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         'Red Hat Enterprise Linux Server-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.5
               pattern: '/tmp'
               match_output: 'noexec'
       description: Ensure noexec option set on /tmp partition
 
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         'Red Hat Enterprise Linux Server-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.14
               pattern: '/home'
               match_output: 'nodev'
       description: Ensure nodev option set on /home partition
 
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         'Red Hat Enterprise Linux Server-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.15
               pattern: '/dev/shm'
               match_output: 'nodev'
       description: Ensure nodev option set on /dev/shm partition
 
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         'Red Hat Enterprise Linux Server-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.16
               pattern: '/dev/shm'
               match_output: 'nosuid'
       description: Ensure nosuid option set on /dev/shm partition
 
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         'Red Hat Enterprise Linux Server-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.17
               pattern: '/dev/shm'
               match_output: 'noexec'
       description: Ensure noexec option set on /dev/shm partition
 
-    fstab_var_tmp_partition_noexec:
+    mounts_var_tmp_partition_noexec:
       data:
         'Red Hat Enterprise Linux Server-6':
-          - '/etc/fstab':
+          - '/proc/mounts':
               tag: CIS-1.1.10
               pattern: '/var/tmp'
               match_output: 'noexec'

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
@@ -86,94 +86,94 @@ grep:
             pattern: ^umask 077
             tag: CIS-7.4
       description: Set Default umask for Users
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /dev/shm
             tag: CIS-1.1.14
       description: Add nodev Option to /dev/shm Partition
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /dev/shm
             tag: CIS-1.1.16
       description: Add noexec Option to /dev/shm Partition
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /dev/shm
             tag: CIS-1.1.15
       description: Add nosuid Option to /dev/shm Partition
-    fstab_home_partition:
+    mounts_home_partition:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /home
             tag: CIS-1.1.9
       description: Create Separate Partition for /home
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /home
             tag: CIS-1.1.10
       description: Add nodev Option to /home
-    fstab_tmp_partition:
+    mounts_tmp_partition:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /tmp
             tag: CIS-1.1.1
       description: Create Separate Partition for /tmp
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /tmp
             tag: CIS-1.1.2
       description: Set nodev option for /tmp Partition
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /tmp
             tag: CIS-1.1.4
       description: Set noexec option for /tmp Partition
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-1.1.3
       description: Set nosuid option for /tmp Partition
-    fstab_var_log_audit_partition:
+    mounts_var_log_audit_partition:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var/log/audit
             tag: CIS-1.1.8
       description: Create Separate Partition for /var/log/audit
-    fstab_var_log_partition:
+    mounts_var_log_partition:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var/log
             tag: CIS-1.1.7
       description: Create Separate Partition for /var/log
-    fstab_var_partition:
+    mounts_var_partition:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var
             tag: CIS-1.1.5
       description: Create Separate Partition for /var

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -253,82 +253,82 @@ grep:
               - '-r'
             tag: CIS-1.1.1.8
       description: Ensure mounting of FAT filesystems is disabled
-    fstab_var_tmp_partition_nodev:
+    mounts_var_tmp_partition_nodev:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /var/tmp
             tag: CIS-1.1.8
       description: Ensure nodev option set on /var/tmp partition
-    fstab_var_tmp_partition_nosuid:
+    mounts_var_tmp_partition_nosuid:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /var/tmp
             tag: CIS-1.1.9
       description: Ensure nosuid option set on /var/tmp partition
-    fstab_var_tmp_partition_noexec:
+    mounts_var_tmp_partition_noexec:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /var/tmp
             tag: CIS-1.1.10
       description: Ensure noexec option set on /var/tmp partition
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /dev/shm
             tag: CIS-1.1.15
       description: Ensure nodev option set on /dev/shm partition
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /dev/shm
             tag: CIS-1.1.17
       description: Ensure noexec option set on /dev/shm partition
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /dev/shm
             tag: CIS-1.1.16
       description: Ensure nosuid option set on /dev/shm partition
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /home
             tag: CIS-1.1.14
       description: Ensure nodev option set on /home partition
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /tmp
             tag: CIS-1.1.3
       description: Ensure nodev option set on /tmp partition
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /tmp
             tag: CIS-1.1.5
       description: Ensure noexec option set on /tmp partition
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-1.1.4

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -243,82 +243,82 @@ grep:
               - '-r'
             tag: CIS-1.1.1.7
       description: Ensure mounting of udf filesystems is disabled
-    fstab_var_tmp_partition_nodev:
+    mounts_var_tmp_partition_nodev:
       data:
         Red Hat Enterprise Linux Workstation-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /var/tmp
             tag: CIS-1.1.8
       description: Ensure nodev option set on /var/tmp partition
-    fstab_var_tmp_partition_nosuid:
+    mounts_var_tmp_partition_nosuid:
       data:
         Red Hat Enterprise Linux Workstation-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /var/tmp
             tag: CIS-1.1.9
       description: Ensure nosuid option set on /var/tmp partition
-    fstab_var_tmp_partition_noexec:
+    mounts_var_tmp_partition_noexec:
       data:
         Red Hat Enterprise Linux Workstation-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /var/tmp
             tag: CIS-1.1.10
       description: Ensure noexec option set on /var/tmp partition
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         Red Hat Enterprise Linux Workstation-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /dev/shm
             tag: CIS-1.1.15
       description: Ensure nodev option set on /dev/shm partition
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         Red Hat Enterprise Linux Workstation-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /dev/shm
             tag: CIS-1.1.17
       description: Ensure noexec option set on /dev/shm partition
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         Red Hat Enterprise Linux Workstation-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /dev/shm
             tag: CIS-1.1.16
       description: Ensure nosuid option set on /dev/shm partition
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         Red Hat Enterprise Linux Workstation-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /home
             tag: CIS-1.1.14
       description: Ensure nodev option set on /home partition
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         Red Hat Enterprise Linux Workstation-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /tmp
             tag: CIS-1.1.3
       description: Ensure nodev option set on /tmp partition
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         Red Hat Enterprise Linux Workstation-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /tmp
             tag: CIS-1.1.5
       description: Ensure noexec option set on /tmp partition
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         Red Hat Enterprise Linux Workstation-7:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-1.1.4

--- a/hubblestack_nova_profiles/cis/ubuntu-1204-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1204-level-1-scored-v1-0-0.yaml
@@ -3,94 +3,94 @@
 
 grep:
   whitelist:
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         Ubuntu-12.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /dev/shm
             tag: CIS-2.14
       description: Add nodev Option to /run/shm Partition
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         Ubuntu-12.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /dev/shm
             tag: CIS-2.16
       description: Add noexec Option to /run/shm Partition
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         Ubuntu-12.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /dev/shm
             tag: CIS-2.15
       description: Add nosuid Option to /run/shm Partition
-    fstab_home_partition:
+    mounts_home_partition:
       data:
         Ubuntu-12.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /home
             tag: CIS-2.9
       description: Create Separate Partition for /home
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         Ubuntu-12.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /home
             tag: CIS-2.10
       description: Add nodev Option to /home
-    fstab_tmp_partition:
+    mounts_tmp_partition:
       data:
         Ubuntu-12.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /tmp
             tag: CIS-2.1
       description: Create Separate Partition for /tmp
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         Ubuntu-12.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /tmp
             tag: CIS-2.2
       description: Set nodev option for /tmp Partition
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         Ubuntu-12.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-2.4
       description: Set noexec option for /tmp Partition
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         Ubuntu-12.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-2.3
       description: Set nosuid option for /tmp Partition
-    fstab_var_log_audit_partition:
+    mounts_var_log_audit_partition:
       data:
         Ubuntu-12.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var/log/audit
             tag: CIS-2.8
       description: Create Separate Partition for /var/log/audit
-    fstab_var_log_partition:
+    mounts_var_log_partition:
       data:
         Ubuntu-12.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var/log
             tag: CIS-2.7
       description: Create Separate Partition for /var/log
-    fstab_var_partition:
+    mounts_var_partition:
       data:
         Ubuntu-12.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var
             tag: CIS-2.5
       description: Create Separate Partition for /var

--- a/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
@@ -26,94 +26,94 @@
 
 grep:
   whitelist:
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         Ubuntu-14.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /dev/shm
             tag: CIS-2.14
       description: Add nodev Option to /run/shm Partition
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         Ubuntu-14.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /dev/shm
             tag: CIS-2.16
       description: Add noexec Option to /run/shm Partition
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         Ubuntu-14.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /dev/shm
             tag: CIS-2.15
       description: Add nosuid Option to /run/shm Partition
-    fstab_home_partition:
+    mounts_home_partition:
       data:
         Ubuntu-14.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /home
             tag: CIS-2.9
       description: Create Separate Partition for /home
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         Ubuntu-14.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /home
             tag: CIS-2.10
       description: Add nodev Option to /home
-    fstab_tmp_partition:
+    mounts_tmp_partition:
       data:
         Ubuntu-14.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /tmp
             tag: CIS-2.1
       description: Create Separate Partition for /tmp
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         Ubuntu-14.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /tmp
             tag: CIS-2.2
       description: Set nodev option for /tmp Partition
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         Ubuntu-14.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-2.4
       description: Set noexec option for /tmp Partition
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         Ubuntu-14.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-2.3
       description: Set nosuid option for /tmp Partition
-    fstab_var_log_audit_partition:
+    mounts_var_log_audit_partition:
       data:
         Ubuntu-14.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var/log/audit
             tag: CIS-2.8
       description: Create Separate Partition for /var/log/audit
-    fstab_var_log_partition:
+    mounts_var_log_partition:
       data:
         Ubuntu-14.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var/log
             tag: CIS-2.7
       description: Create Separate Partition for /var/log
-    fstab_var_partition:
+    mounts_var_partition:
       data:
         Ubuntu-14.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var
             tag: CIS-2.5
       description: Create Separate Partition for /var

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
@@ -3,94 +3,94 @@
 
 grep:
   whitelist:
-    fstab_dev_shm_partition_nodev:
+    mounts_dev_shm_partition_nodev:
       data:
         Ubuntu-16.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /dev/shm
             tag: CIS-2.14
       description: Add nodev Option to /run/shm Partition
-    fstab_dev_shm_partition_noexec:
+    mounts_dev_shm_partition_noexec:
       data:
         Ubuntu-16.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: noexec
             pattern: /dev/shm
             tag: CIS-2.16
       description: Add noexec Option to /run/shm Partition
-    fstab_dev_shm_partition_nosuid:
+    mounts_dev_shm_partition_nosuid:
       data:
         Ubuntu-16.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /dev/shm
             tag: CIS-2.15
       description: Add nosuid Option to /run/shm Partition
-    fstab_home_partition:
+    mounts_home_partition:
       data:
         Ubuntu-16.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /home
             tag: CIS-2.9
       description: Create Separate Partition for /home
-    fstab_home_partition_nodev:
+    mounts_home_partition_nodev:
       data:
         Ubuntu-16.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /home
             tag: CIS-2.10
       description: Add nodev Option to /home
-    fstab_tmp_partition:
+    mounts_tmp_partition:
       data:
         Ubuntu-16.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /tmp
             tag: CIS-2.1
       description: Create Separate Partition for /tmp
-    fstab_tmp_partition_nodev:
+    mounts_tmp_partition_nodev:
       data:
         Ubuntu-16.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nodev
             pattern: /tmp
             tag: CIS-2.2
       description: Set nodev option for /tmp Partition
-    fstab_tmp_partition_noexec:
+    mounts_tmp_partition_noexec:
       data:
         Ubuntu-16.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-2.4
       description: Set noexec option for /tmp Partition
-    fstab_tmp_partition_nosuid:
+    mounts_tmp_partition_nosuid:
       data:
         Ubuntu-16.04:
-        - /etc/fstab:
+        - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-2.3
       description: Set nosuid option for /tmp Partition
-    fstab_var_log_audit_partition:
+    mounts_var_log_audit_partition:
       data:
         Ubuntu-16.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var/log/audit
             tag: CIS-2.8
       description: Create Separate Partition for /var/log/audit
-    fstab_var_log_partition:
+    mounts_var_log_partition:
       data:
         Ubuntu-16.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var/log
             tag: CIS-2.7
       description: Create Separate Partition for /var/log
-    fstab_var_partition:
+    mounts_var_partition:
       data:
         Ubuntu-16.04:
-        - /etc/fstab:
+        - /proc/mounts:
             pattern: /var
             tag: CIS-2.5
       description: Create Separate Partition for /var


### PR DESCRIPTION
I believe that all existing profiles except windows-* apply to OS' based on the Linux kernel.  So I simply applied
```
sed  -i '/fstab_.*_partition/,/description:/{s?/etc/fstab?/proc/mounts?; s/fstab_/mounts_/}' [a-u]*.yaml
```

- In this, I also replaced the internal name from fstab_*_partition* to mounts_*_partition*.  My understanding is that this does not affect output in any way.
- Those bind_mount checks cannot be done in /proc/mounts so I leave them unchanged for now. (My understanding is that CIS v2 has dropped these check (along with a bunch of others) at least for CentOS.)