### PR TITLE
add new audit for latest RHEL 7 level 1 scored v220

### DIFF
--- a/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
@@ -59,13 +59,13 @@ pkg:
     rsyslog:
       data:
         'Amazon Linux AMI-2014':
-          'rsyslog': 'CIS-5.1.1'
+          - 'rsyslog': 'CIS-5.1.1'
       description: 'Install rsyslog'
 
     anacron:
       data:
         'Amazon Linux AMI-2014':
-          'cronie-anacron': 'CIS-6.1.1'
+          - 'cronie-anacron': 'CIS-6.1.1'
       description: 'Enable anacron Daemon'
 
 

--- a/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
@@ -289,7 +289,7 @@ stat:
             user: 'root'
             uid: 0
             group: 'root'
-            uid: 0
+            gid: 0
     description: '/etc/passwd must be owned by root'
 
   shadow_perm:

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
@@ -289,7 +289,7 @@ stat:
             user: 'root'
             uid: 0
             group: 'root'
-            uid: 0
+            gid: 0
     description: '/etc/passwd must be owned by root'
 
   shadow_perm:

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
@@ -59,13 +59,13 @@ pkg:
     rsyslog:
       data:
         'Amazon Linux*':
-          'rsyslog': 'CIS-5.1.1'
+          - 'rsyslog': 'CIS-5.1.1'
       description: 'Install rsyslog'
 
     anacron:
       data:
         'Amazon Linux*':
-          'cronie-anacron': 'CIS-6.1.1'
+          - 'cronie-anacron': 'CIS-6.1.1'
       description: 'Enable anacron Daemon'
 
 

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
@@ -695,9 +695,6 @@ pkg:
         'Amazon Linux*':
         - aide: CIS-1.3.1
       description: Ensure AIDE is installed
-    firewalld:
-      data: {}
-      description: Enable firewalld
     tcp_wrappers:
       data:
         'Amazon Linux*':

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
@@ -320,7 +320,7 @@ stat:
             user: 'root'
             uid: 0
             group: 'root'
-            uid: 0
+            gid: 0
     description: 'Verify User/Group Ownership on /etc/passwd'
 
   shadow_perm:

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
@@ -279,7 +279,7 @@ stat:
             user: 'root'
             uid: 0
             group: 'root'
-            uid: 0
+            gid: 0
     description: Ensure permissions on /etc/passwd- are configured
 
   shadow_perm:
@@ -894,7 +894,7 @@ grep:
               pattern: "^umask 077"
       description: Ensure default user umask is 027 or more restrictive
 
- 
+
 service:
   whitelist:
     rsyslogd_running:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
@@ -204,9 +204,6 @@ grep:
             pattern: wheel
             tag: CIS-6.5
       description: Restrict Access to the su Command
-    pam_cracklib_try_first_pass:
-      data: {}
-      description: PAM cracklib policy
     passwd_change_min_days:
       data:
         CentOS Linux-7:
@@ -450,9 +447,6 @@ pkg:
         CentOS Linux-7:
         - firewalld: CIS-4.7
       description: Enable firewalld
-    iptables:
-      data: {}
-      description: Install IPtables
     rsyslog:
       data:
         CentOS Linux-7:
@@ -710,9 +704,6 @@ sysctl:
           match_output: '1'
           tag: CIS-4.2.6
     description: Enable Bad Error Message Protection
-  exec_shield:
-    data: {}
-    description: Configure ExecShield
   icmp_redirect_acceptance:
     data:
       CentOS Linux-7:
@@ -754,9 +745,6 @@ sysctl:
           match_output: '2'
           tag: CIS-1.6.2
     description: Enable Randomized Virtual Memory Region Placement
-  restrict_suid_core_dumps:
-    data: {}
-    description: Restrict SUID Core Dumps
   send_packet_redirect:
     data:
       CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
@@ -731,9 +731,6 @@ pkg:
         CentOS Linux-7:
         - aide: CIS-1.3.1
       description: Ensure AIDE is installed
-    firewalld:
-      data: {}
-      description: Enable firewalld
     tcp_wrappers:
       data:
         CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -664,7 +664,7 @@ pkg:
         CentOS Linux-7:
         - ypserv: CIS-2.2.16
       description: Ensure NIS Server is not enabled
-    rsh:
+    rsh-server:
       data:
         CentOS Linux-7:
         - rsh-server: CIS-2.2.17

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -472,13 +472,6 @@ grep:
             pattern: hard core
             tag: CIS-1.5.1
       description: Ensure core dumps are restricted
-    rsyslog_remote_logging:
-      data:
-        CentOS Linux-7:
-        - /etc/rsyslog.conf:
-            pattern: ^*.*[^I][^I]*@
-            tag: CIS-4.2.1.4
-      description: Ensure rsyslog is configured to send logs to a remote log host
     sshd_approved_cipher:
       data:
         CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-1.yaml
@@ -463,13 +463,6 @@ grep:
             pattern: hard core
             tag: CIS-1.5.1
       description: Ensure core dumps are restricted
-    rsyslog_remote_logging:
-      data:
-        CentOS Linux-7:
-        - /etc/rsyslog.conf:
-            pattern: ^*.*[^I][^I]*@
-            tag: CIS-4.2.1.4
-      description: Ensure rsyslog is configured to send logs to a remote log host
     sshd_approved_cipher:
       data:
         CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/debian-7.yaml
+++ b/hubblestack_nova_profiles/cis/debian-7.yaml
@@ -566,7 +566,7 @@ sysctl:
             match_output: '0'
     description: Disable ICMP Redirect Acceptance
 
-  icmp_redirect_acceptance:
+  icmp_secure_redirect_acceptance:
     data:
       Debian*7:
         - 'net.ipv4.conf.all.secure_redirects':

--- a/hubblestack_nova_profiles/cis/debian-9.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9.yaml
@@ -566,7 +566,7 @@ sysctl:
             match_output: '0'
     description: Disable ICMP Redirect Acceptance
 
-  icmp_redirect_acceptance:
+  icmp_secure_redirect_acceptance:
     data:
       Debian*9:
         - 'net.ipv4.conf.all.secure_redirects':

--- a/hubblestack_nova_profiles/cis/distribution-independent-linux-level-1-all-v1-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/distribution-independent-linux-level-1-all-v1-1-0.yaml
@@ -455,13 +455,6 @@ grep:
             pattern: hard core
             tag: CIS-1.5.1
       description: Ensure core dumps are restricted
-    rsyslog_remote_logging:
-      data:
-        '*':
-        - /etc/rsyslog.conf:
-            pattern: ^*.*[^I][^I]*@
-            tag: CIS-4.2.1.4
-      description: Ensure rsyslog is configured to send logs to a remote log host
     sshd_banner:
       data:
         '*':

--- a/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
@@ -473,9 +473,6 @@ pkg:
         Red Hat Enterprise Linux Server-5:
         - cronie-anacron: CIS-6.1.1
       description: Enable anacron Daemon
-    firewalld:
-      data: {}
-      description: Enable firewalld (Scored)
     rsyslog:
       data:
         Red Hat Enterprise Linux Server-5:

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
@@ -441,9 +441,6 @@ pkg:
         Red Hat Enterprise Linux Server-6:
         - cronie-anacron: CIS-6.1.1
       description: Enable anacron Daemon (Scored)
-    firewalld:
-      data: {}
-      description: Enable firewalld (Scored)
     iptables:
       data:
         Red Hat Enterprise Linux Server-6:

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
@@ -279,7 +279,7 @@ stat:
             user: 'root'
             uid: 0
             group: 'root'
-            uid: 0
+            gid: 0
     description: Ensure permissions on /etc/passwd- are configured
 
   shadow_perm:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
@@ -204,9 +204,6 @@ grep:
             pattern: wheel
             tag: CIS-6.5
       description: Restrict Access to the su Command
-    pam_cracklib_try_first_pass:
-      data: {}
-      description: PAM cracklib policy
     passwd_change_min_days:
       data:
         Red Hat Enterprise Linux Server-7:
@@ -450,9 +447,6 @@ pkg:
         Red Hat Enterprise Linux Server-7:
         - firewalld: CIS-4.7
       description: Enable firewalld
-    iptables:
-      data: {}
-      description: Install IPtables
     rsyslog:
       data:
         Red Hat Enterprise Linux Server-7:
@@ -710,9 +704,6 @@ sysctl:
           match_output: '1'
           tag: CIS-4.2.6
     description: Enable Bad Error Message Protection
-  exec_shield:
-    data: {}
-    description: Configure ExecShield
   icmp_redirect_acceptance:
     data:
       Red Hat Enterprise Linux Server-7:
@@ -754,9 +745,6 @@ sysctl:
           match_output: '2'
           tag: CIS-1.6.2
     description: Enable Randomized Virtual Memory Region Placement
