### PR TITLE
Issue #179: sshd_idle_timeout should use regex

### DIFF
--- a/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
@@ -702,11 +702,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: "^ClientAliveInterval +300$"
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: 'Set Idle Timeout Interval for User Login (Scored)'
 
     sshd_limit_access:

--- a/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
@@ -702,7 +702,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveInterval"
-              match_output: "^ClientAliveInterval +300$"
+              match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
@@ -702,11 +702,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: "^ClientAliveInterval +300$"
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: 'Set Idle Timeout Interval for User Login (Scored)'
 
     sshd_limit_access:

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
@@ -702,7 +702,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveInterval"
-              match_output: "^ClientAliveInterval +300$"
+              match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
@@ -478,11 +478,13 @@ grep:
       data:
         'Amazon Linux*':
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: "^ClientAliveInterval +300$"
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-5.2.13
       description: Ensure SSH Idle Timeout Interval is configured

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
@@ -41,6 +41,62 @@ grep:
             pattern: '^+:'
             tag: CIS-6.2.3
       description: Ensure no legacy "+" entries exist in /etc/shadow
+    disable_mount_cramfs:
+      data:
+        'Amazon Linux*':
+        - /proc/modules:
+            pattern: "^cramfs "
+            tag: CIS-1.1.1.1
+      description: Ensure mounting of cramfs filesystems is disabled
+    disable_mount_freevxfs:
+      data:
+        'Amazon Linux*':
+        - /proc/modules:
+            pattern: "^freevxfs "
+            tag: CIS-1.1.1.2
+      description: Ensure mounting of freevxfs filesystems is disabled
+    disable_mount_jffs2:
+      data:
+        'Amazon Linux*':
+        - /proc/modules:
+            pattern: "^jffs2 "
+            tag: CIS-1.1.1.3
+      description: Ensure mounting of jffs2 filesystems is disabled
+    disable_mount_hfs:
+      data:
+        'Amazon Linux*':
+        - /proc/modules:
+            pattern: "^hfs "
+            tag: CIS-1.1.1.4
+      description: Ensure mounting of hfs filesystems is disabled
+    disable_mount_hfsplus:
+      data:
+        'Amazon Linux*':
+        - /proc/modules:
+            pattern: "^hfsplus "
+            tag: CIS-1.1.1.5
+      description: Ensure mounting of hfsplus filesystems is disabled
+    disable_mount_squashfs:
+      data:
+        'Amazon Linux*':
+        - /proc/modules:
+            pattern: "^squashfs "
+            tag: CIS-1.1.1.6
+      description: Ensure mounting of squashfs filesystems is disabled
+    disable_mount_udf:
+      data:
+        'Amazon Linux*':
+        - /proc/modules:
+            pattern: "^udf "
+            tag: CIS-1.1.1.7
+      description: Ensure mounting of udf filesystems is disabled
+    disable_mount_fat:
+      data:
+        'Amazon Linux*':
+        - /proc/modules:
+            pattern: "^vfat "
+            tag: CIS-1.1.1.8
+      description: Ensure mounting of FAT filesystems is disabled
   whitelist:
     activate_gpg_check:
       data:
@@ -126,86 +182,6 @@ grep:
             match_pattern: '027'
             tag: CIS-5.4.4
       description: Ensure default user umask is 027 or more restrictive
-    disable_mount_cramfs:
-      data:
-        'Amazon Linux*':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: cramfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.1
-      description: Ensure mounting of cramfs filesystems is disabled
-    disable_mount_freevxfs:
-      data:
-        'Amazon Linux*':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: freevxfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.2
-      description: Ensure mounting of freevxfs filesystems is disabled
-    disable_mount_jffs2:
-      data:
-        'Amazon Linux*':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: jffs2
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.3
-      description: Ensure mounting of jffs2 filesystems is disabled
-    disable_mount_hfs:
-      data:
-        'Amazon Linux*':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.4
-      description: Ensure mounting of hfs filesystems is disabled
-    disable_mount_hfsplus:
-      data:
-        'Amazon Linux*':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfsplus
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.5
-      description: Ensure mounting of hfsplus filesystems is disabled
-    disable_mount_squashfs:
-      data:
-        'Amazon Linux*':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: squashfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.6
-      description: Ensure mounting of squashfs filesystems is disabled
-    disable_mount_udf:
-      data:
-        'Amazon Linux*':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: udf
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.7
-      description: Ensure mounting of udf filesystems is disabled
-    disable_mount_fat:
-      data:
-        'Amazon Linux*':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: vfat
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.8
-      description: Ensure mounting of FAT filesystems is disabled
     mounts_var_tmp_partition_nodev:
       data:
         'Amazon Linux*':

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
@@ -478,7 +478,7 @@ grep:
       data:
         'Amazon Linux*':
         - /etc/ssh/sshd_config:
