### PR TITLE
Fix win_system_info query

### DIFF
--- a/hubblestack_nebula/hubblestack_nebula_win_queries.yaml
+++ b/hubblestack_nebula/hubblestack_nebula_win_queries.yaml
@@ -16,7 +16,7 @@ day:
   - query_name: win_uptime
     query: SELECT t.unix_time AS query_time, total_seconds AS uptime FROM uptime LEFT JOIN time AS t;
   - query_name: win_system_info
-    query: SELECT t.unix_time AS query_time, si.uuid, si.cpu_type, si.cpu_subtype, si.cpu_brand, si.cpu_physical_cores, si.cpu_logical_cores, si.hardware_vendor, si.hardware_serial, si.hardware_model, (SELECT value FROM cpuid WHERE feature = 'hypervisor') AS virtual_machine, pi.vendor AS bios_vendor, pi.version AS bios_version, pi.date AS bios_date, pi.revision AS bios_revision, t.local_timezone AS local_timezone FROM system_info AS si, platform_info AS pi, time AS t;
+    query: SELECT t.unix_time AS query_time, si.uuid, si.cpu_type, si.cpu_subtype, si.cpu_brand, si.cpu_physical_cores, si.cpu_logical_cores, si.hardware_vendor, si.hardware_serial, si.hardware_model, (SELECT value FROM cpuid WHERE feature = 'hypervisor') AS virtual_machine, t.local_timezone AS local_timezone FROM system_info AS si, time AS t;
   - query_name: win_programs
     query: SELECT t.unix_time AS query_time, p.* FROM programs AS p LEFT JOIN time AS t;
   - query_name: profile_version


### PR DESCRIPTION
@madchills This should fix the thing. Can you run this query on a win 2012 and 2008 box to make sure it works?

    SELECT t.unix_time AS query_time, si.uuid, si.cpu_type, si.cpu_subtype, si.cpu_brand, si.cpu_physical_cores, si.cpu_logical_cores, si.hardware_vendor, si.hardware_serial, si.hardware_model, (SELECT value FROM cpuid WHERE feature = 'hypervisor') AS virtual_machine, t.local_timezone AS local_timezone FROM system_info AS si, time AS t;

