### PR TITLE
Fix \d (Issue #179)

### DIFF
--- a/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
@@ -702,7 +702,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveInterval"
-              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
@@ -702,7 +702,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveInterval"
-              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
@@ -478,7 +478,7 @@ grep:
       data:
         'Amazon Linux*':
         - /etc/ssh/sshd_config:
-            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
@@ -740,7 +740,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'
               pattern: "^ClientAliveInterval"
-              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-6.2.12'

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
@@ -797,7 +797,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13
               pattern: "^ClientAliveInterval"
-              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
@@ -289,7 +289,7 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
@@ -522,7 +522,7 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -523,7 +523,7 @@ grep:
       data:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
-            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13

--- a/hubblestack_nova_profiles/cis/debian-7.yaml
+++ b/hubblestack_nova_profiles/cis/debian-7.yaml
@@ -248,7 +248,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveInterval"
-              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'

--- a/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-8-level-1-scored-v1-0-0.yaml
@@ -269,7 +269,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveInterval"
-              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'

--- a/hubblestack_nova_profiles/cis/debian-9.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9.yaml
@@ -257,7 +257,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'
               pattern: "^ClientAliveInterval"
-              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: 'CIS-9.3.12'

--- a/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
@@ -308,7 +308,7 @@ grep:
       data:
         Red Hat Enterprise Linux Server-5:
         - /etc/ssh/sshd_config:
-            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
@@ -295,7 +295,7 @@ grep:
       data:
         Red Hat Enterprise Linux Server-6:
         - /etc/ssh/sshd_config:
-            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
@@ -797,7 +797,7 @@ grep:
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13
               pattern: "^ClientAliveInterval"
-              match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+              match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
               match_output_regex: True
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.13

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
@@ -289,7 +289,7 @@ grep:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-6.2.12

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -515,7 +515,7 @@ grep:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -508,7 +508,7 @@ grep:
       data:
         Red Hat Enterprise Linux Workstation-7:
         - /etc/ssh/sshd_config:
-            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
             match_output_regex: True
             pattern: ^ClientAliveInterval
             tag: CIS-5.2.13

--- a/hubblestack_nova_profiles/cis/ubuntu-1204-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1204-level-1-scored-v1-0-0.yaml
@@ -288,7 +288,7 @@ grep:
         Ubuntu-12.04:
         - /etc/ssh/sshd_config:
             pattern: ClientAliveInterval
-            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
             match_output_regex: True
             tag: CIS-9.3.12
         - /etc/ssh/sshd_config:

--- a/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1404-level-1-scored-v1-0-0.yaml
@@ -311,7 +311,7 @@ grep:
         Ubuntu-14.04:
         - /etc/ssh/sshd_config:
             pattern: ClientAliveInterval
-            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
             match_output_regex: True
             tag: CIS-9.3.12
         - /etc/ssh/sshd_config:

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
@@ -288,7 +288,7 @@ grep:
         Ubuntu-16.04:
         - /etc/ssh/sshd_config:
             pattern: ClientAliveInterval
-            match_output: ^ClientAliveInterval +([1-2]{0,1}d{1,2}|300)$
+            match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
             match_output_regex: True
             tag: CIS-9.3.12
         - /etc/ssh/sshd_config:


### PR DESCRIPTION
@mew1033 is right.  My sed sub got reverted when I rearranged order to cope for 'match_output: 0'.  Fix now.
```
fgrep -l ClientAliveInterval *.yaml |xargs sed -i~ 's/match_output: ^ClientAliveInterval.*/match_output: ^ClientAliveInterval +([1-2]{0,1}\\d{1,2}|300)$/'
```
On branch issue_179anew3
	modified:   amazon-201409-level-1-scored-v1-0-0.yaml
	modified:   amazon-level-1-scored-v1-0-0.yaml
	modified:   amazon-level-1-scored-v2-0-0.yaml
	modified:   centos-6-level-1-scored-v1-0-0.yaml
	modified:   centos-6-level-1-scored-v2-0-1.yaml
	modified:   centos-7-level-1-scored-v1-0-0.yaml
	modified:   centos-7-level-1-scored-v2-0-0.yaml
	modified:   centos-7-level-1-scored-v2-1-0.yaml
	modified:   debian-7.yaml
	modified:   debian-8-level-1-scored-v1-0-0.yaml
	modified:   debian-9.yaml
	modified:   rhels-5-level-1-scored-v2-2-0.yaml
	modified:   rhels-6-level-1-scored-v1-0-0.yaml
	modified:   rhels-6-level-1-scored-v2-0-1.yaml
	modified:   rhels-7-level-1-scored-v1-0-0.yaml
	modified:   rhels-7-level-1-scored-v2-1-0.yaml
	modified:   rhelw-7-level-1-scored-v2-1-0.yaml
	modified:   ubuntu-1204-level-1-scored-v1-0-0.yaml
	modified:   ubuntu-1404-level-1-scored-v1-0-0.yaml
	modified:   ubuntu-1604-level-1-scored-v1-0-0.yaml