-            match_output: "^ClientAliveInterval +300$"
+            match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
@@ -740,7 +740,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveInterval"
-              match_output: "^ClientAliveInterval +300$"
+              match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
@@ -740,11 +740,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: "^ClientAliveInterval +300$"
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: 'Set Idle Timeout Interval for User Login'
 
     sshd_limit_access:

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
@@ -461,6 +461,29 @@ sysctl:
 
 grep:
   blacklist:
+    legacy_passwd_entries_passwd:
+      data:
+        'CentOS-6':
+          - '/etc/passwd':
+              tag: CIS-6.2.2
+              pattern: "^+:"
+      description: Ensure no legacy "+" entries exist in /etc/passwd
+
+    legacy_passwd_entries_shadow:
+      data:
+        'CentOS-6':
+          - '/etc/shadow':
+              tag: CIS-6.2.3
+              pattern: "^+:"
+      description: Ensure no legacy "+" entries exist in /etc/shadow
+
+    legacy_passwd_entries_group:
+      data:
+        'CentOS-6':
+          - '/etc/group':
+              tag: CIS-6.2.4
+              pattern: "^+:"
+      description: Ensure no legacy "+" entries exist in /etc/group
     disable_mount_cramfs:
       data:
         'CentOS-6':
@@ -868,31 +891,7 @@ grep:
               pattern: "^umask 077"
       description: Ensure default user umask is 027 or more restrictive
 
-  blacklist:
-    legacy_passwd_entries_passwd:
-      data:
-        'CentOS-6':
-          - '/etc/passwd':
-              tag: CIS-6.2.2
-              pattern: "^+:"
-      description: Ensure no legacy "+" entries exist in /etc/passwd
-
-    legacy_passwd_entries_shadow:
-      data:
-        'CentOS-6':
-          - '/etc/shadow':
-              tag: CIS-6.2.3
-              pattern: "^+:"
-      description: Ensure no legacy "+" entries exist in /etc/shadow
-
-    legacy_passwd_entries_group:
-      data:
-        'CentOS-6':
-          - '/etc/group':
-              tag: CIS-6.2.4
-              pattern: "^+:"
-      description: Ensure no legacy "+" entries exist in /etc/group
-
+ 
 service:
   whitelist:
     rsyslogd_running:

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
@@ -797,7 +797,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13
               pattern: "^ClientAliveInterval"
-              match_output: "^ClientAliveInterval +300$"
+              match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
@@ -797,11 +797,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: "^ClientAliveInterval +300$"
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: Ensure SSH Idle Timeout Interval is configured
 
     sshd_login_grace:

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
@@ -460,87 +460,64 @@ sysctl:
 
 
 grep:
-  whitelist:
+  blacklist:
     disable_mount_cramfs:
       data:
         'CentOS-6':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: cramfs
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^cramfs "
             tag: CIS-1.1.1.1
       description: Ensure mounting of cramfs filesystems is disabled
     disable_mount_freevxfs:
       data:
         'CentOS-6':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: freevxfs
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^freevxfs "
             tag: CIS-1.1.1.2
       description: Ensure mounting of freevxfs filesystems is disabled
     disable_mount_jffs2:
       data:
         'CentOS-6':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: jffs2
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^jffs2 "
             tag: CIS-1.1.1.3
       description: Ensure mounting of jffs2 filesystems is disabled
     disable_mount_hfs:
       data:
         'CentOS-6':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfs
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^hfs "
             tag: CIS-1.1.1.4
       description: Ensure mounting of hfs filesystems is disabled
     disable_mount_hfsplus:
       data:
         'CentOS-6':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfsplus
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^hfsplus "
             tag: CIS-1.1.1.5
       description: Ensure mounting of hfsplus filesystems is disabled
     disable_mount_squashfs:
       data:
         'CentOS-6':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: squashfs
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^squashfs "
             tag: CIS-1.1.1.6
       description: Ensure mounting of squashfs filesystems is disabled
     disable_mount_udf:
       data:
         'CentOS-6':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: udf
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^udf "
             tag: CIS-1.1.1.7
       description: Ensure mounting of udf filesystems is disabled
     disable_mount_fat:
       data:
         'CentOS-6':
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: vfat
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^vfat "
             tag: CIS-1.1.1.8
       description: Ensure mounting of FAT filesystems is disabled
+  whitelist:
     mounts_tmp_partition_nodev:
       data:
         'CentOS-6':

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
@@ -289,11 +289,13 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: "^ClientAliveInterval +300$"
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-6.2.12
       description: Set Idle Timeout Interval for User Login

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
@@ -289,7 +289,7 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: "^ClientAliveInterval +300$"
+            match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
@@ -522,7 +522,7 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: "^ClientAliveInterval +300$"
+            match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
@@ -522,11 +522,13 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: "^ClientAliveInterval +300$"
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-5.2.13
       description: Ensure SSH Idle Timeout Interval is configured

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
@@ -45,6 +45,62 @@ grep:
             pattern: '^+:'
             tag: CIS-6.2.3
       description: Ensure no legacy "+" entries exist in /etc/shadow
+    disable_mount_cramfs:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^cramfs "
+            tag: CIS-1.1.1.1
+      description: Ensure mounting of cramfs filesystems is disabled
+    disable_mount_freevxfs:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^freevxfs "
+            tag: CIS-1.1.1.2
+      description: Ensure mounting of freevxfs filesystems is disabled
+    disable_mount_jffs2:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^jffs2 "
+            tag: CIS-1.1.1.3
+      description: Ensure mounting of jffs2 filesystems is disabled
+    disable_mount_hfs:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^hfs "
+            tag: CIS-1.1.1.4
+      description: Ensure mounting of hfs filesystems is disabled
+    disable_mount_hfsplus:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^hfsplus "
+            tag: CIS-1.1.1.5
+      description: Ensure mounting of hfsplus filesystems is disabled
+    disable_mount_squashfs:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^squashfs "
+            tag: CIS-1.1.1.6
+      description: Ensure mounting of squashfs filesystems is disabled
+    disable_mount_udf:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^udf "
+            tag: CIS-1.1.1.7
+      description: Ensure mounting of udf filesystems is disabled
+    disable_mount_fat:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^vfat "
+            tag: CIS-1.1.1.8
+      description: Ensure mounting of FAT filesystems is disabled
   whitelist:
     activate_gpg_check:
       data:
@@ -179,86 +235,6 @@ grep:
               - '-r'
             tag: CIS-5.4.4
       description: Ensure default user umask is 027 or more restrictive
-    disable_mount_cramfs:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: cramfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.1
-      description: Ensure mounting of cramfs filesystems is disabled
-    disable_mount_freevxfs:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: freevxfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.2
-      description: Ensure mounting of freevxfs filesystems is disabled
-    disable_mount_jffs2:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: jffs2
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.3
-      description: Ensure mounting of jffs2 filesystems is disabled
-    disable_mount_hfs:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.4
-      description: Ensure mounting of hfs filesystems is disabled
-    disable_mount_hfsplus:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfsplus
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.5
-      description: Ensure mounting of hfsplus filesystems is disabled
-    disable_mount_squashfs:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: squashfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.6
-      description: Ensure mounting of squashfs filesystems is disabled
-    disable_mount_udf:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: udf
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.7
-      description: Ensure mounting of udf filesystems is disabled
-    disable_mount_fat:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: vfat
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.8
-      description: Ensure mounting of FAT filesystems is disabled
     mounts_var_tmp_partition_nodev:
       data:
         CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -39,6 +39,62 @@ grep:
             pattern: '^+:'
             tag: CIS-6.2.3
       description: Ensure no legacy "+" entries exist in /etc/shadow
+    disable_mount_cramfs:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^cramfs "
+            tag: CIS-1.1.1.1
+      description: Ensure mounting of cramfs filesystems is disabled
+    disable_mount_freevxfs:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^freevxfs "
+            tag: CIS-1.1.1.2
+      description: Ensure mounting of freevxfs filesystems is disabled
+    disable_mount_jffs2:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^jffs2 "
+            tag: CIS-1.1.1.3
+      description: Ensure mounting of jffs2 filesystems is disabled
+    disable_mount_hfs:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^hfs "
+            tag: CIS-1.1.1.4
+      description: Ensure mounting of hfs filesystems is disabled
+    disable_mount_hfsplus:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^hfsplus "
+            tag: CIS-1.1.1.5
+      description: Ensure mounting of hfsplus filesystems is disabled
+    disable_mount_squashfs:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^squashfs "
+            tag: CIS-1.1.1.6
+      description: Ensure mounting of squashfs filesystems is disabled
+    disable_mount_udf:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^udf "
+            tag: CIS-1.1.1.7
+      description: Ensure mounting of udf filesystems is disabled
+    disable_mount_fat:
+      data:
+        CentOS Linux-7:
+        - /proc/modules:
+            pattern: "^vfat "
+            tag: CIS-1.1.1.8
+      description: Ensure mounting of FAT filesystems is disabled
   whitelist:
     activate_gpg_check:
       data:
@@ -173,86 +229,6 @@ grep:
               - '-r'
             tag: CIS-5.4.4
       description: Ensure default user umask is 027 or more restrictive
-    disable_mount_cramfs:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: cramfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.1
-      description: Ensure mounting of cramfs filesystems is disabled
-    disable_mount_freevxfs:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: freevxfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.2
-      description: Ensure mounting of freevxfs filesystems is disabled
-    disable_mount_jffs2:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: jffs2
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.3
-      description: Ensure mounting of jffs2 filesystems is disabled
-    disable_mount_hfs:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.4
-      description: Ensure mounting of hfs filesystems is disabled
-    disable_mount_hfsplus:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfsplus
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.5
-      description: Ensure mounting of hfsplus filesystems is disabled
-    disable_mount_squashfs:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: squashfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.6
-      description: Ensure mounting of squashfs filesystems is disabled
-    disable_mount_udf:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: udf
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.7
-      description: Ensure mounting of udf filesystems is disabled
-    disable_mount_fat:
-      data:
-        CentOS Linux-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: vfat
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.8
-      description: Ensure mounting of FAT filesystems is disabled
     mounts_var_tmp_partition_nodev:
       data:
         CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -523,11 +523,13 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: "^ClientAliveInterval +300$"
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-5.2.13
       description: Ensure SSH Idle Timeout Interval is configured

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -523,7 +523,7 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: "^ClientAliveInterval +300$"
+            match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13

--- a/hubblestack_nova_profiles/cis/debian-7.yaml
+++ b/hubblestack_nova_profiles/cis/debian-7.yaml
@@ -248,7 +248,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveInterval"
-              match_output: "^ClientAliveInterval +300$"
+              match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'

--- a/hubblestack_nova_profiles/cis/debian-7.yaml
+++ b/hubblestack_nova_profiles/cis/debian-7.yaml
@@ -248,11 +248,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: "^ClientAliveInterval +300$"
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: Set Idle Timeout Interval for User Login
 
     sshd_limit_access:

--- a/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
@@ -269,11 +269,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: "^ClientAliveInterval +300$"
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: Set Idle Timeout Interval for User Login
 
     sshd_limit_access:

--- a/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
@@ -269,7 +269,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveInterval"
-              match_output: "^ClientAliveInterval +300$"
+              match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'

--- a/hubblestack_nova_profiles/cis/debian-9.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9.yaml
@@ -257,7 +257,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveInterval"
-              match_output: "^ClientAliveInterval +300$"
+              match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'

--- a/hubblestack_nova_profiles/cis/debian-9.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9.yaml
@@ -257,11 +257,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: "^ClientAliveInterval +300$"
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: Set Idle Timeout Interval for User Login
 
     sshd_limit_access:

--- a/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
@@ -308,11 +308,13 @@ grep:
       data:
         Red Hat Enterprise Linux Server-5:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: "^ClientAliveInterval +300$"
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-6.2.12
       description: Ensure SSH Idle Timeout Interval is configured

--- a/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
@@ -308,7 +308,7 @@ grep:
       data:
         Red Hat Enterprise Linux Server-5:
         - /etc/ssh/sshd_config:
-            match_output: "^ClientAliveInterval +300$"
+            match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
@@ -295,11 +295,13 @@ grep:
       data:
         Red Hat Enterprise Linux Server-6:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: "^ClientAliveInterval +300$"
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-6.2.12
       description: Set Idle Timeout Interval for User Login (Scored)

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
@@ -295,7 +295,7 @@ grep:
       data:
         Red Hat Enterprise Linux Server-6:
         - /etc/ssh/sshd_config:
-            match_output: "^ClientAliveInterval +300$"
+            match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
@@ -461,6 +461,29 @@ sysctl:
 
 grep:
   blacklist:
+    legacy_passwd_entries_passwd:
+      data:
+        'Red Hat Enterprise Linux Server-6':
+          - '/etc/passwd':
+              tag: CIS-6.2.2
+              pattern: "^+:"
+      description: Ensure no legacy "+" entries exist in /etc/passwd
+
+    legacy_passwd_entries_shadow:
+      data:
+        'Red Hat Enterprise Linux Server-6':
+          - '/etc/shadow':
+              tag: CIS-6.2.3
+              pattern: "^+:"
+      description: Ensure no legacy "+" entries exist in /etc/shadow
+
+    legacy_passwd_entries_group:
+      data:
+        'Red Hat Enterprise Linux Server-6':
+          - '/etc/group':
+              tag: CIS-6.2.4
+              pattern: "^+:"
+      description: Ensure no legacy "+" entries exist in /etc/group
     disable_mount_cramfs:
       data:
         Red Hat Enterprise Linux Server-6:
@@ -868,30 +891,6 @@ grep:
               pattern: "^umask 077"
       description: Ensure default user umask is 027 or more restrictive
 
-  blacklist:
-    legacy_passwd_entries_passwd:
-      data:
-        'Red Hat Enterprise Linux Server-6':
-          - '/etc/passwd':
-              tag: CIS-6.2.2
-              pattern: "^+:"
-      description: Ensure no legacy "+" entries exist in /etc/passwd
-
-    legacy_passwd_entries_shadow:
-      data:
-        'Red Hat Enterprise Linux Server-6':
-          - '/etc/shadow':
-              tag: CIS-6.2.3
-              pattern: "^+:"
-      description: Ensure no legacy "+" entries exist in /etc/shadow
-
-    legacy_passwd_entries_group:
-      data:
-        'Red Hat Enterprise Linux Server-6':
-          - '/etc/group':
-              tag: CIS-6.2.4
-              pattern: "^+:"
-      description: Ensure no legacy "+" entries exist in /etc/group
 
 service:
   whitelist:

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
@@ -460,87 +460,64 @@ sysctl:
 
 
 grep:
-  whitelist:
+  blacklist:
     disable_mount_cramfs:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: cramfs
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^cramfs "
             tag: CIS-1.1.1.1
       description: Ensure mounting of cramfs filesystems is disabled
     disable_mount_freevxfs:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: freevxfs
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^freevxfs "
             tag: CIS-1.1.1.2
       description: Ensure mounting of freevxfs filesystems is disabled
     disable_mount_jffs2:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: jffs2
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^jffs2 "
             tag: CIS-1.1.1.3
       description: Ensure mounting of jffs2 filesystems is disabled
     disable_mount_hfs:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfs
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^hfs "
             tag: CIS-1.1.1.4
       description: Ensure mounting of hfs filesystems is disabled
     disable_mount_hfsplus:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfsplus
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^hfsplus "
             tag: CIS-1.1.1.5
       description: Ensure mounting of hfsplus filesystems is disabled
     disable_mount_squashfs:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: squashfs
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^squashfs "
             tag: CIS-1.1.1.6
       description: Ensure mounting of squashfs filesystems is disabled
     disable_mount_udf:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: udf
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^udf "
             tag: CIS-1.1.1.7
       description: Ensure mounting of udf filesystems is disabled
     disable_mount_fat:
       data:
         Red Hat Enterprise Linux Server-6:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: vfat
-            grep_args:
-              - '-r'
+        - /proc/modules:
+            pattern: "^vfat "
             tag: CIS-1.1.1.8
       description: Ensure mounting of FAT filesystems is disabled
+  whitelist:
     mounts_tmp_partition_nodev:
       data:
         'Red Hat Enterprise Linux Server-6':

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
@@ -797,7 +797,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13
               pattern: "^ClientAliveInterval"
-              match_output: "^ClientAliveInterval +300$"
+              match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
@@ -797,11 +797,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: "^ClientAliveInterval +300$"
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: Ensure SSH Idle Timeout Interval is configured
 
     sshd_login_grace:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
@@ -289,11 +289,13 @@ grep:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: "^ClientAliveInterval +300$"
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-6.2.12
       description: Set Idle Timeout Interval for User Login

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
@@ -289,7 +289,7 @@ grep:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            match_output: "^ClientAliveInterval +300$"
+            match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -515,11 +515,13 @@ grep:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: "^ClientAliveInterval +300$"
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-5.2.13
       description: Ensure SSH Idle Timeout Interval is configured

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -515,7 +515,7 @@ grep:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            match_output: "^ClientAliveInterval +300$"
+            match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -39,6 +39,62 @@ grep:
             pattern: '^+:'
             tag: CIS-6.2.3
       description: Ensure no legacy "+" entries exist in /etc/shadow
+    disable_mount_cramfs:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^cramfs "
+            tag: CIS-1.1.1.1
+      description: Ensure mounting of cramfs filesystems is disabled
+    disable_mount_freevxfs:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^freevxfs "
+            tag: CIS-1.1.1.2
+      description: Ensure mounting of freevxfs filesystems is disabled
+    disable_mount_jffs2:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^jffs2 "
+            tag: CIS-1.1.1.3
+      description: Ensure mounting of jffs2 filesystems is disabled
+    disable_mount_hfs:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^hfs "
+            tag: CIS-1.1.1.4
+      description: Ensure mounting of hfs filesystems is disabled
+    disable_mount_hfsplus:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^hfsplus "
+            tag: CIS-1.1.1.5
+      description: Ensure mounting of hfsplus filesystems is disabled
+    disable_mount_squashfs:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^squashfs "
+            tag: CIS-1.1.1.6
+      description: Ensure mounting of squashfs filesystems is disabled
+    disable_mount_udf:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^udf "
+            tag: CIS-1.1.1.7
+      description: Ensure mounting of udf filesystems is disabled
+    disable_mount_fat:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^vfat "
+            tag: CIS-1.1.1.8
+      description: Ensure mounting of FAT filesystems is disabled
   whitelist:
     activate_gpg_check:
       data:
@@ -173,86 +229,6 @@ grep:
               - '-r'
             tag: CIS-5.4.4
       description: Ensure default user umask is 027 or more restrictive
-    disable_mount_cramfs:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: cramfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.1
-      description: Ensure mounting of cramfs filesystems is disabled
-    disable_mount_freevxfs:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: freevxfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.2
-      description: Ensure mounting of freevxfs filesystems is disabled
-    disable_mount_jffs2:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: jffs2
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.3
-      description: Ensure mounting of jffs2 filesystems is disabled
-    disable_mount_hfs:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.4
-      description: Ensure mounting of hfs filesystems is disabled
-    disable_mount_hfsplus:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfsplus
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.5
-      description: Ensure mounting of hfsplus filesystems is disabled
-    disable_mount_squashfs:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: squashfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.6
-      description: Ensure mounting of squashfs filesystems is disabled
-    disable_mount_udf:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: udf
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.7
-      description: Ensure mounting of udf filesystems is disabled
-    disable_mount_fat:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: vfat
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.8
-      description: Ensure mounting of FAT filesystems is disabled
     mounts_var_tmp_partition_nodev:
       data:
         Red Hat Enterprise Linux Server-7:

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -39,6 +39,55 @@ grep:
             pattern: '^+:'
             tag: CIS-6.2.3
       description: Ensure no legacy "+" entries exist in /etc/shadow
+    disable_mount_cramfs:
+      data:
+        Red Hat Enterprise Linux Workstation-7:
+        - /proc/modules:
+            pattern: "^cramfs "
+            tag: CIS-1.1.1.1
+      description: Ensure mounting of cramfs filesystems is disabled
+    disable_mount_freevxfs:
+      data:
+        Red Hat Enterprise Linux Workstation-7:
+        - /proc/modules:
+            pattern: "^freevxfs "
+            tag: CIS-1.1.1.2
+      description: Ensure mounting of freevxfs filesystems is disabled
+    disable_mount_jffs2:
+      data:
+        Red Hat Enterprise Linux Workstation-7:
+        - /proc/modules:
+            pattern: "^jffs2 "
+            tag: CIS-1.1.1.3
+      description: Ensure mounting of jffs2 filesystems is disabled
+    disable_mount_hfs:
+      data:
+        Red Hat Enterprise Linux Workstation-7:
+        - /proc/modules:
+            pattern: "^hfs "
+            tag: CIS-1.1.1.4
+      description: Ensure mounting of hfs filesystems is disabled
+    disable_mount_hfsplus:
+      data:
+        Red Hat Enterprise Linux Workstation-7:
+        - /proc/modules:
+            pattern: "^hfsplus "
+            tag: CIS-1.1.1.5
+      description: Ensure mounting of hfsplus filesystems is disabled
+    disable_mount_squashfs:
+      data:
+        Red Hat Enterprise Linux Workstation-7:
+        - /proc/modules:
+            pattern: "^squashfs "
+            tag: CIS-1.1.1.6
+      description: Ensure mounting of squashfs filesystems is disabled
+    disable_mount_udf:
+      data:
+        Red Hat Enterprise Linux Workstation-7:
+        - /proc/modules:
+            pattern: "^udf "
+            tag: CIS-1.1.1.7
+      description: Ensure mounting of udf filesystems is disabled
   whitelist:
     activate_gpg_check:
       data:
@@ -173,76 +222,6 @@ grep:
               - '-r'
             tag: CIS-5.4.4
       description: Ensure default user umask is 027 or more restrictive
-    disable_mount_cramfs:
-      data:
-        Red Hat Enterprise Linux Workstation-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: cramfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.1
-      description: Ensure mounting of cramfs filesystems is disabled
-    disable_mount_freevxfs:
-      data:
-        Red Hat Enterprise Linux Workstation-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: freevxfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.2
-      description: Ensure mounting of freevxfs filesystems is disabled
-    disable_mount_jffs2:
-      data:
-        Red Hat Enterprise Linux Workstation-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: jffs2
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.3
-      description: Ensure mounting of jffs2 filesystems is disabled
-    disable_mount_hfs:
-      data:
-        Red Hat Enterprise Linux Workstation-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.4
-      description: Ensure mounting of hfs filesystems is disabled
-    disable_mount_hfsplus:
-      data:
-        Red Hat Enterprise Linux Workstation-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfsplus
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.5
-      description: Ensure mounting of hfsplus filesystems is disabled
-    disable_mount_squashfs:
-      data:
-        Red Hat Enterprise Linux Workstation-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: squashfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.6
-      description: Ensure mounting of squashfs filesystems is disabled
-    disable_mount_udf:
-      data:
-        Red Hat Enterprise Linux Workstation-7:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: udf
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.7
-      description: Ensure mounting of udf filesystems is disabled
     mounts_var_tmp_partition_nodev:
       data:
         Red Hat Enterprise Linux Workstation-7:

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -508,11 +508,13 @@ grep:
       data:
         Red Hat Enterprise Linux Workstation-7:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: "^ClientAliveInterval +300$"
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-5.2.13
       description: Ensure SSH Idle Timeout Interval is configured

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -508,7 +508,7 @@ grep:
       data:
         Red Hat Enterprise Linux Workstation-7:
         - /etc/ssh/sshd_config:
-            match_output: "^ClientAliveInterval +300$"
+            match_output: ^ClientAliveInterval +[1-3]{0,1}\d{1,2}$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13


### PR DESCRIPTION
(PR #60 for issue 171 is included)
The fix would have been very simple if indentations/levels are consistent among yamls.
```
fgrep -l sshd_idle_timeout *.yaml |xargs sed '/sshd_idle_timeout:/,/description:/{s/match_output:.*ClientAliveInterval.*/match_output: "^ClientAliveInterval +300$"/; s/match_output:.*ClientAliveCountMax.*/match_output: "^ClientAliveCountMax +[0-3]$"/;/match_output:/a\
\            match_output_regex: True
;}'
```
I then manually realigned jagged indentations - I thought they were merely aesthetic but indentations are actually used in code.