### PR TITLE
set value_type to account for CIS-2.2.5

### DIFF
--- a/hubblestack_nova_profiles/cis/windows-2012r2-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/windows-2012r2-level-1-scored-v2-0-0.yaml
@@ -98,7 +98,7 @@ win_secedit:
           - 'SeIncreaseQuotaPrivilege':
               tag: CIS-2.2.5
               match_output: 'Administrators, LOCAL SERVICE, NETWORK SERVICE'
-              value_type: 'match'
+              value_type: 'account'
       description: (l1) ensure 'adjust memory quotas for a process' is set to 'administrators, local service, network service'
     allow_logon_locally:
       data:


### PR DESCRIPTION
match is not a valid value_type