-  restrict_suid_core_dumps:
-    data: {}
-    description: Restrict SUID Core Dumps
   send_packet_redirect:
     data:
       Red Hat Enterprise Linux Server-7:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -658,7 +658,7 @@ pkg:
         Red Hat Enterprise Linux Server-7:
         - ypserv: CIS-2.2.16
       description: Ensure NIS Server is not enabled
-    rsh:
+    rsh-server:
       data:
         Red Hat Enterprise Linux Server-7:
         - rsh-server: CIS-2.2.17
@@ -1261,7 +1261,7 @@ misc:
     data:
       Red Hat Enterprise Linux Server-7:
         tag: CIS-6.2.8
-        function: check_users_home_directory_permissions 
+        function: check_users_home_directory_permissions
     description: Ensure users home directories permissions are 750 or more restrictive
   user_own_home_directory:
     data:
@@ -1311,7 +1311,7 @@ misc:
     data:
       Red Hat Enterprise Linux Server-7:
         tag: CIS-6.2.16
-        function: check_duplicate_uids 
+        function: check_duplicate_uids
     description: Ensure no duplicate UIDs exist
   no_duplicate_gid:
     data:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-2-0.yaml
@@ -3,32 +3,9 @@
 #       organization's specific policy.  Search for '# NOTE: ' comments through the file.
 
 # TODO: Checks that aren't implemented yet:
-#       1.7.2
-#       3.6.5
 
 grep:
   blacklist:
-    legacy_passwd_entries_group:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - /etc/group:
-            pattern: '^+:'
-            tag: CIS-6.2.4
-      description: Ensure no legacy "+" entries exist in /etc/group
-    legacy_passwd_entries_passwd:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - /etc/passwd:
-            pattern: '^+:'
-            tag: CIS-6.2.2
-      description: Ensure no legacy "+" entries exist in /etc/passwd
-    legacy_passwd_entries_shadow:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - /etc/shadow:
-            pattern: '^+:'
-            tag: CIS-6.2.3
-      description: Ensure no legacy "+" entries exist in /etc/shadow
     disable_mount_cramfs:
       data:
         Red Hat Enterprise Linux Server-7:
@@ -85,6 +62,27 @@ grep:
             pattern: "^vfat "
             tag: CIS-1.1.1.8
       description: Ensure mounting of FAT filesystems is disabled
+    legacy_passwd_entries_group:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/group:
+            pattern: '^+:'
+            tag: CIS-6.2.4
+      description: Ensure no legacy "+" entries exist in /etc/group
+    legacy_passwd_entries_passwd:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/passwd:
+            pattern: '^+:'
+            tag: CIS-6.2.2
+      description: Ensure no legacy "+" entries exist in /etc/passwd
+    legacy_passwd_entries_shadow:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/shadow:
+            pattern: '^+:'
+            tag: CIS-6.2.3
+      description: Ensure no legacy "+" entries exist in /etc/shadow
     chargen_disabled:
       data:
         Red Hat Enterprise Linux Server-7:
@@ -92,10 +90,12 @@ grep:
             pattern: disable
             match_output: 'no'
             tag: CIS-2.1.1
+            match_on_file_missing: False
         - /etc/xinetd.d/chargen-stream:
             pattern: disable
             match_output: 'no'
             tag: CIS-2.1.1
+            match_on_file_missing: False
       description: Ensure chargen services are not enabled
     daytime_disabled:
       data:
@@ -104,10 +104,12 @@ grep:
             pattern: disable
             match_output: 'no'
             tag: CIS-2.1.2
+            match_on_file_missing: False
         - /etc/xinetd.d/daytime-stream:
             pattern: disable
             match_output: 'no'
             tag: CIS-2.1.2
+            match_on_file_missing: False
       description: Ensure daytime services are not enabled
     discard_disabled:
       data:
@@ -116,10 +118,12 @@ grep:
             pattern: disable
             match_output: 'no'
             tag: CIS-2.1.3
+            match_on_file_missing: False
         - /etc/xinetd.d/discard-stream:
             pattern: disable
             match_output: 'no'
             tag: CIS-2.1.3
+            match_on_file_missing: False
       description: Ensure discard services are not enabled
     echo_disabled:
       data:
@@ -128,10 +132,12 @@ grep:
             pattern: disable
             match_output: 'no'
             tag: CIS-2.1.4
+            match_on_file_missing: False
         - /etc/xinetd.d/echo-stream:
             pattern: disable
             match_output: 'no'
             tag: CIS-2.1.4
+            match_on_file_missing: False
       description: Ensure echo services are not enabled
     time_disabled:
       data:
@@ -140,10 +146,12 @@ grep:
             pattern: disable
             match_output: 'no'
             tag: CIS-2.1.5
+            match_on_file_missing: False
         - /etc/xinetd.d/time-stream:
             pattern: disable
             match_output: 'no'
             tag: CIS-2.1.5
+            match_on_file_missing: False
       description: Ensure time services are not enabled
     banner_os_info_motd:
       data:
@@ -155,6 +163,14 @@ grep:
             tag: CIS-1.7.1.1
       description: Ensure message of the day is configured properly
   whitelist:
+    single_user_mode_check:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/sysconfig/init:
+            match_output: SINGLE=/sbin/sulogin
+            pattern: ^SINGLE
+            tag: CIS-1.4.3
+      description: Ensure authentication required for single user mode
     activate_gpg_check:
       data:
         Red Hat Enterprise Linux Server-7:
@@ -170,8 +186,10 @@ grep:
     aide_filesystem_scans:
       data:
         Red Hat Enterprise Linux Server-7:
-        - /var/spool/cron/root:
-            pattern: 'aide'
+        - /etc/cron.d:
+            pattern: aide
+            grep_args:
+              - '-r'
             tag: CIS-1.3.2
       description: Ensure filesystem integrity is regularly checked
     boot_loader_passwd:
@@ -208,14 +226,6 @@ grep:
             tag: CIS-2.2.1.3
             pattern: 'chrony'
       description: Ensure chrony is configured
-    local_mail:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - /etc/postfix/main.cf:
-            pattern: ^inet_interfaces
-            match_output: localhost
-            tag: CIS-2.2.15
-      description: Ensure mail transfer agent is configured for local-only mode
     default_umask:
       data:
         Red Hat Enterprise Linux Server-7:
@@ -487,24 +497,22 @@ grep:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
             pattern: ^Banner
-            tag: CIS-5.2.16
+            tag: CIS-5.2.15
       description: Ensure SSH warning banner is configured
     sshd_disable_root_login:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            pattern: '"^PermitRootLogin\s+no"'
-            grep_args:
-              - '-E'
+            match_output: PermitRootLogin no
+            pattern: ^PermitRootLogin
             tag: CIS-5.2.8
       description: Ensure SSH root login is disabled
     sshd_hostbased_auth:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            pattern: '"^HostbasedAuthentication\s+no"'
-            grep_args:
-              - '-E'
+            match_output: HostbasedAuthentication no
+            pattern: ^HostbasedAuthentication
             tag: CIS-5.2.7
       description: Ensure SSH HostbasedAuthentication is disabled
     sshd_idle_timeout:
@@ -514,12 +522,12 @@ grep:
             match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
             match_output_regex: True
             pattern: ^ClientAliveInterval
-            tag: CIS-5.2.13
+            tag: CIS-5.2.12
         - /etc/ssh/sshd_config:
             match_output: "^ClientAliveCountMax +[0-3]$"
             match_output_regex: True
             pattern: ^ClientAliveCountMax
-            tag: CIS-5.2.13
+            tag: CIS-5.2.12
       description: Ensure SSH Idle Timeout Interval is configured
     sshd_gracetime:
       data:
@@ -528,33 +536,38 @@ grep:
             pattern: ^LoginGraceTime
             match_output: ^LoginGraceTime ([0-5]{0,1}\d|60|1m)$
             match_output_regex: True
-            tag: CIS-5.2.14
+            tag: CIS-5.2.13
       description: Ensure SSH LoginGraceTime is set to one minute or less
     sshd_ignore_rhosts:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            pattern: '"^IgnoreRhosts\s+yes"'
-            grep_args:
-              - '-E'
+            match_output: IgnoreRhosts yes
+            pattern: ^IgnoreRhosts
             tag: CIS-5.2.6
       description: Ensure SSH IgnoreRhosts is enabled
     sshd_limit_access:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            pattern: '^AllowUsers|^AllowGroups|^DenyUsers|^DenyGroups'
-            grep_args:
-              - '-E'
-            tag: CIS-5.2.15
+            pattern: ^AllowUsers
+            tag: CIS-5.2.14
+        - /etc/ssh/sshd_config:
+            pattern: ^AllowGroups
+            tag: CIS-5.2.14
+        - /etc/ssh/sshd_config:
+            pattern: ^DenyUsers
+            tag: CIS-5.2.14
+        - /etc/ssh/sshd_config:
+            pattern: ^DenyGroups
+            tag: CIS-5.2.14
       description: Ensure SSH access is limited
     sshd_loglevel_info:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            pattern: '"^LogLevel\s+INFO"'
-            grep_args:
-              - '-E'
+            match_output: LogLevel INFO
+            pattern: ^LogLevel
             tag: CIS-5.2.3
       description: Ensure SSH LogLevel is set to INFO
     sshd_max_auth_retries:
@@ -570,36 +583,32 @@ grep:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            pattern: '"^PermitEmptyPasswords\s+no"'
-            grep_args:
-              - '-E'
+            match_output: PermitEmptyPasswords no
+            pattern: ^PermitEmptyPasswords
             tag: CIS-5.2.9
       description: Ensure SSH PermitEmptyPasswords is disabled
     sshd_permit_user_environment:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            pattern: '"^PermitUserEnvironment\s+no"'
-            grep_args:
-              - '-E'
+            match_output: PermitUserEnvironment no
+            pattern: ^PermitUserEnvironment
             tag: CIS-5.2.10
       description: Ensure SSH PermitUserEnvironment is disabled
     sshd_protocol_2:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            pattern: '"^Protocol\s+2"'
-            grep_args:
-              - '-E'
+            match_output: Protocol 2
+            pattern: ^Protocol
             tag: CIS-5.2.2
       description: Ensure SSH Protocol is set to 2
     sshd_x11_forwarding:
       data:
         Red Hat Enterprise Linux Server-7:
         - /etc/ssh/sshd_config:
-            pattern: '"^X11Forwarding\s+no"'
-            grep_args:
-              - '-E'
+            match_output: X11Forwarding no
+            pattern: ^X11Forwarding
             tag: CIS-5.2.4
       description: Ensure SSH X11 forwarding is disabled
     lockout_account:
@@ -618,91 +627,198 @@ grep:
               - '-E'
             tag: CIS-5.3.2
       description: Ensure lockout for failed password attempts is configured
+systemctl:
+  whitelist:
+    rsyslog_enabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - rsyslog:
+           tag: CIS-4.2.1.1
+      description: Ensure rsyslog Service is enabled
+    cron_deamon_enabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - crond:
+           tag: CIS-5.1.1
+      description: Ensure cron daemon is enabled
+  blacklist:
+    xinetd:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - xinetd:
+            tag: CIS-2.1.7
+      description: Ensure xinetd is not enabled
+    avahi-daemon-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - avahi-daemon:
+            tag: CIS-2.2.3
+      description: Ensure Avahi Server is not enabled
+    cups-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - cups:
+            tag: CIS-2.2.4
+      description: Ensure CUPS is not enabled
+    dhcpd-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - dhcpd:
+            tag: CIS-2.2.5
+      description: Ensure DHCP Server is not enabled
+    ldap-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - slapd:
+            tag: CIS-2.2.6
+      description: Ensure LDAP server is not enabled
+    nfs-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - nfs:
+            tag: CIS-2.2.7
+      description: Ensure NFS and RPC are not enabled
+    rpc-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - rpcbind:
+            tag: CIS-2.2.7
+      description: Ensure NFS and RPC are not enabled
+    dns-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - named:
+            tag: CIS-2.2.8
+      description: Ensure DNS Server is not enabled
+    vsftpd-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - vsftpd:
+            tag: CIS-2.2.9
+      description: Ensure FTP Server is not enabled
+    proftpd-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - proftpd:
+            tag: CIS-2.2.9
+      description: Ensure FTP Server is not enabled
+    pure-ftpd-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - pure-ftpd:
+            tag: CIS-2.2.9
+      description: Ensure FTP Server is not enabled
+    perl-ftpd-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - perl-ftpd:
+            tag: CIS-2.2.9
+      description: Ensure FTP Server is not enabled
+    http-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - httpd:
+            tag: CIS-2.2.10
+      description: Ensure HTTP server is not enabled
+    imap-pop3-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - dovecot:
+            tag: CIS-2.2.11
+      description: Ensure IMAP and POP3 server is not enabled
+    samba-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - smb:
+            tag: CIS-2.2.12
+      description: Ensure Samba is not enabled
+    http-proxy-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - squid:
+            tag: CIS-2.2.13
+      description: Ensure HTTP Proxy Server is not enabled
+    snmp-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - snmpd:
+            tag: CIS-2.2.14
+      description: Ensure SNMP Server is not enabled
+    nis-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - ypserv:
+            tag: CIS-2.2.16
+      description: Ensure NIS Server is not enabled
+    rsh-socket-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - rsh.socket:
+            tag: CIS-2.2.17
+      description: Ensure rsh Server is not enabled
+    rlogin-socket-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - rlogin.socket:
+            tag: CIS-2.2.17
+      description: Ensure rsh Server is not enabled
+    rexec-socket-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - rexec.socket:
+            tag: CIS-2.2.17
+      description: Ensure rsh Server is not enabled
+    talk-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - ntalk:
+            tag: CIS-2.2.18
+      description: Ensure talk server is not enabled
+    telnet-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - telnet.socket:
+            tag: CIS-2.2.19
+      description: Ensure telnet server is not enabled
+    tftp-server-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - tftp.socket:
+            tag: CIS-2.2.20
+      description: Ensure tftp server is not enabled
+    rsync-service-disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - rsyncd:
+            tag: CIS-2.2.21
+      description: Ensure rsync service is not enabled
 pkg:
   blacklist:
-    avahi-daemon:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - avahi: CIS-2.2.3
-      description: Ensure Avahi Server is not enabled
-    cups:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - cups: CIS-2.2.4
-      description: Ensure CUPS is not enabled
-    dhcp:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - dhcp: CIS-2.2.5
-      description: Ensure DHCP Server is not enabled
-    slapd:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - openldap-servers: CIS-2.2.6
-      description: Ensure LDAP server is not enabled
-    ftp:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - perl-ftpd: CIS-2.2.9
-        - proftpd: CIS-2.2.9
-        - pure-ftpd: CIS-2.2.9
-        - vsftpd: CIS-2.2.9
-      description: Ensure FTP Server is not enabled
-    nis-client:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - ypbind: CIS-2.3.1
-      description: Ensure NIS Client is not installed
-    nis-server:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - ypserv: CIS-2.2.16
-      description: Ensure NIS Server is not enabled
-    rsh-server:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - rsh-server: CIS-2.2.17
-      description: Ensure rsh server is not enabled
-    rsh:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - rsh: CIS-2.3.2
-      description: Ensure rsh client is not installed
     tftp-server2:
       data:
         Red Hat Enterprise Linux Server-7:
         - tftp-server: CIS-2.1.6
       description: Ensure tftp server is not enabled
+    nis-client:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - ypbind: CIS-2.3.1
+      description: Ensure NIS Client is not installed
+    rsh:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - rsh: CIS-2.3.2
+      description: Ensure rsh client is not installed
     talk-client:
       data:
         Red Hat Enterprise Linux Server-7:
         - talk: CIS-2.3.3
       description: Ensure talk client is not installed
-    talk-server:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - talk-server: CIS-2.2.18
-      description: Ensure talk server is not enabled
     telnet-client:
       data:
         Red Hat Enterprise Linux Server-7:
         - telnet: CIS-2.3.4
       description: Ensure telnet client is not installed
-    telnet-server:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - telnet-server: CIS-2.2.19
-      description: Ensure telnet server is not enabled
-    tftp-server:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - tftp-server: CIS-2.2.20
-      description: Ensure tftp server is not enabled
-    xinetd:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - xinetd: CIS-2.1.7
-      description: Ensure xinetd is not enabled
     xorg-x11-server-common:
       data:
         Red Hat Enterprise Linux Server-7:
@@ -741,67 +857,12 @@ service:
         Red Hat Enterprise Linux Server-7:
         - autofs: CIS-1.1.22
       description: Disable Automounting
-    rsync:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - rsyncd: CIS-2.2.21
-      description: Ensure rsync service is not enabled
-    nfs:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - nfs: CIS-2.2.7
-      description: Ensure NFS and RPC are not enabled
-    rpc:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - rpcbind: CIS-2.2.7
-      description: Ensure NFS and RPC are not enabled
-    named:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - named: CIS-2.2.8
-      description: Ensure DNS Server is not enabled
-    httpd:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - httpd: CIS-2.2.10
-      description: Ensure HTTP server is not enabled
-    pop3_imap:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - dovecot: CIS-2.2.11
-      description: Ensure IMAP and POP3 server is not enabled
-    samba:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - smb: CIS-2.2.12
-      description: Ensure Samba is not enabled
-    http_proxy:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - squid: CIS-2.2.13
-      description: Ensure HTTP Proxy Server is not enabled
-    snmp:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - snmpd: CIS-2.2.14
-      description: Ensure SNMP Server is not enabled
   whitelist:
-    rsyslogd_running:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - rsyslog: CIS-4.2.1.1
-      description: Ensure rsyslog Service is enabled
     syslog-ng_running:
       data:
         Red Hat Enterprise Linux Server-7:
         - syslog-ng: CIS-4.2.2.1
       description: Ensure syslog-ng service is enabled
-    crond_running:
-      data:
-        Red Hat Enterprise Linux Server-7:
-        - crond: CIS-5.1.1
-      description: Ensure cron daemon is enabled
 stat:
   at_cron_allow:
     data:
@@ -909,6 +970,7 @@ stat:
     data:
       Red Hat Enterprise Linux Server-7:
       - /etc/passwd:
+          gid: 0
           group: root
           mode: 644
           tag: CIS-6.1.2
@@ -921,7 +983,7 @@ stat:
       - /etc/shadow:
           gid: 0
           group: root
-          mode: 000
+          mode: '000'
           tag: CIS-6.1.3
           uid: 0
           user: root
@@ -943,7 +1005,7 @@ stat:
       - /etc/gshadow:
           gid: 0
           group: root
-          mode: 000
+          mode: '000'
           tag: CIS-6.1.5
           uid: 0
           user: root
@@ -952,8 +1014,9 @@ stat:
     data:
       Red Hat Enterprise Linux Server-7:
       - /etc/passwd-:
+          gid: 0
           group: root
-          mode: 600
+          mode: 644
           tag: CIS-6.1.6
           uid: 0
           user: root
@@ -964,7 +1027,7 @@ stat:
       - /etc/shadow-:
           gid: 0
           group: root
-          mode: 600
+          mode: '000'
           tag: CIS-6.1.7
           uid: 0
           user: root
@@ -975,7 +1038,8 @@ stat:
       - /etc/group-:
           gid: 0
           group: root
-          mode: 600
+          allow_more_strict: true
+          mode: 644
           tag: CIS-6.1.8
           uid: 0
           user: root
@@ -986,7 +1050,7 @@ stat:
       - /etc/gshadow-:
           gid: 0
           group: root
-          mode: 0
+          mode: '000'
           tag: CIS-6.1.9
           uid: 0
           user: root
@@ -1009,7 +1073,6 @@ stat:
           gid: 0
           group: root
           mode: 644
-          allow_more_strict: true
           tag: CIS-3.4.4
           uid: 0
           user: root
@@ -1021,7 +1084,6 @@ stat:
           gid: 0
           group: root
           mode: 644
-          allow_more_strict: true
           tag: CIS-3.4.5
           uid: 0
           user: root
@@ -1032,8 +1094,7 @@ stat:
       - /etc/ssh/sshd_config:
           gid: 0
           group: root
-          mode: 644
-          allow_more_strict: true
+          mode: 600
           tag: CIS-5.2.1
           uid: 0
           user: root
@@ -1048,7 +1109,6 @@ stat:
           tag: CIS-1.7.1.5
           uid: 0
           user: root
-          allow_more_strict: true
     description: Ensure permissions on /etc/issue are configured
 sysctl:
   bad_error_message_protection:
@@ -1058,15 +1118,15 @@ sysctl:
           match_output: '1'
           tag: CIS-3.2.6
     description: Ensure bogus ICMP responses are ignored
-  rp_filter:
+  reverse_path_filtering:
     data:
       Red Hat Enterprise Linux Server-7:
-      - net.ipv4.conf.default.rp_filter:
-          match_output: '1'
-          tag: CIS-3.2.7
-      - net.ipv4.conf.all.rp_filter:
-          match_output: '1'
-          tag: CIS-3.2.7
+        - net.ipv4.conf.all.rp_filter:
+            match_output: '1'
+            tag: CIS-3.2.7
+        - net.ipv4.conf.default.rp_filter:
+            match_output: '1'
+            tag: CIS-3.2.7
     description: Ensure Reverse Path Filtering is enabled
   icmp_redirect_acceptance:
     data:
@@ -1174,6 +1234,12 @@ sysctl:
           tag: CIS-3.2.8
     description: Ensure TCP SYN Cookies is enabled
 misc:
+  mail_configured_for_local_only_mode:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-2.2.15
+        function: mail_conf_check
+    description: Ensure mail transfer agent is configured for local-only mode
   check_any_package:
     data:
       Red Hat Enterprise Linux Server-7:
@@ -1194,7 +1260,7 @@ misc:
   sshd_approved_macs:
     data:
       Red Hat Enterprise Linux Server-7:
-       tag: CIS-5.2.12
+       tag: CIS-5.2.11
        function: check_list_values
        args:
          - /etc/ssh/sshd_config
@@ -1208,7 +1274,7 @@ misc:
   sshd_approved_ciphers:
     data:
       Red Hat Enterprise Linux Server-7:
-       tag: CIS-5.2.11
+       tag: CIS-5.2.11.1
        function: check_list_values
        args:
          - /etc/ssh/sshd_config

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-2-0.yaml
@@ -1,0 +1,1333 @@
+# NOTE: This CIS Profile only includes Level 1 Scored Items for Red Hat Enterprise Linux Server 7
+# NOTE: Within this file, there are a few sections that should be tailored to your
+#       organization's specific policy.  Search for '# NOTE: ' comments through the file.
+
+# TODO: Checks that aren't implemented yet:
+#       1.7.2
+#       3.6.5
+
+grep:
+  blacklist:
+    legacy_passwd_entries_group:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/group:
+            pattern: '^+:'
+            tag: CIS-6.2.4
+      description: Ensure no legacy "+" entries exist in /etc/group
+    legacy_passwd_entries_passwd:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/passwd:
+            pattern: '^+:'
+            tag: CIS-6.2.2
+      description: Ensure no legacy "+" entries exist in /etc/passwd
+    legacy_passwd_entries_shadow:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/shadow:
+            pattern: '^+:'
+            tag: CIS-6.2.3
+      description: Ensure no legacy "+" entries exist in /etc/shadow
+    disable_mount_cramfs:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^cramfs "
+            tag: CIS-1.1.1.1
+      description: Ensure mounting of cramfs filesystems is disabled
+    disable_mount_freevxfs:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^freevxfs "
+            tag: CIS-1.1.1.2
+      description: Ensure mounting of freevxfs filesystems is disabled
+    disable_mount_jffs2:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^jffs2 "
+            tag: CIS-1.1.1.3
+      description: Ensure mounting of jffs2 filesystems is disabled
+    disable_mount_hfs:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^hfs "
+            tag: CIS-1.1.1.4
+      description: Ensure mounting of hfs filesystems is disabled
+    disable_mount_hfsplus:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^hfsplus "
+            tag: CIS-1.1.1.5
+      description: Ensure mounting of hfsplus filesystems is disabled
+    disable_mount_squashfs:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^squashfs "
+            tag: CIS-1.1.1.6
+      description: Ensure mounting of squashfs filesystems is disabled
+    disable_mount_udf:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^udf "
+            tag: CIS-1.1.1.7
+      description: Ensure mounting of udf filesystems is disabled
+    disable_mount_fat:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/modules:
+            pattern: "^vfat "
+            tag: CIS-1.1.1.8
+      description: Ensure mounting of FAT filesystems is disabled
+    chargen_disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/xinetd.d/chargen-dgram:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.1
+        - /etc/xinetd.d/chargen-stream:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.1
+      description: Ensure chargen services are not enabled
+    daytime_disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/xinetd.d/daytime-dgram:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.2
+        - /etc/xinetd.d/daytime-stream:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.2
+      description: Ensure daytime services are not enabled
+    discard_disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/xinetd.d/discard-dgram:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.3
+        - /etc/xinetd.d/discard-stream:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.3
+      description: Ensure discard services are not enabled
+    echo_disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/xinetd.d/echo-dgram:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.4
+        - /etc/xinetd.d/echo-stream:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.4
+      description: Ensure echo services are not enabled
+    time_disabled:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/xinetd.d/time-dgram:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.5
+        - /etc/xinetd.d/time-stream:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.5
+      description: Ensure time services are not enabled
+    banner_os_info_motd:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/motd:
+            pattern: '"(\\\v|\\\r|\\\m|\\\s)"'
+            grep_args:
+              - '-E'
+            tag: CIS-1.7.1.1
+      description: Ensure message of the day is configured properly
+  whitelist:
+    activate_gpg_check:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/yum.conf:
+            pattern: '^\s*gpgcheck\s*=\s*1'
+            tag: CIS-1.2.2
+        - /etc/yum.repos.d:
+            pattern: '^\s*gpgcheck\s*=\s*1'
+            grep_args:
+              - '-r'
+            tag: CIS-1.2.2
+      description: Ensure gpgcheck is globally activated
+    aide_filesystem_scans:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /var/spool/cron/root:
+            pattern: 'aide'
+            tag: CIS-1.3.2
+      description: Ensure filesystem integrity is regularly checked
+    boot_loader_passwd:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /boot/grub2/grub.cfg:
+            pattern: password
+            tag: CIS-1.4.2
+      description: Ensure bootloader password is set
+    configure_ntp:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/ntp.conf:
+            pattern: ^restrict
+            match_output: default
+            tag: CIS-2.2.1.2
+        - /etc/ntp.conf:
+            pattern: restrict -6 default
+            tag: CIS-2.2.1.2
+        - /etc/ntp.conf:
+            tag: CIS-2.2.1.2
+            pattern: '^server'
+        - /etc/sysconfig/ntpd:
+            tag: CIS-2.2.1.2
+            pattern: 'ntp:ntp'
+      description: Ensure ntp is configured
+    configure_chrony:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/chrony.conf:
+            tag: CIS-2.2.1.3
+            pattern: '^server'
+        - /etc/sysconfig/chronyd:
+            tag: CIS-2.2.1.3
+            pattern: 'chrony'
+      description: Ensure chrony is configured
+    local_mail:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/postfix/main.cf:
+            pattern: ^inet_interfaces
+            match_output: localhost
+            tag: CIS-2.2.15
+      description: Ensure mail transfer agent is configured for local-only mode
+    default_umask:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/bashrc:
+            pattern: umask
+            match_pattern: '0[257]7'
+            grep_args:
+              - '-E'
+            tag: CIS-5.4.4
+        - /etc/profile.d:
+            pattern: umask
+            match_pattern: '0[257]7'
+            grep_args:
+              - '-r'
+              - '-E'
+            tag: CIS-5.4.4
+        - /etc/profile:
+            pattern: umask
+            match_pattern: '0[257]7'
+            grep_arge:
+              - '-E'
+            tag: CIS-5.4.4
+      description: Ensure default user umask is 027 or more restrictive
+    mounts_var_tmp_partition_nodev:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/mounts:
+            match_output: nodev
+            pattern: /var/tmp
+            tag: CIS-1.1.8
+      description: Ensure nodev option set on /var/tmp partition
+    mounts_var_tmp_partition_nosuid:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/mounts:
+            match_output: nosuid
+            pattern: /var/tmp
+            tag: CIS-1.1.9
+      description: Ensure nosuid option set on /var/tmp partition
+    mounts_var_tmp_partition_noexec:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/mounts:
+            match_output: noexec
+            pattern: /var/tmp
+            tag: CIS-1.1.10
+      description: Ensure noexec option set on /var/tmp partition
+    mounts_dev_shm_partition_nodev:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/mounts:
+            match_output: nodev
+            pattern: /dev/shm
+            tag: CIS-1.1.15
+      description: Ensure nodev option set on /dev/shm partition
+    mounts_dev_shm_partition_noexec:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/mounts:
+            match_output: noexec
+            pattern: /dev/shm
+            tag: CIS-1.1.17
+      description: Ensure noexec option set on /dev/shm partition
+    mounts_dev_shm_partition_nosuid:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/mounts:
+            match_output: nosuid
+            pattern: /dev/shm
+            tag: CIS-1.1.16
+      description: Ensure nosuid option set on /dev/shm partition
+    mounts_home_partition_nodev:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/mounts:
+            match_output: nodev
+            pattern: /home
+            tag: CIS-1.1.14
+      description: Ensure nodev option set on /home partition
+    mounts_tmp_partition_nodev:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/mounts:
+            match_output: nodev
+            pattern: /tmp
+            tag: CIS-1.1.3
+      description: Ensure nodev option set on /tmp partition
+    mounts_tmp_partition_noexec:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/mounts:
+            match_output: noexec
+            pattern: /tmp
+            tag: CIS-1.1.5
+      description: Ensure noexec option set on /tmp partition
+    mounts_tmp_partition_nosuid:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /proc/mounts:
+            match_output: nosuid
+            pattern: /tmp
+            tag: CIS-1.1.4
+      description: Ensure nosuid option set on /tmp partition
+    hosts_allow:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/hosts.allow:
+            pattern: ALL
+            tag: CIS-3.4.2
+      description: Ensure /etc/hosts.allow is configured
+    hosts_deny:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/hosts.deny:
+            pattern:  ALL
+            tag: CIS-3.4.3
+      description: Ensure /etc/hosts.deny is configured
+    firewall_default_deny:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/sysconfig/iptables:
+            pattern: :INPUT
+            match_output: DROP
+            tag: CIS-3.6.2
+        - /etc/sysconfig/iptables:
+            pattern: :FORWARD
+            match_pattern: DROP
+            tag: CIS-3.6.2
+        - /etc/sysconfig/iptables:
+            pattern: :OUTPUT
+            match_output: DROP
+            tag: CIS-3.6.2
+      description: Ensure default deny firewall policy
+    firewall_accept_lo:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/sysconfig/iptables:
+            pattern: lo
+            match_output: ACCEPT
+            tag: CIS-3.6.3
+      description: Ensure loopback traffic is configured
+    rsyslog_file_perms:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/rsyslog.conf:
+            pattern: '^\$FileCreateMode'
+            match_output: '0640'
+            tag: CIS-4.2.1.3
+      description: Ensure rsyslog default file permissions configured
+    syslog-ng_file_perms:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/syslog-ng/syslog-ng.conf:
+            pattern: ^options
+            match_output: 'perm(0640)'
+            tag: CIS-4.2.2.3
+      description: Ensure syslog-ng default file permissions configured
+    limit_password_reuse:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/pam.d/system-auth:
+            pattern: '"^password\s+sufficient\s+pam_unix\.so.*"'
+            match_output: remember=5
+            grep_args:
+              - '-E'
+            tag: CIS-5.3.3
+      description: Ensure password reuse is limited
+    password_hash:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/pam.d/password-auth:
+            pattern: '"^password\s+\w+\s+pam_unix\.so"'
+            match_output: sha512
+            grep_args:
+              - '-E'
+            tag: CIS-5.3.4
+      description: Ensure password hashing algorithm is SHA-512
+    limit_su_command_access:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/pam.d/su:
+            match_output: use_uid
+            pattern: pam_wheel.so
+            tag: CIS-5.6
+        - /etc/group:
+            pattern: wheel
+            tag: CIS-5.6
+      description: Ensure access to the su command is restricted
+    pam_pwquality_try_first_pass:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/pam.d/system-auth:
+            match_output: try_first_pass
+            pattern: pam_pwquality.so
+            tag: CIS-5.3.1
+        - /etc/pam.d/system-auth:
+            match_output: retry=3
+            pattern: pam_pwquality.so
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: minlen
+            match_output: '14'
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: dcredit
+            match_output: '-1'
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: ucredit
+            match_output: '-1'
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: ocredit
+            match_output: '-1'
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: lcredit
+            match_output: '-1'
+            tag: CIS-5.3.1
+      description: Ensure password creation requirements are configured
+    passwd_change_min_days:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/login.defs:
+            match_output: '7'
+            pattern: PASS_MIN_DAYS
+            tag: CIS-5.4.1.2
+      description: Ensure minimum days between password changes is 7 or more
+    passwd_expiration_days:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/login.defs:
+            match_output: '90'
+            pattern: PASS_MAX_DAYS
+            tag: CIS-5.4.1.1
+      description: Ensure password expiration is 90 days or less
+    passwd_expiry_warning:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/login.defs:
+            match_output: '7'
+            pattern: PASS_WARN_AGE
+            tag: CIS-5.4.1.3
+      description: Ensure password expiration warning days is 7 or more
+    passwd_inactive:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/default/useradd:
+            pattern: INACTIVE=30
+            tag: CIS-5.4.1.4
+      description: Ensure inactive password lock is 30 days or less
+    restrict_core_dumps:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/security/limits.conf:
+            match_output: '0'
+            pattern: hard core
+            tag: CIS-1.5.1
+      description: Ensure core dumps are restricted
+    rsyslog_remote_logging:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/rsyslog.conf:
+            pattern: ^*.*[^I][^I]*@
+            tag: CIS-4.2.1.4
+      description: Ensure rsyslog is configured to send logs to a remote log host
+    sshd_banner:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/ssh/sshd_config:
+            pattern: ^Banner
+            tag: CIS-5.2.16
+      description: Ensure SSH warning banner is configured
+    sshd_disable_root_login:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/ssh/sshd_config:
+            pattern: '"^PermitRootLogin\s+no"'
+            grep_args:
+              - '-E'
+            tag: CIS-5.2.8
+      description: Ensure SSH root login is disabled
+    sshd_hostbased_auth:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/ssh/sshd_config:
+            pattern: '"^HostbasedAuthentication\s+no"'
+            grep_args:
+              - '-E'
+            tag: CIS-5.2.7
+      description: Ensure SSH HostbasedAuthentication is disabled
+    sshd_idle_timeout:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/ssh/sshd_config:
+            match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
+            match_output_regex: True
+            pattern: ^ClientAliveInterval
+            tag: CIS-5.2.13
+        - /etc/ssh/sshd_config:
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
+            pattern: ^ClientAliveCountMax
+            tag: CIS-5.2.13
+      description: Ensure SSH Idle Timeout Interval is configured
+    sshd_gracetime:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/ssh/sshd_config:
+            pattern: ^LoginGraceTime
+            match_output: ^LoginGraceTime ([0-5]{0,1}\d|60|1m)$
+            match_output_regex: True
+            tag: CIS-5.2.14
+      description: Ensure SSH LoginGraceTime is set to one minute or less
+    sshd_ignore_rhosts:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/ssh/sshd_config:
+            pattern: '"^IgnoreRhosts\s+yes"'
+            grep_args:
+              - '-E'
+            tag: CIS-5.2.6
+      description: Ensure SSH IgnoreRhosts is enabled
+    sshd_limit_access:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/ssh/sshd_config:
+            pattern: '^AllowUsers|^AllowGroups|^DenyUsers|^DenyGroups'
+            grep_args:
+              - '-E'
+            tag: CIS-5.2.15
+      description: Ensure SSH access is limited
+    sshd_loglevel_info:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/ssh/sshd_config:
+            pattern: '"^LogLevel\s+INFO"'
+            grep_args:
+              - '-E'
+            tag: CIS-5.2.3
+      description: Ensure SSH LogLevel is set to INFO
+    sshd_max_auth_retries:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/ssh/sshd_config:
+            match_output: "^MaxAuthTries +[1-4]$"
+            pattern: ^MaxAuthTries
+            match_output_regex: True
+            tag: CIS-5.2.5
+      description: Ensure SSH MaxAuthTries is set to 4 or less
+    sshd_permit_empty_passwords:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/ssh/sshd_config:
+            pattern: '"^PermitEmptyPasswords\s+no"'
+            grep_args:
+              - '-E'
+            tag: CIS-5.2.9
+      description: Ensure SSH PermitEmptyPasswords is disabled
+    sshd_permit_user_environment:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/ssh/sshd_config:
+            pattern: '"^PermitUserEnvironment\s+no"'
+            grep_args:
+              - '-E'
+            tag: CIS-5.2.10
+      description: Ensure SSH PermitUserEnvironment is disabled
+    sshd_protocol_2:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/ssh/sshd_config:
+            pattern: '"^Protocol\s+2"'
+            grep_args:
+              - '-E'
+            tag: CIS-5.2.2
+      description: Ensure SSH Protocol is set to 2
+    sshd_x11_forwarding:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/ssh/sshd_config:
+            pattern: '"^X11Forwarding\s+no"'
+            grep_args:
+              - '-E'
+            tag: CIS-5.2.4
+      description: Ensure SSH X11 forwarding is disabled
+    lockout_account:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - /etc/pam.d/system-auth:
+            pattern: '"^auth\s+required\s+pam_faillock\.so.*"'
+            match_output: deny=5
+            grep_args:
+              - '-E'
+            tag: CIS-5.3.2
+        - /etc/pam.d/password-auth:
+            pattern: '"^auth\s+required\s+pam_faillock\.so.*"'
+            match_output: deny=5
+            grep_args:
+              - '-E'
+            tag: CIS-5.3.2
+      description: Ensure lockout for failed password attempts is configured
+pkg:
+  blacklist:
+    avahi-daemon:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - avahi: CIS-2.2.3
+      description: Ensure Avahi Server is not enabled
+    cups:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - cups: CIS-2.2.4
+      description: Ensure CUPS is not enabled
+    dhcp:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - dhcp: CIS-2.2.5
+      description: Ensure DHCP Server is not enabled
+    slapd:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - openldap-servers: CIS-2.2.6
+      description: Ensure LDAP server is not enabled
+    ftp:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - perl-ftpd: CIS-2.2.9
+        - proftpd: CIS-2.2.9
+        - pure-ftpd: CIS-2.2.9
+        - vsftpd: CIS-2.2.9
+      description: Ensure FTP Server is not enabled
+    nis-client:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - ypbind: CIS-2.3.1
+      description: Ensure NIS Client is not installed
+    nis-server:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - ypserv: CIS-2.2.16
+      description: Ensure NIS Server is not enabled
+    rsh-server:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - rsh-server: CIS-2.2.17
+      description: Ensure rsh server is not enabled
+    rsh:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - rsh: CIS-2.3.2
+      description: Ensure rsh client is not installed
+    tftp-server2:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - tftp-server: CIS-2.1.6
+      description: Ensure tftp server is not enabled
+    talk-client:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - talk: CIS-2.3.3
+      description: Ensure talk client is not installed
+    talk-server:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - talk-server: CIS-2.2.18
+      description: Ensure talk server is not enabled
+    telnet-client:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - telnet: CIS-2.3.4
+      description: Ensure telnet client is not installed
+    telnet-server:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - telnet-server: CIS-2.2.19
+      description: Ensure telnet server is not enabled
+    tftp-server:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - tftp-server: CIS-2.2.20
+      description: Ensure tftp server is not enabled
+    xinetd:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - xinetd: CIS-2.1.7
+      description: Ensure xinetd is not enabled
+    xorg-x11-server-common:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - xorg-x11-server-common: CIS-2.2.2
+      description: Ensure X Window System is not installed
+    prelink:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - prelink: CIS-1.5.4
+      description: Ensure prelink is disabled
+    ldap_clients:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - openldap-clients: CIS-2.3.5
+      description: Ensure LDAP client is not installed
+  whitelist:
+    aide:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - aide: CIS-1.3.1
+      description: Ensure AIDE is installed
+    tcp_wrappers:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - tcp_wrappers: CIS-3.4.1
+      description: Ensure TCP Wrappers is installed
+    iptables:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - iptables: CIS-3.6.1
+      description: Ensure iptables is installed
+service:
+  blacklist:
+    autofs:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - autofs: CIS-1.1.22
+      description: Disable Automounting
+    rsync:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - rsyncd: CIS-2.2.21
+      description: Ensure rsync service is not enabled
+    nfs:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - nfs: CIS-2.2.7
+      description: Ensure NFS and RPC are not enabled
+    rpc:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - rpcbind: CIS-2.2.7
+      description: Ensure NFS and RPC are not enabled
+    named:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - named: CIS-2.2.8
+      description: Ensure DNS Server is not enabled
+    httpd:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - httpd: CIS-2.2.10
+      description: Ensure HTTP server is not enabled
+    pop3_imap:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - dovecot: CIS-2.2.11
+      description: Ensure IMAP and POP3 server is not enabled
+    samba:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - smb: CIS-2.2.12
+      description: Ensure Samba is not enabled
+    http_proxy:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - squid: CIS-2.2.13
+      description: Ensure HTTP Proxy Server is not enabled
+    snmp:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - snmpd: CIS-2.2.14
+      description: Ensure SNMP Server is not enabled
+  whitelist:
+    rsyslogd_running:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - rsyslog: CIS-4.2.1.1
+      description: Ensure rsyslog Service is enabled
+    syslog-ng_running:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - syslog-ng: CIS-4.2.2.1
+      description: Ensure syslog-ng service is enabled
+    crond_running:
+      data:
+        Red Hat Enterprise Linux Server-7:
+        - crond: CIS-5.1.1
+      description: Ensure cron daemon is enabled
+stat:
+  at_cron_allow:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/cron.deny:
+          gid: null
+          group: null
+          mode: null
+          tag: CIS-5.1.8
+          uid: null
+          user: null
+      - /etc/at.deny:
+          gid: null
+          group: null
+          mode: null
+          tag: CIS-5.1.8
+          uid: null
+          user: null
+      - /etc/cron.allow:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-5.1.8
+          uid: 0
+          user: root
+      - /etc/at.allow:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-5.1.8
+          uid: 0
+          user: root
+    description: Ensure at/cron is restricted to authorized users
+  cron_d:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/cron.d:
+          gid: 0
+          group: root
+          mode: 700
+          allow_more_strict: True
+          tag: CIS-5.1.7
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/cron.d are configured
+  cron_daily:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/cron.daily:
+          gid: 0
+          group: root
+          mode: 700
+          tag: CIS-5.1.4
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/cron.daily are configured
+  cron_hourly:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/cron.hourly:
+          gid: 0
+          group: root
+          mode: 700
+          allow_more_strict: true
+          tag: CIS-5.1.3
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/cron.hourly are configured
+  cron_monthly:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/cron.monthly:
+          gid: 0
+          group: root
+          mode: 700
+          allow_more_strict: true
+          tag: CIS-5.1.6
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/cron.monthly are configured
+  cron_weekly:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/cron.weekly:
+          gid: 0
+          group: root
+          mode: 700
+          allow_more_strict: true
+          tag: CIS-5.1.5
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/cron.weekly are configured
+  crontab:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/crontab:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-5.1.2
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/crontab are configured
+  passwd_own_perm:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/passwd:
+          group: root
+          mode: 644
+          tag: CIS-6.1.2
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/passwd are configured
+  shadow_own_perm:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/shadow:
+          gid: 0
+          group: root
+          mode: 000
+          tag: CIS-6.1.3
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/shadow are configured
+  group_own_perm:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/group:
+          gid: 0
+          group: root
+          mode: 644
+          tag: CIS-6.1.4
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/group are configured
+  gshadow_own_perm:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/gshadow:
+          gid: 0
+          group: root
+          mode: 000
+          tag: CIS-6.1.5
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/gshadow are configured
+  passwd-_own_perm:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/passwd-:
+          group: root
+          mode: 600
+          tag: CIS-6.1.6
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/passwd- are configured
+  shadow-_own_perm:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/shadow-:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-6.1.7
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/shadow- are configured
+  group-_own_perm:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/group-:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-6.1.8
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/group- are configured
+  gshadow-_own_perm:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/gshadow-:
+          gid: 0
+          group: root
+          mode: 0
+          tag: CIS-6.1.9
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/gshadow- are configured
+  grub_conf_own_perm:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/grub2.cfg:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-1.4.1
+          uid: 0
+          user: root
+    description: Ensure permissions on bootloader config are configured
+  hosts_allow:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/hosts.allow:
+          gid: 0
+          group: root
+          mode: 644
+          allow_more_strict: true
+          tag: CIS-3.4.4
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/hosts.allow are configured
+  hosts_deny:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/hosts.deny:
+          gid: 0
+          group: root
+          mode: 644
+          allow_more_strict: true
+          tag: CIS-3.4.5
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/hosts.deny are 644
+  sshd_config:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/ssh/sshd_config:
+          gid: 0
+          group: root
+          mode: 644
+          allow_more_strict: true
+          tag: CIS-5.2.1
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/ssh/sshd_config are configured
+  warning_banner_issue:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - /etc/issue:
+          gid: 0
+          group: root
+          mode: 644
+          tag: CIS-1.7.1.5
+          uid: 0
+          user: root
+          allow_more_strict: true
+    description: Ensure permissions on /etc/issue are configured
+sysctl:
+  bad_error_message_protection:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - net.ipv4.icmp_ignore_bogus_error_responses:
+          match_output: '1'
+          tag: CIS-3.2.6
+    description: Ensure bogus ICMP responses are ignored
+  rp_filter:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - net.ipv4.conf.default.rp_filter:
+          match_output: '1'
+          tag: CIS-3.2.7
+      - net.ipv4.conf.all.rp_filter:
+          match_output: '1'
+          tag: CIS-3.2.7
+    description: Ensure Reverse Path Filtering is enabled
+  icmp_redirect_acceptance:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - net.ipv4.conf.all.accept_redirects:
+          match_output: '0'
+          tag: CIS-3.2.2
+      - net.ipv4.conf.default.accept_redirects:
+          match_output: '0'
+          tag: CIS-3.2.2
+    description: Ensure ICMP redirects are not accepted
+  ignore_broadcast_requests:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - net.ipv4.icmp_echo_ignore_broadcasts:
+          match_output: '1'
+          tag: CIS-3.2.5
+    description: Ensure broadcast ICMP requests are ignored
+  ip_forwarding:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - net.ipv4.ip_forward:
+          match_output: '0'
+          tag: CIS-3.1.1
+    description: Ensure IP forwarding is disabled
+  log_suspicious_packets:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - net.ipv4.conf.all.log_martians:
+          match_output: '1'
+          tag: CIS-3.2.4
+      - net.ipv4.conf.default.log_martians:
+          match_output: '1'
+          tag: CIS-3.2.4
+    description: Ensure suspicious packets are logged
+  ipv6_adverts:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - net.ipv6.conf.all.accept_ra:
+          match_output: '0'
+          tag: CIS-3.3.1
+      - net.ipv6.conf.default.accept_ra:
+          match_output: '0'
+          tag: CIS-3.3.1
+    description: Ensure IPv6 router advertisements are not accepted
+  ipv6_redir:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - net.ipv6.conf.all.accept_redirects:
+          match_output: '0'
+          tag: CIS-3.3.2
+      - net.ipv6.conf.default.accept_redirects:
+          match_output: '0'
+          tag: CIS-3.3.2
+    description: Ensure IPv6 redirects are not accepted
+  randomize_va_space:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - kernel.randomize_va_space:
+          match_output: '2'
+          tag: CIS-1.5.3
+    description: Ensure address space layout randomization (ASLR) is enabled
+  restrict_suid_core_dumps:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - fs.suid_dumpable:
+          match_output: '0'
+          tag: CIS-1.5.1
+    description: Ensure core dumps are restricted
+  secure_icmp_redirect_acceptance:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - net.ipv4.conf.all.secure_redirects:
+          match_output: '0'
+          tag: CIS-3.2.3
+      - net.ipv4.conf.default.secure_redirects:
+          match_output: '0'
+          tag: CIS-3.2.3
+    description: Ensure secure ICMP redirects are not accepted
+  send_packet_redirect:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - net.ipv4.conf.all.send_redirects:
+          match_output: '0'
+          tag: CIS-3.1.2
+      - net.ipv4.conf.default.send_redirects:
+          match_output: '0'
+          tag: CIS-3.1.2
+    description: Ensure packet redirect sending is disabled
+  source_routed_packet_acceptance:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - net.ipv4.conf.all.accept_source_route:
+          match_output: '0'
+          tag: CIS-3.2.1
+      - net.ipv4.conf.default.accept_source_route:
+          match_output: '0'
+          tag: CIS-3.2.1
+    description: Ensure source routed packets are not accepted
+  tcp_syn_cookies:
+    data:
+      Red Hat Enterprise Linux Server-7:
+      - net.ipv4.tcp_syncookies:
+          match_output: '1'
+          tag: CIS-3.2.8
+    description: Ensure TCP SYN Cookies is enabled
+misc:
+  check_any_package:
+    data:
+      Red Hat Enterprise Linux Server-7:
+       tag: CIS-4.2.3
+       function: check_if_any_pkg_installed
+       args:
+         - rsyslog, syslog-ng
+    description: Ensure rsyslog or syslog-ng is installed
+  check_log_files_permission:
+    data:
+      Red Hat Enterprise Linux Server-7:
+       tag: CIS-4.2.4
+       function: check_directory_files_permission
+       args:
+        - /var/log
+        - 740
+    description: Ensure permissions on all logfiles are configured
+  sshd_approved_macs:
+    data:
+      Red Hat Enterprise Linux Server-7:
+       tag: CIS-5.2.12
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^MACs'
+         - '^MACs(.*)$'
+         - null
+         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+         - null
+         - ','
+    description: Ensure only approved MAC algorithms are used
+  sshd_approved_ciphers:
+    data:
+      Red Hat Enterprise Linux Server-7:
+       tag: CIS-5.2.11
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^Ciphers'
+         - '^Ciphers(.*)$'
+         - null
+         - 'aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com,chacha20-poly1305@openssh.com'
+         - null
+         - ','
+    description: Ensure only approved ciphers are used
+  system_account_non_login:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-5.4.2
+        function: system_account_non_login
+    description: Ensure system accounts are non-login
+  default_group_for_root_account:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-5.4.3
+        function: default_group_for_root
+    description: Ensure default group for the root account is GID 0
+  ensure_password_fields_non_empty:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.1
+        function: check_password_fields_not_empty
+    description: Ensure password fields are not empty
+  root_is_only_uid_0_account:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.5
+        function: root_is_only_uid_0_account
+    description: Ensure root is the only UID 0 account
+  check_path_integrity:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.6
+        function: check_path_integrity
+    description: Ensure root PATH Integrity
+  valid_home_directory:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.7
+        function: check_all_users_home_directory
+        args:
+        - 1000
+    description: Ensure all users home directories exist
+  home_directory_permission:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.8
+        function: check_users_home_directory_permissions
+    description: Ensure users home directories permissions are 750 or more restrictive
+  user_own_home_directory:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.9
+        function: check_users_own_their_home
+        args:
+        - 1000
+    description: Ensure users own their home directories
+  check_users_dot_files_not_writable:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.10
+        function: check_users_dot_files
+    description: Ensure users dot files are not group or world writable
+  check_users_not_forward_files:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.11
+        function: check_users_forward_files
+    description: Ensure no users have .forward files
+  check_no_users_netrc_files:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.12
+        function: check_users_netrc_files
+    description: Ensure no users have .netrc files
+  check_netrc_files_not_world_writable:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.13
+        function: check_netrc_files_accessibility
+    description: Ensure users .netrc Files are not group or world accessible
+  check_no_users_have_rhosts_files:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.14
+        function: check_users_rhosts_files
+    description: Ensure no users have .rhosts files
+  check_groups_validity_in_systemfiles:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.15
+        function: check_groups_validity
+    description: Ensure all groups in /etc/passwd exist in /etc/group
+  no_duplicate_sid:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.16
+        function: check_duplicate_uids
+    description: Ensure no duplicate UIDs exist
+  no_duplicate_gid:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.17
+        function: check_duplicate_gids
+    description: Ensure no duplicate GIDs exist
+  check_duplicate_unames_exist:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.18
+        function: check_duplicate_unames
+    description: Ensure no duplicate user names exist
+  check_duplicate_gnames_exist:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.19
+        function: check_duplicate_gnames
+    description: Ensure no duplicate group names exist

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -644,7 +644,7 @@ pkg:
         Red Hat Enterprise Linux Workstation-7:
         - ypserv: CIS-2.2.16
       description: Ensure NIS Server is not enabled
-    rsh:
+    rsh-server:
       data:
         Red Hat Enterprise Linux Workstation-7:
         - rsh-server: CIS-2.2.17

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -465,13 +465,6 @@ grep:
             pattern: hard core
             tag: CIS-1.5.1
       description: Ensure core dumps are restricted
-    rsyslog_remote_logging:
-      data:
-        Red Hat Enterprise Linux Workstation-7:
-        - /etc/rsyslog.conf:
-            pattern: ^*.*[^I][^I]*@
-            tag: CIS-4.2.1.4
-      description: Ensure rsyslog is configured to send logs to a remote log host
     sshd_approved_cipher:
       data:
         Red Hat Enterprise Linux Workstation-7:

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
@@ -1350,12 +1350,14 @@ systemctl:
     ldap-server-disabled:
       data:
         Ubuntu-16.04:
-        - slapd: CIS-2.2.6
+        - slapd:
+            tag: CIS-2.2.6
       description: Ensure LDAP server is not enabled
     nfs-disabled:
       data:
         Ubuntu-16.04:
-        - nfs-kernel-server: CIS-2.2.7
+        - nfs-kernel-server:
+            tag: CIS-2.2.7
       description: Ensure NFS and RPC are not enabled
 #    rpc-disabled:
 #      data:

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
@@ -921,7 +921,6 @@ stat:
           tag: CIS-3.4.4
           uid: 0
           user: root
-          tag: CIS-3.4.4
     description: Ensure permissions on /etc/hosts.allow are configured
   hosts_deny_perms:
     data:
@@ -934,7 +933,6 @@ stat:
           tag: CIS-3.4.5
           uid: 0
           user: root
-          tag: CIS-3.4.5
     description: Ensure permissions on /etc/hosts.deny are configured
   crontab_own_perms:
     data:
@@ -1175,7 +1173,7 @@ misc:
         tag: CIS-5.4.2
         function: system_account_non_login
     description: Ensure system accounts are non-login
-    control: Code change required for filtering the users by their login shell 
+    control: Code change required for filtering the users by their login shell
   default_group_for_root_account:
     data:
       Ubuntu-16.04:

--- a/hubblestack_nova_profiles/cis/windows-2016-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/windows-2016-level-1-scored-v1-0-0.yaml
@@ -500,7 +500,7 @@ win_secedit:
               match_output: 'Lock Workstation' # can be anything but No Action
               value_type: 'equal'
       description: (l1) ensure 'interactive logon - smart card removal behavior' is set to 'lock workstation' or higher
-    microsoft_network_client_digitally_sign_communications_ :
+    microsoft_network_require_client_digitally_sign_communications_ :
       data:
         'Microsoft Windows Server 2016*':
           - 'MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters\RequireSecuritySignature':
@@ -532,7 +532,7 @@ win_secedit:
               match_output: '16'
               value_type: 'less'
       description: (l1) ensure 'microsoft network server - amount of idle time required before suspending session' is set to '15 or fewer minute(s), but not 0'
-    microsoft_network_server_digitally_sign_communications_ :
+    microsoft_network_server_require_digitally_sign_communications_ :
       data:
         'Microsoft Windows Server 2016*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\RequireSecuritySignature':
@@ -540,7 +540,7 @@ win_secedit:
               match_output: '1'
               value_type: 'equal'
       description: (l1) ensure 'microsoft network server - digitally sign communications (always)' is set to 'enabled'
-    microsoft_network_server_digitally_sign_communications_ :
+    microsoft_network_server_enable_digitally_sign_communications_ :
       data:
         'Microsoft Windows Server 2016*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\EnableSecuritySignature':
@@ -1419,7 +1419,7 @@ win_reg:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd\PasswordComplexity':
               tag: CIS-18.2.4
-              match_output: '4' 
+              match_output: '4'
               value_type: 'equal'
       description: 'Ensure Password Settings - Password Complexity is set to Enabled - Large letters + small letters + numbers + special characters '
     Password Settings_ Password Length :
@@ -1595,7 +1595,7 @@ win_reg:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Policies\EarlyLaunch\DriverLoadPolicy':
               tag: CIS-18.8.11.1
-              match_output: '3' 
+              match_output: '3'
               value_type: 'equal'
       description: (l1) ensure 'boot-start driver initialization policy' is set to 'enabled -  good, unknown and bad but critical'
     Configure registry policy processing_ Do not apply during periodic background processing :
@@ -1814,7 +1814,7 @@ win_reg:
               match_output: '0'
               value_type: 'equal'
       description: (l1) ensure 'do not preserve zone information in file attachments' is set to 'disabled'
-    Always install with elevated privileges :
+    Always install with elevated privileges HKU :
       data:
         'Microsoft Windows Server 2016*':
           - 'HKEY_USERS\<SID>\Software\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated':
@@ -2151,7 +2151,7 @@ win_reg:
               match_output: '0'
               value_type: 'equal'
       description: (l1) ensure 'allow user control over installs' is set to 'disabled'
-    Always install with elevated privileges :
+    Always install with elevated privileges HKLM :
       data:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated':
@@ -2183,7 +2183,7 @@ win_reg:
               match_output: '0'
               value_type: 'equal'
       description: (l1) ensure 'turn on powershell transcription' is set to 'disabled'
-    Allow Basic authentication :
+    Allow Basic authentication client :
       data:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client\AllowBasic':
@@ -2191,7 +2191,7 @@ win_reg:
               match_output: '0'
               value_type: 'equal'
       description: (l1) ensure 'allow basic authentication' is set to 'disabled'
-    Allow unencrypted traffic :
+    Allow unencrypted traffic client :
       data:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client\AllowUnencryptedTraffic':
@@ -2207,7 +2207,7 @@ win_reg:
               match_output: '0'
               value_type: 'equal'
       description: (l1) ensure 'disallow digest authentication' is set to 'enabled'
-    Allow Basic authentication :
+    Allow Basic authentication service:
       data:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service\AllowBasic':
@@ -2215,7 +2215,7 @@ win_reg:
               match_output: '0'
               value_type: 'equal'
       description: (l1) ensure 'allow basic authentication' is set to 'disabled'
-    Allow unencrypted traffic :
+    Allow unencrypted traffic service:
       data:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service\AllowUnencryptedTraffic':
@@ -2231,7 +2231,7 @@ win_reg:
               match_output: '1'
               value_type: 'equal'
       description: (l1) ensure 'disallow winrm from storing runas credentials' is set to 'enabled'
-    Configure Automatic Updates :
+    Enable Configure Automatic Updates:
       data:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU\NoAutoUpdate':

--- a/hubblestack_nova_profiles/top.nova
+++ b/hubblestack_nova_profiles/top.nova
@@ -18,7 +18,7 @@ nova:
   'G@osfinger:Red*Hat*Enterprise*Linux*Server-6':
     - cis.rhels-6-level-1-scored-v2-0-1
   'G@osfinger:Red*Hat*Enterprise*Linux*Server-7':
-    - cis.rhels-7-level-1-scored-v2-1-0
+    - cis.rhels-7-level-1-scored-v2-2-0
   'G@osfinger:Red*Hat*Enterprise*Linux*Workstation-7':
     - cis.rhelw-7-level-1-scored-v2-1-0
   'G@osfinger:Ubuntu-12.04':


### PR DESCRIPTION
Multiple changes from prior audit file:
    Configure audits to match CentOS v220 audits
    Configure audits to match CIS benchmarks section numbers
    Changes to several audits related to pattern matching
    Changes to many stats command checks adding mode and gid where missing
    Add systemctl section and move many items from the pkg section to systemctl section

Added check:
CIS-1.4.3 -- Ensure authentication required for single user mode

Checks not added:
CIS-1.1.21 -- Ensure sticky bit is set on all world-writable directories (Scored)
CIS-1.7.2 -- Ensure GDM login banner is configured (Scored)
CIS-1.8 -- Ensure updates, patches, and additional security software are installed (Scored)
CIS-3.6.5 -- Ensure firewall rules exist for all open ports (Scored)
CIS-5.4.1.5 -- Ensure all users last password change date is in the past (Scored)
CIS-6.1.10 -- Ensure no world writable files exist (Scored)
CIS-6.1.11 -- Ensure no unowned files or directories exist (Scored)
CIS-6.1.12 -- Ensure no ungrouped files or directories exist (Scored)