### PR TITLE
Issue #179 (3rd try): sshd_idle_timeout should use regex with boundary, range

### DIFF
--- a/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
@@ -702,11 +702,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: 'Set Idle Timeout Interval for User Login (Scored)'
 
     sshd_limit_access:

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
@@ -702,11 +702,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: 'Set Idle Timeout Interval for User Login (Scored)'
 
     sshd_limit_access:

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
@@ -478,11 +478,13 @@ grep:
       data:
         'Amazon Linux*':
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-5.2.13
       description: Ensure SSH Idle Timeout Interval is configured

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
@@ -740,11 +740,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: 'Set Idle Timeout Interval for User Login'
 
     sshd_limit_access:

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
@@ -797,11 +797,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: Ensure SSH Idle Timeout Interval is configured
 
     sshd_login_grace:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
@@ -289,11 +289,13 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-6.2.12
       description: Set Idle Timeout Interval for User Login

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
@@ -522,11 +522,13 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-5.2.13
       description: Ensure SSH Idle Timeout Interval is configured

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -523,11 +523,13 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-5.2.13
       description: Ensure SSH Idle Timeout Interval is configured

--- a/hubblestack_nova_profiles/cis/debian-7.yaml
+++ b/hubblestack_nova_profiles/cis/debian-7.yaml
@@ -248,11 +248,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: Set Idle Timeout Interval for User Login
 
     sshd_limit_access:

--- a/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
@@ -269,11 +269,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: Set Idle Timeout Interval for User Login
 
     sshd_limit_access:

--- a/hubblestack_nova_profiles/cis/debian-9.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9.yaml
@@ -257,11 +257,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: Set Idle Timeout Interval for User Login
 
     sshd_limit_access:

--- a/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
@@ -308,11 +308,13 @@ grep:
       data:
         Red Hat Enterprise Linux Server-5:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-6.2.12
       description: Ensure SSH Idle Timeout Interval is configured

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
@@ -295,11 +295,13 @@ grep:
       data:
         Red Hat Enterprise Linux Server-6:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-6.2.12
       description: Set Idle Timeout Interval for User Login (Scored)

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
@@ -797,11 +797,13 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13
               pattern: "^ClientAliveInterval"
-              match_output: "ClientAliveInterval 300"
+              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13
               pattern: "^ClientAliveCountMax"
-              match_output: "ClientAliveCountMax 0"
+              match_output: "^ClientAliveCountMax +[0-3]$"
+              match_output_regex: True
       description: Ensure SSH Idle Timeout Interval is configured
 
     sshd_login_grace:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
@@ -289,11 +289,13 @@ grep:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-6.2.12
       description: Set Idle Timeout Interval for User Login

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -515,11 +515,13 @@ grep:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-5.2.13
       description: Ensure SSH Idle Timeout Interval is configured

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -508,11 +508,13 @@ grep:
       data:
         Red Hat Enterprise Linux Workstation-7:
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveInterval 300
+            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13
         - /etc/ssh/sshd_config:
-            match_output: ClientAliveCountMax 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             pattern: ^ClientAliveCountMax
             tag: CIS-5.2.13
       description: Ensure SSH Idle Timeout Interval is configured

--- a/hubblestack_nova_profiles/cis/ubuntu-1204-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1204-level-1-scored-v1-0-0.yaml
@@ -283,16 +283,18 @@ grep:
             match_output_regex: True
             tag: CIS-9.3.11
       description: Use Only Approved Cipher in Counter Mode
-    ssh_idle_timeout:
+    sshd_idle_timeout:
       data:
         Ubuntu-12.04:
         - /etc/ssh/sshd_config:
             pattern: ClientAliveInterval
-            match_output: '300'
+            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output_regex: True
             tag: CIS-9.3.12
         - /etc/ssh/sshd_config:
             pattern: ClientAliveCountMax
-            match_output: 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             tag: CIS-9.3.12
       description: Set Idle Timeout Interval for User Login
     ssh_limit_access:

--- a/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
@@ -306,16 +306,18 @@ grep:
             match_output_regex: True
             tag: CIS-9.3.11
       description: Use Only Approved Cipher in Counter Mode
-    ssh_idle_timeout:
+    sshd_idle_timeout:
       data:
         Ubuntu-14.04:
         - /etc/ssh/sshd_config:
             pattern: ClientAliveInterval
-            match_output: '300'
+            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output_regex: True
             tag: CIS-9.3.12
         - /etc/ssh/sshd_config:
             pattern: ClientAliveCountMax
-            match_output: 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             tag: CIS-9.3.12
       description: Set Idle Timeout Interval for User Login
     ssh_limit_access:

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
@@ -283,16 +283,18 @@ grep:
             match_output_regex: True
             tag: CIS-9.3.11
       description: Use Only Approved Cipher in Counter Mode
-    ssh_idle_timeout:
+    sshd_idle_timeout:
       data:
         Ubuntu-16.04:
         - /etc/ssh/sshd_config:
             pattern: ClientAliveInterval
-            match_output: '300'
+            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output_regex: True
             tag: CIS-9.3.12
         - /etc/ssh/sshd_config:
             pattern: ClientAliveCountMax
-            match_output: 0
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
             tag: CIS-9.3.12
       description: Set Idle Timeout Interval for User Login
     ssh_limit_access:


### PR DESCRIPTION
Final solution for <=300 is 0..299 or 300 (feeling lazy:-). Then the matter got even more interesting as I discovered inconsistence in match_output string, some includes key name some don't; even some headings use ssh_idle_timeout even though dealing wth sshd. This forced more general search strings and a fixing of headings. Fortunately the variations stop there. Anyway, here's the formula
```
fgrep -l ClientAliveInterval *.yaml |xargs sed -i~ '/_idle_timeout:/,/description:/{s/ssh_idle_timeout:/sshd_idle_timeout:/; s/match_output:.*[^0-9]0[^0-9]*$/match_output: "^ClientAliveCountMax +[0-3]$"/;  s/match_output:.*300.*/match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$/;/match_output:.*ClientAlive/a\                               
\            match_output_regex: True
;}'
```
followed by fixing jagged indents.  Also got my workflow together:-)

On branch issue_179anew3
	modified:   hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
	modified:   hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
	modified:   hubblestack_nova_profiles/cis/debian-7.yaml
	modified:   hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/debian-9.yaml
	modified:   hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
	modified:   hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
	modified:   hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
	modified:   hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
	modified:   hubblestack_nova_profiles/cis/ubuntu-1204-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml