### PR TITLE
Issue #188: Use regex for sshd_gracetime (and related fixes)

### DIFF
--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
@@ -493,7 +493,8 @@ grep:
         'Amazon Linux*':
         - /etc/ssh/sshd_config:
             pattern: ^LoginGraceTime
-            match_output: '60'
+            match_output: ^LoginGraceTime ([0-5]{0,1}\d|60|1m)$
+            match_output_regex: True
             tag: CIS-5.2.14
       description: Ensure SSH LoginGraceTime is set to one minute or less
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
@@ -806,13 +806,14 @@ grep:
               match_output_regex: True
       description: Ensure SSH Idle Timeout Interval is configured
 
-    sshd_login_grace:
+    sshd_gracetime:
       data:
         'CentOS-6':
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.14
-              pattern: "LoginGraceTime"
-              match_output: "LoginGraceTime 60"
+              pattern: ^LoginGraceTime
+              match_output: ^LoginGraceTime ([0-5]{0,1}\d|60|1m)$
+              match_output_regex: True
       description: Ensure SSH LoginGraceTime is set to one minute or less
 
     sshd_limit_access:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
@@ -537,7 +537,8 @@ grep:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
             pattern: ^LoginGraceTime
-            match_output: '60'
+            match_output: ^LoginGraceTime ([0-5]{0,1}\d|60|1m)$
+            match_output_regex: True
             tag: CIS-5.2.14
       description: Ensure SSH LoginGraceTime is set to one minute or less
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -538,7 +538,8 @@ grep:
         CentOS Linux-7:
         - /etc/ssh/sshd_config:
             pattern: ^LoginGraceTime
-            match_output: '60'
+            match_output: ^LoginGraceTime ([0-5]{0,1}\d|60|1m)$
+            match_output_regex: True
             tag: CIS-5.2.14
       description: Ensure SSH LoginGraceTime is set to one minute or less
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/coreos-level-1.yaml
+++ b/hubblestack_nova_profiles/cis/coreos-level-1.yaml
@@ -125,7 +125,8 @@ grep:
         '*CoreOS*':
         - /etc/ssh/sshd_config:
             pattern: ^LoginGraceTime
-            match_output: '60'
+            match_output: ^LoginGraceTime ([0-5]{0,1}\d|60|1m)$
+            match_output_regex: True
             tag: CIS-5.2.14
       description: Ensure SSH LoginGraceTime is set to one minute or less
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
@@ -806,13 +806,14 @@ grep:
               match_output_regex: True
       description: Ensure SSH Idle Timeout Interval is configured
 
-    sshd_login_grace:
+    sshd_gracetime:
       data:
         'Red Hat Enterprise Linux Server-6':
           - '/etc/ssh/sshd_config':
               tag: CIS-5.2.14
-              pattern: "LoginGraceTime"
-              match_output: "LoginGraceTime 60"
+              pattern: ^LoginGraceTime
+              match_output: ^LoginGraceTime ([0-5]{0,1}\d|60|1m)$
+              match_output_regex: True
       description: Ensure SSH LoginGraceTime is set to one minute or less
 
     sshd_limit_access:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -530,7 +530,8 @@ grep:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
             pattern: ^LoginGraceTime
-            match_output: '60'
+            match_output: ^LoginGraceTime ([0-5]{0,1}\d|60|1m)$
+            match_output_regex: True
             tag: CIS-5.2.14
       description: Ensure SSH LoginGraceTime is set to one minute or less
     sshd_ignore_rhosts:

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -523,7 +523,8 @@ grep:
         Red Hat Enterprise Linux Workstation-7:
         - /etc/ssh/sshd_config:
             pattern: ^LoginGraceTime
-            match_output: '60'
+            match_output: ^LoginGraceTime ([0-5]{0,1}\d|60|1m)$
+            match_output_regex: True
             tag: CIS-5.2.14
       description: Ensure SSH LoginGraceTime is set to one minute or less
     sshd_ignore_rhosts:


### PR DESCRIPTION
Also fixed two related problems.

- Some profiles used sshd_login_grace as label; I go with majority, sshd_gracetime.
- Some profiles also did not anchor `pattern`; when combined with literal `match_output`, this can lead to more possible negatives when valid range is placed in comments.

`
fgrep -l LoginGraceTime *.yaml
| xargs sed i~ 's/sshd_login_grace:/sshd_gracetime:/;/LoginGraceTime/,/description/{s/pattern: .*/pattern: ^LoginGraceTime/; s/match_output:.*/match_output: ^LoginGraceTime ([0-5]{0,1}\\d|60|1m)$/; /match_output:/a\
\            match_output_regex: True
; }'
`
followed by manually fixing jagged indents.

On branch sshd_gracetime
	modified:   hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
	modified:   hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
	modified:   hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
	modified:   hubblestack_nova_profiles/cis/coreos-level-1.yaml
	modified:   hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
	modified:   hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
	modified:   hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml