### PR TITLE
Add PCID check for meltdown/spectre

### DIFF
--- a/hubblestack_nova_profiles/security/meltdown_spectre.yaml
+++ b/hubblestack_nova_profiles/security/meltdown_spectre.yaml
@@ -9,4 +9,4 @@ grep:
               match_output: ' pcid'
               grep_args:
                 - '-i'
-      description: 'This checks the /proc/cpuinfo file for the pcid flag. Helpful for triaging Spectre and Meltdown.'
+      description: 'This checks the /proc/cpuinfo file for the pcid flag.'

--- a/hubblestack_nova_profiles/security/pcid.yaml
+++ b/hubblestack_nova_profiles/security/pcid.yaml
@@ -1,0 +1,12 @@
+grep:
+  whitelist:
+    check_cpuinfo_for_pcid:
+      data:
+        '*':
+          - '/proc/cpuinfo':
+              tag: 'Meltdown/Spectre'
+              pattern: 'flags'
+              match_output: ' pcid'
+              grep_args:
+                - '-i'
+      description: 'This checks the /proc/cpuinfo file for the pcid flag. Helpful for triaging Spectre and Meltdown.'

--- a/hubblestack_nova_profiles/top.nova
+++ b/hubblestack_nova_profiles/top.nova
@@ -44,7 +44,7 @@ nova:
   'G@osfinger:Amazon*Linux*2018*':
     - cis.amazon-level-1-scored-v1-0-0
   'G@kernel:Linux':
-    - security.pcid
+    - security.meltdown_spectre
   #'*':
   #  - misc
   #'G@kernel:Linux and not G@osfinger:*CoreOS*':

--- a/hubblestack_nova_profiles/top.nova
+++ b/hubblestack_nova_profiles/top.nova
@@ -43,8 +43,9 @@ nova:
     - cis.amazon-level-1-scored-v1-0-0
   'G@osfinger:Amazon*Linux*2018*':
     - cis.amazon-level-1-scored-v1-0-0
-  '*':
-     - security.pcid
+  'G@kernel:Linux':
+    - security.pcid
+  #'*':
   #  - misc
   #'G@kernel:Linux and not G@osfinger:*CoreOS*':
   #  - cve.scan-v2

--- a/hubblestack_nova_profiles/top.nova
+++ b/hubblestack_nova_profiles/top.nova
@@ -43,7 +43,8 @@ nova:
     - cis.amazon-level-1-scored-v1-0-0
   'G@osfinger:Amazon*Linux*2018*':
     - cis.amazon-level-1-scored-v1-0-0
-  #'*':
+  '*':
+     - security.pcid
   #  - misc
   #'G@kernel:Linux and not G@osfinger:*CoreOS*':
   #  - cve.scan-v2


### PR DESCRIPTION
This adds a new check to look for pcid support in /proc/cpuinfo. This information can help when triaging systems for Meltdown/Spectre.

This is modifying the top.nova file. I've tested it and it seems to work, but we should definitely have a few more eyes on this before merging.