### PR TITLE
add new audit for latest debian 9 level 1 scored v100

### DIFF
--- a/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
@@ -59,13 +59,13 @@ pkg:
     rsyslog:
       data:
         'Amazon Linux AMI-2014':
-          'rsyslog': 'CIS-5.1.1'
+          - 'rsyslog': 'CIS-5.1.1'
       description: 'Install rsyslog'
 
     anacron:
       data:
         'Amazon Linux AMI-2014':
-          'cronie-anacron': 'CIS-6.1.1'
+          - 'cronie-anacron': 'CIS-6.1.1'
       description: 'Enable anacron Daemon'
 
 

--- a/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-201409-level-1-scored-v1-0-0.yaml
@@ -289,7 +289,7 @@ stat:
             user: 'root'
             uid: 0
             group: 'root'
-            uid: 0
+            gid: 0
     description: '/etc/passwd must be owned by root'
 
   shadow_perm:

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
@@ -289,7 +289,7 @@ stat:
             user: 'root'
             uid: 0
             group: 'root'
-            uid: 0
+            gid: 0
     description: '/etc/passwd must be owned by root'
 
   shadow_perm:

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v1-0-0.yaml
@@ -59,13 +59,13 @@ pkg:
     rsyslog:
       data:
         'Amazon Linux*':
-          'rsyslog': 'CIS-5.1.1'
+          - 'rsyslog': 'CIS-5.1.1'
       description: 'Install rsyslog'
 
     anacron:
       data:
         'Amazon Linux*':
-          'cronie-anacron': 'CIS-6.1.1'
+          - 'cronie-anacron': 'CIS-6.1.1'
       description: 'Enable anacron Daemon'
 
 

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
@@ -695,9 +695,6 @@ pkg:
         'Amazon Linux*':
         - aide: CIS-1.3.1
       description: Ensure AIDE is installed
-    firewalld:
-      data: {}
-      description: Enable firewalld
     tcp_wrappers:
       data:
         'Amazon Linux*':

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v1-0-0.yaml
@@ -320,7 +320,7 @@ stat:
             user: 'root'
             uid: 0
             group: 'root'
-            uid: 0
+            gid: 0
     description: 'Verify User/Group Ownership on /etc/passwd'
 
   shadow_perm:

--- a/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-6-level-1-scored-v2-0-1.yaml
@@ -279,7 +279,7 @@ stat:
             user: 'root'
             uid: 0
             group: 'root'
-            uid: 0
+            gid: 0
     description: Ensure permissions on /etc/passwd- are configured
 
   shadow_perm:
@@ -894,7 +894,7 @@ grep:
               pattern: "^umask 077"
       description: Ensure default user umask is 027 or more restrictive
 
- 
+
 service:
   whitelist:
     rsyslogd_running:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v1-0-0.yaml
@@ -204,9 +204,6 @@ grep:
             pattern: wheel
             tag: CIS-6.5
       description: Restrict Access to the su Command
-    pam_cracklib_try_first_pass:
-      data: {}
-      description: PAM cracklib policy
     passwd_change_min_days:
       data:
         CentOS Linux-7:
@@ -450,9 +447,6 @@ pkg:
         CentOS Linux-7:
         - firewalld: CIS-4.7
       description: Enable firewalld
-    iptables:
-      data: {}
-      description: Install IPtables
     rsyslog:
       data:
         CentOS Linux-7:
@@ -710,9 +704,6 @@ sysctl:
           match_output: '1'
           tag: CIS-4.2.6
     description: Enable Bad Error Message Protection
-  exec_shield:
-    data: {}
-    description: Configure ExecShield
   icmp_redirect_acceptance:
     data:
       CentOS Linux-7:
@@ -754,9 +745,6 @@ sysctl:
           match_output: '2'
           tag: CIS-1.6.2
     description: Enable Randomized Virtual Memory Region Placement
-  restrict_suid_core_dumps:
-    data: {}
-    description: Restrict SUID Core Dumps
   send_packet_redirect:
     data:
       CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-0-0.yaml
@@ -731,9 +731,6 @@ pkg:
         CentOS Linux-7:
         - aide: CIS-1.3.1
       description: Ensure AIDE is installed
-    firewalld:
-      data: {}
-      description: Enable firewalld
     tcp_wrappers:
       data:
         CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -664,7 +664,7 @@ pkg:
         CentOS Linux-7:
         - ypserv: CIS-2.2.16
       description: Ensure NIS Server is not enabled
-    rsh:
+    rsh-server:
       data:
         CentOS Linux-7:
         - rsh-server: CIS-2.2.17

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-0.yaml
@@ -472,13 +472,6 @@ grep:
             pattern: hard core
             tag: CIS-1.5.1
       description: Ensure core dumps are restricted
-    rsyslog_remote_logging:
-      data:
-        CentOS Linux-7:
-        - /etc/rsyslog.conf:
-            pattern: ^*.*[^I][^I]*@
-            tag: CIS-4.2.1.4
-      description: Ensure rsyslog is configured to send logs to a remote log host
     sshd_approved_cipher:
       data:
         CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-1.yaml
@@ -463,13 +463,6 @@ grep:
             pattern: hard core
             tag: CIS-1.5.1
       description: Ensure core dumps are restricted
-    rsyslog_remote_logging:
-      data:
-        CentOS Linux-7:
-        - /etc/rsyslog.conf:
-            pattern: ^*.*[^I][^I]*@
-            tag: CIS-4.2.1.4
-      description: Ensure rsyslog is configured to send logs to a remote log host
     sshd_approved_cipher:
       data:
         CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/debian-7.yaml
+++ b/hubblestack_nova_profiles/cis/debian-7.yaml
@@ -566,7 +566,7 @@ sysctl:
             match_output: '0'
     description: Disable ICMP Redirect Acceptance
 
-  icmp_redirect_acceptance:
+  icmp_secure_redirect_acceptance:
     data:
       Debian*7:
         - 'net.ipv4.conf.all.secure_redirects':

--- a/hubblestack_nova_profiles/cis/debian-9-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9-level-1-scored-v1-0-0.yaml
@@ -1,0 +1,1447 @@
+grep:
+  whitelist:
+    disable_mount_cramfs:
+      data:
+        Ubuntu-16.04:
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: cramfs
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.1
+      description: Ensure mounting of cramfs filesystems is disabled
+    disable_mount_freevxfs:
+      data:
+        Ubuntu-16.04:
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: freevxfs
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.2
+      description: Ensure mounting of freevxfs filesystems is disabled
+    disable_mount_jffs2:
+      data:
+        Ubuntu-16.04:
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: jffs2
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.3
+      description: Ensure mounting of jffs2 filesystems is disabled
+    disable_mount_hfs:
+      data:
+        Ubuntu-16.04:
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: hfs
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.4
+      description: Ensure mounting of hfs filesystems is disabled
+    disable_mount_hfsplus:
+      data:
+        Ubuntu-16.04:
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: hfsplus
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.5
+      description: Ensure mounting of hfsplus filesystems is disabled
+    disable_mount_squashfs:
+      data:
+        Ubuntu-16.04:
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: squashfs
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.6
+      description: Ensure mounting of squashfs filesystems is disabled
+    disable_mount_udf:
+      data:
+        Ubuntu-16.04:
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: udf
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.7
+      description: Ensure mounting of udf filesystems is disabled
+    disable_mount_fat:
+      data:
+        Ubuntu-16.04:
+        - /etc/modprobe.d:
+            match_output: /bin/true
+            pattern: vfat
+            grep_args:
+              - '-r'
+            tag: CIS-1.1.1.8
+      description: Ensure mounting of FAT filesystems is disabled
+    mounts_dev_shm_partition_nodev:
+      data:
+        Ubuntu-16.04:
+        - /proc/mounts:
+            match_output: nodev
+            pattern: /dev/shm
+            tag: CIS-1.1.14
+      description: Ensure nodev option set on /dev/shm partition
+    mounts_dev_shm_partition_noexec:
+      data:
+        Ubuntu-16.04:
+        - /proc/mounts:
+            match_output: noexec
+            pattern: /dev/shm
+            tag: CIS-1.1.16
+      description: Ensure noexec option set on /dev/shm partition
+    mounts_dev_shm_partition_nosuid:
+      data:
+        Ubuntu-16.04:
+        - /proc/mounts:
+            match_output: nosuid
+            pattern: /dev/shm
+            tag: CIS-1.1.15
+      description: Ensure nosuid option set on /dev/shm partition
+    mounts_tmp_partition_nodev:
+      data:
+        Ubuntu-16.04:
+        - /proc/mounts:
+            match_output: nodev
+            pattern: /tmp
+            tag: CIS-1.1.3
+      description: Ensure nodev option set on /tmp partition
+    mounts_tmp_partition_nosuid:
+      data:
+        Ubuntu-16.04:
+        - /proc/mounts:
+            match_output: nosuid
+            pattern: /tmp
+            tag: CIS-1.1.4
+      description: Ensure nosuid option set on /tmp partition
+    mount_var_tmp_partition_nodev:
+      data:
+        Ubuntu-16.04:
+        - /proc/mounts:
+            match_output: nodev
+            pattern: /var/tmp
+            tag: CIS-1.1.7
+      description: Ensure nodev option set on /var/tmp partition
+    mount_var_tmp_partition_nosuid:
+      data:
+        Ubuntu-16.04:
+        - /proc/mounts:
+            match_output: nosuid
+            pattern: /var/tmp
+            tag: CIS-1.1.8
+      description: Ensure nosuid option set on /var/tmp partition
+    mount_var_tmp_partition_noexec:
+      data:
+        Ubuntu-16.04:
+        - /proc/mounts:
+            match_output: noexec
+            pattern: /var/tmp
+            tag: CIS-1.1.9
+      description: Ensure noexec option set on /var/tmp partition
+    aide_filesystem_scans:
+      data:
+        Ubuntu-16.04:
+        - /var/spool/cron/crontabs/root:
+#            match_output: '0 5 * * * /usr/bin/aide --check'
+            pattern: aide
+            tag: CIS-1.3.2
+      description: Ensure filesystem integrity is regularly checked
+    core_hard_limit:
+      data:
+        Ubuntu-16.04:
+        - /etc/security/limits.conf:
+            match_output: '0'
+            pattern: hard core
+            tag: CIS-1.5.1
+      description: Ensure core dumps are restricted
+    ntp_restrict_default:
+      data:
+        Ubuntu-16.04:
+        - /etc/ntp.conf:
+            pattern: '^restrict'
+            match_output: default
+            tag: CIS-2.2.1.2
+        - /etc/ntp.conf:
+            pattern: restrict -6 default
+            tag: CIS-2.2.1.2
+        - /etc/ntp.conf:
+            pattern: '^server'
+            tag: CIS-2.2.1.2
+        - /etc/init.d/ntp:
+            pattern: RUNASUSER=
+            tag: CIS-2.2.1.2
+      description: Ensure NTP is configured
+    local_mta:
+      data:
+        Ubuntu-16.04:
+          - /etc/postfix/main.cf:
+              pattern: '^inet_interfaces'
+              match_output: localhost
+              tag: CIS-2.2.15
+      description: Ensure mail transfer agent is configured for local-only mode
+    rsync:
+      data:
+        Ubuntu-16.04:
+        - /etc/default/rsync:
+            pattern: ^RSYNC_ENABLE
+            match_output: 'false'
+            tag: CIS-2.2.16
+      description: Ensure rsync service is not enabled
+    hosts_allow:
+      data:
+        Ubuntu-16.04:
+        - /etc/hosts.allow:
+            pattern: ALL
+            tag: CIS-3.4.2
+      description: Ensure /etc/hosts.allow is configured
+    hosts_deny:
+      data:
+        Ubuntu-16.04:
+        - /etc/hosts.deny:
+            pattern:  ALL
+            tag: CIS-3.4.3
+      description: Ensure /etc/hosts.deny is configured
+    firewall_default_deny:
+      data:
+        Ubuntu-16.04:
+        - /etc/iptables/rules.v4:
+            pattern: :INPUT
+            match_output: DROP
+            tag: CIS-3.6.2
+        - /etc/iptables/rules.v4:
+            pattern: :FORWARD
+            match_pattern: DROP
+            tag: CIS-3.6.2
+        - /etc/iptables/rules.v4:
+            pattern: :OUTPUT
+            match_output: DROP
+            tag: CIS-3.6.2
+      description: Ensure default deny firewall policy
+    firewall_accept_lo:
+      data:
+        Ubuntu-16.04:
+        - /etc/iptables/rules.v4:
+            pattern: '"\-A INPUT \-i lo \-j"'
+            match_output: ACCEPT
+            tag: CIS-3.6.3
+        - /etc/iptables/rules.v4:
+            pattern: '"\-A OUTPUT \-o lo \-j"'
+            match_output: ACCEPT
+            tag: CIS-3.6.3
+        - /etc/iptables/rules.v4:
+            pattern: '"\-A INPUT \-s 127.0.0.0/8 \-j"'
+            match_output: DROP
+            tag: CIS-3.6.3
+      description: Ensure loopback traffic is configured
+#3.6.5 is not implemented as need code changes
+    rsyslog_file_perms:
+      data:
+        Ubuntu-16.04:
+        - /etc/rsyslog.conf:
+            pattern: '^\$FileCreateMode'
+            match_output: '0640'
+            tag: CIS-4.2.1.3
+            allow_more_strict: true
+      description: Ensure rsyslog default file permissions configured
+    rsyslog_remote_logging:
+      data:
+        Ubuntu-16.04:
+        - /etc/rsyslog.conf:
+            pattern: ^*.*[^I][^I]*@
+            tag: CIS-4.2.1.4
+      description: Ensure rsyslog is configured to send logs to a remote log host
+    pam_password_reuse:
+      data:
+        Ubuntu-16.04:
+        - /etc/pam.d/common-password:
+            pattern: remember
+            match_output: 'remember=5'
+            tag: CIS-5.3.3
+      description: Ensure password reuse is limited
+    ssh_version_2:
+      data:
+        Ubuntu-16.04:
+        - /etc/ssh/sshd_config:
+            pattern: ^Protocol
+            match_output: Protocol\s+2
+            match_output_regex: True
+            tag: CIS-5.2.2
+      description: Ensure SSH Protocol is set to 2
+    ssh_log_level:
+      data:
+        Ubuntu-16.04:
+        - /etc/ssh/sshd_config:
+            pattern: ^LogLevel
+            match_output: LogLevel\s+INFO
+            match_output_regex: True
+            tag: CIS-5.2.3
+      description: Ensure SSH LogLevel is set to INFO
+    ssh_disable_xforward:
+      data:
+        Ubuntu-16.04:
+        - /etc/ssh/sshd_config:
+            pattern: ^X11Forwarding
+            match_output: X11Forwarding\s+no
+            match_output_regex: True
+            tag: CIS-5.2.4
+      description: Ensure SSH X11 forwarding is disabled
+    ssh_auth_retries:
+      data:
+        Ubuntu-16.04:
+        - /etc/ssh/sshd_config:
+            pattern: ^MaxAuthTries
+            match_output_regex: True
+            match_output: "^MaxAuthTries +[1-4]$"
+            tag: CIS-5.2.5
+      description: Ensure SSH MaxAuthTries is set to 4 or less
+    ssh_ignore_rhosts:
+      data:
+        Ubuntu-16.04:
+        - /etc/ssh/sshd_config:
+            pattern: ^IgnoreRhosts
+            match_output: IgnoreRhosts\s+yes
+            match_output_regex: True
+            tag: CIS-5.2.6
+      description: Ensure SSH IgnoreRhosts is enabled
+    ssh_hostbased_auth:
+      data:
+        Ubuntu-16.04:
+        - /etc/ssh/sshd_config:
+            pattern: ^HostbasedAuthentication
+            match_output: HostbasedAuthentication\s+no
+            match_output_regex: True
+            tag: CIS-5.2.7
+      description: Ensure SSH HostbasedAuthentication is disabled
+    ssh_permit_root:
+      data:
+        Ubuntu-16.04:
+        - /etc/ssh/sshd_config:
+            pattern: ^PermitRootLogin
+            match_output: PermitRootLogin\s+no
+            match_output_regex: True
+            tag: CIS-5.2.8
+      description: Ensure SSH root login is disabled
+    ssh_permit_empty_pw:
+      data:
+        Ubuntu-16.04:
+        - /etc/ssh/sshd_config:
+            pattern: ^PermitEmptyPasswords
+            match_output: PermitEmptyPasswords\s+no
+            match_output_regex: True
+            tag: CIS-5.2.9
+      description: Ensure SSH PermitEmptyPasswords is disabled
+    ssh_permit_user_env:
+      data:
+        Ubuntu-16.04:
+        - /etc/ssh/sshd_config:
+            pattern: ^PermitUserEnvironment
+            match_output: PermitUserEnvironment\s+no
+            match_output_regex: True
+            tag: CIS-5.2.10
+      description: Ensure SSH PermitUserEnvironment is disabled
+    sshd_idle_timeout:
+      data:
+        Ubuntu-16.04:
+        - /etc/ssh/sshd_config:
+            pattern: ^ClientAliveInterval
+            match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
+            match_output_regex: True
+            tag: CIS-5.2.12
+        - /etc/ssh/sshd_config:
+            pattern: ClientAliveCountMax
+            match_output: "^ClientAliveCountMax +[0-3]$"
+            match_output_regex: True
+            tag: CIS-5.2.12
+      description: Ensure SSH Idle Timeout Interval is configured
+    sshd_gracetime:
+      data:
+        Ubuntu-16.04:
+        - /etc/ssh/sshd_config:
+            pattern: ^LoginGraceTime
+            match_output: ^LoginGraceTime ([0-5]{0,1}\d|60|1m)$
+            match_output_regex: True
+            tag: CIS-5.2.13
+      description: Ensure SSH LoginGraceTime is set to one minute or less
+    ssh_limit_access:
+      data:
+        Ubuntu-16.04:
+        - /etc/ssh/sshd_config:
+            pattern: '^AllowUsers|^AllowGroups|^DenyUsers|^DenyGroups'
+            grep_args:
+              - '-E'
+            tag: CIS-5.2.14
+      description:  Ensure SSH access is limited
+    sshd_banner:
+      data:
+        Ubuntu-16.04:
+        - /etc/ssh/sshd_config:
+            match_output: "/etc/issue.net"
+            pattern: ^Banner
+            tag: CIS-5.2.15
+      description: Ensure SSH warning banner is configured
+    pam_pwquality_try_first_pass:
+      data:
+        Ubuntu-16.04:
+        - /etc/pam.d/common-password:
+            match_output: try_first_pass
+            pattern: pam_pwquality.so
+            tag: CIS-5.3.1
+        - /etc/pam.d/common-password:
+            match_output: retry=3
+            pattern: pam_pwquality.so
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: minlen
+            match_output: '14'
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: dcredit
+            match_output: '-1'
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: ucredit
+            match_output: '-1'
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: ocredit
+            match_output: '-1'
+            tag: CIS-5.3.1
+        - /etc/security/pwquality.conf:
+            pattern: lcredit
+            match_output: '-1'
+            tag: CIS-5.3.1
+      description: Ensure password creation requirements are configured
+    password_hash:
+      data:
+        Ubuntu-16.04:
+        - /etc/pam.d/common-password:
+            pattern: '"^password\s.*\w+.*\s+pam_unix.so\s+\w+\s"'
+            match_output: sha512
+            grep_args:
+              - '-E'
+            tag: CIS-5.3.4
+      description: Ensure password hashing algorithm is SHA-512
+    limit_su_access:
+      data:
+        Ubuntu-16.04:
+        - /etc/pam.d/su:
+            pattern: pam_wheel.so
+            match_output: use_uid
+            tag: CIS-5.6
+        - /etc/group:
+            pattern: wheel
+            tag: CIS-5.6
+      description: Ensure access to the su command is restricted
+    password_max_days:
+      data:
+        Ubuntu-16.04:
+        - /etc/login.defs:
+            pattern: PASS_MAX_DAYS
+            match_output: '90'
+            tag: CIS-5.4.1.1
+      description: Ensure password expiration is 90 days or less
+    password_min_days:
+      data:
+        Ubuntu-16.04:
+        - /etc/login.defs:
+            pattern: PASS_MIN_DAYS
+            match_output: '7'
+            tag: CIS-5.4.1.2
+      description: Ensure minimum days between password changes is 7 or more
+    password_warn_days:
+      data:
+        Ubuntu-16.04:
+        - /etc/login.defs:
+            pattern: PASS_WARN_AGE
+            match_output: '7'
+            tag: CIS-5.4.1.3
+      description: Ensure password expiration warning days is 7 or more
+    default_umask:
+      data:
+        Ubuntu-16.04:
+        - /etc/bash.bashrc:
+            pattern: umask
+            match_pattern: '0[2367]7'
+            grep_args:
+              - '-E'
+            tag: CIS-5.4.4
+        - /etc/profile.d/cis.sh:
+            pattern: umask
+            match_pattern: '0[2367]7'
+            grep_args:
+              - '-E'
+            tag: CIS-5.4.4
+      description: Ensure default user umask is 027 or more restrictive
+    passwd_inactive:
+      data:
+        Ubuntu-16.04:
+        - /etc/default/useradd:
+            pattern: INACTIVE=30
+            tag: CIS-5.4.1.4
+      description: Ensure inactive password lock is 30 days or less
+  blacklist:
+    talkd:
+      data:
+        Ubuntu-16.04:
+        - /etc/xinetd*:
+            pattern: '^talk'
+            grep_args:
+              - '-r'
+            tag: CIS-2.1.7
+        - /etc/xinetd*:
+            pattern: '^ntalk'
+            grep_args:
+              - '-r'
+            tag: CIS-2.1.7
+      description: Ensure talk server is not enabled
+    telnet:
+      data:
+        Ubuntu-16.04:
+        - /etc/xinetd*:
+            pattern: '^telnet'
+            greps_args:
+              - '-r'
+            tag: CIS-2.1.8
+      description: Ensure Telnet Server is not Enabled
+    tftp:
+      data:
+        Ubuntu-16.04:
+        - /etc/xinetd*:
+            pattern: '^tftp'
+            grep_args:
+              - '-r'
+            tag: CIS-2.1.9
+      description: Ensure tftp server is not enabled
+    chargen:
+      data:
+        Ubuntu-16.04:
+        - /etc/xinetd.d/chargen:
+            match_output: '^\s*disable\s*=\s*no'
+            pattern: chargen-stream
+            match_output_regex: True
+            grep_args:
+              - '-B'
+              - '3'
+            tag: CIS-2.1.1
+        - /etc/xinetd.d/chargen:
+            match_output: '^\s*disable\s*=\s*no'
+            pattern: chargen-dgram
+            match_output_regex: True
+            grep_args:
+              - '-B'
+              - '3'
+            tag: CIS-2.1.1
+      description: Ensure Chargen Services are not Enabled
+    daytime:
+      data:
+        Ubuntu-16.04:
+        - /etc/xinetd.d/daytime:
+            match_output: '^\s*disable\s*=\s*no'
+            pattern: daytime-stream
+            match_output_regex: True
+            grep_args:
+              - '-B'
+              - '3'
+            tag: CIS-2.1.2
+        - /etc/xinetd.d/daytime:
+            match_output: '^\s*disable\s*=\s*no'
+            pattern: daytime-dgram
+            match_output_regex: True
+            grep_args:
+              - '-B'
+              - '3'
+            tag: CIS-2.1.2
+      description: Ensure daytime services are not enabled
+    echo:
+      data:
+        Ubuntu-16.04:
+        - /etc/xinetd.d/echo:
+            match_output: '^\s*disable\s*=\s*no'
+            pattern: echo-stream
+            match_output_regex: True
+            grep_args:
+              - '-B'
+              - '3'
+            tag: CIS-2.1.4
+        - /etc/xinetd.d/echo:
+            match_output: '^\s*disable\s*=\s*no'
+            pattern: echo-dgram
+            match_output_regex: True
+            grep_args:
+              - '-B'
+              - '3'
+            tag: CIS-2.1.4
+      description: Ensure echo services are not enabled
+    discard:
+      data:
+        Ubuntu-16.04:
+        - /etc/xinetd.d/discard:
+            match_output: '^\s*disable\s*=\s*no'
+            pattern: discard-stream
+            match_output_regex: True
+            grep_args:
+              - '-B'
+              - '3'
+            tag: CIS-2.1.3
+        - /etc/xinetd.d/discard:
+            match_output: '^\s*disable\s*=\s*no'
+            pattern: discard-dgram
+            match_output_regex: True
+            grep_args:
+              - '-B'
+              - '3'
+            tag: CIS-2.1.3
+      description: Ensure discard services are not enabled
+    time:
+      data:
+        Ubuntu-16.04:
+        - /etc/xinetd.d/time:
+            match_output: '^\s*disable\s*=\s*no'
+            pattern: time-stream
+            match_output_regex: True
+            grep_args:
+              - '-B'
+              - '3'
+            tag: CIS-2.1.5
+        - /etc/xinetd.d/time:
+            match_output: '^\s*disable\s*=\s*no'
+            pattern: time-dgram
+            match_output_regex: True
+            grep_args:
+              - '-B'
+              - '3'
+            tag: CIS-2.1.5
+      description: Ensure time Services are not Enabled
+    banner_os_info_motd:
+      data:
+        Ubuntu-16.04:
+        - /etc/motd:
+            pattern: '\v'
+            tag: CIS-1.7.1.1
+        - /etc/motd:
+            pattern: '\r'
+            tag: CIS-1.7.1.1
+        - /etc/motd:
+            pattern: '\m'
+            tag: CIS-1.7.1.1
+        - /etc/motd:
+            pattern: '\s'
+            tag: CIS-1.7.1.1
+      description: Ensure message of the day is configured properly
+    legacy_entries_passwd:
+      data:
+        Ubuntu-16.04:
+        - /etc/passwd:
+            pattern: '^+'
+            tag: CIS-6.2.2
+      description: Ensure No Legacy "+" Entries Exist in /etc/passwd File
+    legacy_entries_shadow:
+      data:
+        Ubuntu-16.04:
+        - /etc/shadow:
+            pattern: '^+'
+            tag: CIS-6.2.3
+      description: Ensure No Legacy "+" Entries Exist in /etc/shadow File
+    legacy_entries_group:
+      data:
+        Ubuntu-16.04:
+        - /etc/group:
+            pattern: '^+'
+            tag: CIS-6.2.4
+      description: Ensure No Legacy "+" Entries Exist in /etc/group File
+
+service:
+  blacklist:
+    autofs:
+      data:
+        Ubuntu-16.04:
+        - autofs: CIS-1.1.21
+      description: Disable Automounting
+    xinetd:
+      data:
+        Ubuntu-16.04:
+          - xinetd: CIS-2.1.10
+      description: Ensure xinetd is not enabled
+    avahi_daemon:
+      data:
+        Ubuntu-16.04:
+          - avahi-daemon: CIS-2.2.3
+      description: Ensure Avahi Server is not enabled
+    cups:
+      data:
+        Ubuntu-16.04:
+          - cups: CIS-2.2.4
+      description: Ensure CUPS is not enabled
+    dhcp-server:
+      data:
+        Ubuntu-16.04:
+          - isc-dhcp-server: CIS-2.2.5
+          - isc-dhcp-server6: CIS-2.2.5
+      description: Ensure DHCP Server is not enabled
+    slapd:
+      data:
+        Ubuntu-16.04:
+        - slapd: CIS-2.2.6
+      description: Ensure LDAP server is not enabled
+    nfs-service:
+      data:
+        Ubuntu-16.04:
+        - nfs-kernel-server: CIS-2.2.7
+      description: Ensure NFS and RPC are not enabled
+    rpc-bind-service:
+      data:
+        Ubuntu-16.04:
+        - rpcbind: CIS-2.2.7
+      description: Ensure NFS and RPC are not enabled
+    bind9:
+      data:
+        Ubuntu-16.04:
+        - bind9: CIS-2.2.8
+      description: Ensure DNS Server is not enabled
+    http-server-service:
+      data:
+        Ubuntu-16.04:
+        - apache2: CIS-2.2.10
+      description: Ensure HTTP server is not enabled
+    imap-pop3-server-service:
+      data:
+        Ubuntu-16.04:
+        - dovecot: CIS-2.2.11
+      description: Ensure IMAP and POP3 server is not enabled
+
+  whitelist:
+    rsyslog:
+      data:
+        Ubuntu-16.04:
+          - rsyslog: CIS-4.2.1.1
+      description: Ensure the rsyslog Service is enabled
+    cron:
+      data:
+        Ubuntu-16.04:
+          - cron: CIS-5.1.1
+      description: Enable cron Daemon
+
+sysctl:
+  disable_suid_dumpable:
+    data:
+      Ubuntu-16.04:
+      - fs.suid_dumpable:
+          match_output: '0'
+          tag: CIS-1.5.1
+    description: Restrict Core Dumps
+  randomize_va_space:
+    data:
+      Ubuntu-16.04:
+      - kernel.randomize_va_space:
+          match_output: '2'
+          tag: CIS-1.5.3
+    description: Ensure address space layout randomization (ASLR) is enabled
+  disable_ip4_ip_forward:
+    data:
+      Ubuntu-16.04:
+      - net.ipv4.ip_forward:
+          match_output: '0'
+          tag: CIS-3.1.1
+    description: Ensure IP forwarding is disabled
+  disable_packet_redirect:
+    data:
+      Ubuntu-16.04:
+      - net.ipv4.conf.all.send_redirects:
+          match_output: '0'
+          tag: CIS-3.1.2
+    description: Ensure packet redirect sending is disabled
+  disable_source_routed_packets:
+    data:
+      Ubuntu-16.04:
+      - net.ipv4.conf.all.accept_source_route:
+          match_output: '0'
+          tag: CIS-3.2.1
+    description: Ensure source routed packets are not accepted
+  disable_icmp_redirect:
+    data:
+      Ubuntu-16.04:
+      - net.ipv4.conf.all.accept_redirects:
+          match_output: '0'
+          tag: CIS-3.2.2
+    description: Ensure ICMP redirects are not accepted
+  disable_secure_icmp_redirect:
+    data:
+      Ubuntu-16.04:
+      - net.ipv4.conf.all.secure_redirects:
+          match_output: '0'
+          tag: CIS-3.2.3
+    description: Ensure secure ICMP redirects are not accepted
+  log_martians:
+    data:
+      Ubuntu-16.04:
+      - net.ipv4.conf.all.log_martians:
+          match_output: '1'
+          tag: CIS-3.2.4
+    description: Ensure suspicious packets are logged
+  ignore_broadcast:
+    data:
+      Ubuntu-16.04:
+      - net.ipv4.icmp_echo_ignore_broadcasts:
+          match_output: '1'
+          tag: CIS-3.2.5
+    description: Ensure broadcast ICMP requests are ignored
+  bogus_errors:
+    data:
+      Ubuntu-16.04:
+      - net.ipv4.icmp_ignore_bogus_error_responses:
+          match_output: '1'
+          tag: CIS-3.2.6
+    description: Ensure bogus ICMP responses are ignored
+  rp_filter:
+    data:
+      Ubuntu-16.04:
+      - net.ipv4.conf.all.rp_filter:
+          match_output: '1'
+          tag: CIS-3.2.7
+    description: Ensure Reverse Path Filtering is enabled
+  tcp_syncookies:
+    data:
+      Ubuntu-16.04:
+      - net.ipv4.tcp_syncookies:
+          match_output: '1'
+          tag: CIS-3.2.8
+    description: Ensure TCP SYN Cookies is enabled
+
+pkg:
+  blacklist:
+    prelink:
+      data:
+        Ubuntu-16.04:
+        - prelink: CIS-1.5.4
+      description: Ensure prelink is disabled
+    nis:
+      data:
+        Ubuntu-16.04:
+        - nis: CIS-2.3.1
+      description: Ensure NIS Client is not installed
+    talkd:
+      data:
+        Ubuntu-16.04:
+        - talkd: CIS-2.1.7
+      description: Ensure Talk Server is not installed
+    telnet-server:
+      data:
+        Ubuntu-16.04:
+        - telnetd: CIS-2.1.8
+      description: Ensure Telnet Server is not installed
+    telnet-client:
+      data:
+        Ubuntu-16.04:
+        - telnet: CIS-2.3.4
+      description: Ensure Telnet Client is not installed
+    ldap-client:
+      data:
+        Ubuntu-16.04:
+        - ldap-utils: CIS-2.3.5
+      description: Ensure LDAP Client is not installed
+    talk:
+      data:
+        Ubuntu-16.04:
+        - talk: CIS-2.3.3
+      description: Ensure Talk Client is not installed
+    xserver:
+      data:
+        Ubuntu-16.04:
+        - xserver-xorg-core\*: CIS-2.2.2
+      description: Ensure the X Window System is not installed
+    biosdevname:
+      data:
+        Ubuntu-16.04:
+        - biosdevname: CIS-6.17
+      description: Ensure biosdevname is not enabled
+    rsh-server:
+      data:
+        Ubuntu-16.04:
+        - rsh-server: CIS-2.1.6
+      description: Ensure rsh server is not enabled
+    rsh-client:
+      data:
+        Ubuntu-16.04:
+        - rsh-client: CIS-2.3.2
+        - rsh-redone-client: CIS-2.3.2
+      description: Ensure rsh client is not installed
+  whitelist:
+    ntp:
+      data:
+        Ubuntu-16.04:
+        - ntp: CIS-2.2.1.2
+      description: Configure Network Time Protocol (NTP)
+    aide:
+      data:
+        Ubuntu-16.04:
+        - aide: CIS-1.3.1
+      description: Ensure AIDE is installed
+    tcpd:
+      data:
+        Ubuntu-16.04:
+        - tcpd: CIS-3.4.1
+      description: Ensure TCP Wrappers is installed
+    rsyslog:
+      data:
+        Ubuntu-16.04:
+        - rsyslog: CIS-4.2.3
+      description: Ensure rsyslog is installed
+    iptables:
+      data:
+        Ubuntu-16.04:
+        - iptables: CIS-3.6.1
+      description: Ensure iptables is installed
+stat:
+  grub_cfg_perms:
+    data:
+      Ubuntu-16.04:
+      - /boot/grub/grub.cfg:
+          gid: 0
+          group: root
+          uid: 0
+          user: root
+          mode: 600
+          allow_more_strict: true
+          tag: CIS-1.4.1
+    description: Ensure permissions on bootloader config are configured
+  hosts_allow_perms:
+    data:
+      Ubuntu-16.04:
+      - /etc/hosts.allow:
+          gid: 0
+          group: root
+          mode: 644
+          allow_more_strict: true
+          tag: CIS-3.4.4
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/hosts.allow are configured
+  hosts_deny_perms:
+    data:
+      Ubuntu-16.04:
+      - /etc/hosts.deny:
+          gid: 0
+          group: root
+          mode: 644
+          allow_more_strict: true
+          tag: CIS-3.4.5
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/hosts.deny are configured
+  crontab_own_perms:
+    data:
+      Ubuntu-16.04:
+      - /etc/crontab:
+          gid: 0
+          group: root
+          uid: 0
+          user: root
+          mode: 600
+          allow_more_strict: true
+          tag: CIS-5.1.2
+    description:  Ensure permissions on /etc/crontab are configured
+  cron_hourly_own_perms:
+    data:
+      Ubuntu-16.04:
+      - /etc/cron.hourly:
+          gid: 0
+          group: root
+          uid: 0
+          user: root
+          mode: 600
+          allow_more_strict: true
+          tag: CIS-5.1.3
+    description:  Ensure permissions on /etc/cron.hourly are configured
+  cron_daily_own_perms:
+    data:
+      Ubuntu-16.04:
+      - /etc/cron.daily:
+          gid: 0
+          group: root
+          uid: 0
+          user: root
+          mode: 600
+          allow_more_strict: true
+          tag: CIS-5.1.4
+    description:  Ensure permissions on /etc/cron.daily are configured
+  cron_weekly_own_perms:
+    data:
+      Ubuntu-16.04:
+      - /etc/cron.weekly:
+          gid: 0
+          group: root
+          uid: 0
+          user: root
+          mode: 600
+          allow_more_strict: true
+          tag: CIS-5.1.5
+    description:  Ensure permissions on /etc/cron.weekly are configured
+  cron_monthly_own_perms:
+    data:
+      Ubuntu-16.04:
+      - /etc/cron.monthly:
+          gid: 0
+          group: root
+          uid: 0
+          user: root
+          mode: 600
+          allow_more_strict: true
+          tag: CIS-5.1.6
+    description:  Ensure permissions on /etc/cron.monthly are configured
+  cron_d_own_perms:
+    data:
+      Ubuntu-16.04:
+      - /etc/cron.d:
+          gid: 0
+          group: root
+          uid: 0
+          user: root
+          mode: 700
+          allow_more_strict: true
+          tag: CIS-5.1.7
+    description:  Ensure permissions on /etc/cron.d are configured
+  at_cron_allow:
+    data:
+      Ubuntu-16.04:
+      - /etc/cron.deny:
+          gid: null
+          group: null
+          mode: null
+          tag: CIS-5.1.8
+          uid: null
+          user: null
+      - /etc/at.deny:
+          gid: null
+          group: null
+          mode: null
+          tag: CIS-5.1.8
+          uid: null
+          user: null
+      - /etc/cron.allow:
+          gid: 0
+          group: root
+          mode: 600
+          allow_more_strict: true
+          tag: CIS-5.1.8
+          uid: 0
+          user: root
+      - /etc/at.allow:
+          gid: 0
+          group: root
+          mode: 600
+          allow_more_strict: true
+          tag: CIS-5.1.8
+          uid: 0
+          user: root
+    description: Ensure at/cron is restricted to authorized users
+  sshd_config:
+    data:
+      Ubuntu-16.04:
+      - /etc/ssh/sshd_config:
+          uid: 0
+          gid: 0
+          user: root
+          group: root
+          mode: 600
+          allow_more_strict: true
+          tag: CIS-5.2.1
+    description: Ensure permissions on /etc/ssh/sshd_config are configured
+  banner_files_issue:
+    data:
+      Ubuntu-16.04:
+      - /etc/issue:
+          uid: 0
+          gid: 0
+          user: root
+          group: root
+          mode: 644
+          allow_more_strict: true
+          tag: CIS-1.7.1.5
+    description: Ensure permissions on /etc/issue are configured
+  passwd_perms:
+    data:
+      Ubuntu-16.04:
+      - /etc/passwd:
+          uid: 0
+          gid: 0
+          user: root
+          group: root
+          mode: 644
+          tag: CIS-6.1.2
+    description: Ensure permissions on /etc/passwd are configured
+  shadow_perms:
+    data:
+      Ubuntu-16.04:
+      - /etc/shadow:
+          uid: 0
+          gid: 42
+          user: root
+          group: shadow
+          mode: 640
+          tag: CIS-6.1.3
+    description: Ensure permissions on /etc/shadow are configured
+  group_perms:
+    data:
+      Ubuntu-16.04:
+      - /etc/group:
+          uid: 0
+          gid: 0
+          user: root
+          group: root
+          mode: 644
+          tag: CIS-6.1.4
+    description: Ensure permissions on /etc/group are configured
+  gshadow_owner_group:
+    data:
+      Ubuntu-16.04:
+      - /etc/gshadow:
+          uid: 0
+          gid: 42
+          user: root
+          group: shadow
+          tag: CIS-6.1.5
+    description: Ensure permissions on /etc/gshadow are configured
+  passwd-_own_perm:
+    data:
+      Ubuntu-16.04:
+      - /etc/passwd-:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-6.1.6
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/passwd- are configured
+  shadow-_own_perm:
+    data:
+      Ubuntu-16.04:
+      - /etc/shadow-:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-6.1.7
+          uid: 0
+          user: root
+    description: 'Ensure permissions on /etc/shadow- are configured'
+  group-_own_perm:
+    data:
+      Ubuntu-16.04:
+      - /etc/group-:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-6.1.8
+          uid: 0
+          user: root
+    description: 'Ensure permissions on /etc/group- are configured'
+  gshadow-_own_perm:
+    data:
+      Ubuntu-16.04:
+      - /etc/gshadow-:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-6.1.9
+          uid: 0
+          user: root
+    description: 'Ensure permissions on /etc/gshadow- are configured'
+misc:
+  sticky_bit_on_world_writable_directories:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-1.1.20
+        function: sticky_bit_on_world_writable_dirs
+    description: Ensure sticky bit is set on all world-writable directories
+  check_log_files_permission:
+    data:
+      Ubuntu-16.04:
+       tag: CIS-4.2.4
+       function: check_directory_files_permission
+       args:
+        - /var/log
+        - 740
+    description: Ensure permissions on all logfiles are configured
+  system_account_non_login:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-5.4.2
+        function: system_account_non_login
+    description: Ensure system accounts are non-login
+    control: Code change required for filtering the users by their login shell
+  default_group_for_root_account:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-5.4.3
+        function: default_group_for_root
+    description: 'Ensure default group for the root account is GID 0'
+  sshd_approved_macs:
+    data:
+      Ubuntu-16.04:
+       tag: CIS-5.2.11
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^MACs'
+         - '^MACs(.*)$'
+         - null
+         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+         - null
+         - ','
+    description: Ensure only approved MAC algorithms are used
+  no_world_writable_file:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.1.10
+        function: world_writable_file
+    description: Ensure no world writable files exist
+  no_unowned_file_or_directories:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.1.11
+        function: unowned_files_or_dir
+    description: Ensure no unowned files or directories exist
+  no_ungrouped_file_or_directories:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.1.12
+        function: ungrouped_files_or_dir
+    description: Ensure no ungrouped files or directories exist
+  ensure_password_fields_non_empty:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.1
+        function: check_password_fields_not_empty
+    description: Ensure password fields are not empty
+  root_is_only_uid_0_account:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.5
+        function: root_is_only_uid_0_account
+    description: 'Ensure root is the only UID 0 account'
+  check_path_integrity:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.6
+        function: check_path_integrity
+    description: Ensure root PATH Integrity
+  valid_home_directory:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.7
+        function: check_all_users_home_directory
+        args:
+        - 1000
+    description: 'Ensure all users home directories exist'
+  home_directory_permission:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.8
+        function: check_users_home_directory_permissions
+    description: 'Ensure users home directories permissions are 750 or more restrictive'
+  user_own_home_directory:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.9
+        function: check_users_own_their_home
+        args:
+        - 1000
+    description: Ensure users own their home directories
+  check_users_dot_files_not_writable:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.10
+        function: check_users_dot_files
+    description: Ensure users dot files are not group or world writable
+  check_users_not_forward_files:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.11
+        function: check_users_forward_files
+    description: 'Ensure no users have .forward files'
+  check_no_users_netrc_files:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.12
+        function: check_users_netrc_files
+    description: Ensure no users have .netrc files
+  check_netrc_files_not_world_writable:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.13
+        function: check_netrc_files_accessibility
+    description: 'Ensure users .netrc Files are not group or world accessible'
+  check_no_users_have_rhosts_files:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.14
+        function: check_users_rhosts_files
+    description: Ensure no users have .rhosts files
+  check_groups_validity_in_systemfiles:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.15
+        function: check_groups_validity
+    description: Ensure all groups in /etc/passwd exist in /etc/group
+  no_duplicate_sid:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.16
+        function: check_duplicate_uids
+    description: Ensure no duplicate UIDs exist
+  no_duplicate_gid:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.17
+        function: check_duplicate_gids
+    description: Ensure no duplicate GIDs exist
+  check_duplicate_unames_exist:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.18
+        function: check_duplicate_unames
+    description: Ensure no duplicate user names exist
+  check_duplicate_gnames_exist:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.19
+        function: check_duplicate_gnames
+    description: Ensure no duplicate group names exist
+systemctl:
+  whitelist:
+    rsyslog_enabled:
+      data:
+        Ubuntu-16.04:
+        - rsyslog:
+           tag: CIS-4.2.1.1
+      description: Ensure rsyslog Service is enabled
+    cron_deamon_enabled:
+      data:
+        Ubuntu-16.04:
+        - cron:
+           tag: CIS-5.1.1
+      description: Ensure cron daemon is enabled
+  blacklist:
+    avahi-daemon-disabled:
+      data:
+        Ubuntu-16.04:
+        - avahi-daemon:
+            tag: CIS-2.2.3
+      description: Ensure Avahi Server is not enabled
+    cups-disabled:
+      data:
+        Ubuntu-16.04:
+        - cups:
+            tag: CIS-2.2.4
+      description: Ensure CUPS is not enabled
+    dhcpd-disabled:
+      data:
+        Ubuntu-16.04:
+        - isc-dhcp-server:
+            tag: CIS-2.2.5
+      description: Ensure DHCP Server is not enabled
+    ldap-server-disabled:
+      data:
+        Ubuntu-16.04:
+        - slapd:
+            tag: CIS-2.2.6
+      description: Ensure LDAP server is not enabled
+    nfs-disabled:
+      data:
+        Ubuntu-16.04:
+        - nfs-kernel-server:
+            tag: CIS-2.2.7
+      description: Ensure NFS and RPC are not enabled
+#    rpc-disabled:
+#      data:
+#        Ubuntu-16.04:
+#        - rpcbind:
+#            tag: CIS-2.2.7
+#      description: Ensure NFS and RPC are not enabled(rpcbind-systemctl)
+    dns-server-disabled:
+      data:
+        Ubuntu-16.04:
+        - bind9:
+            tag: CIS-2.2.8
+      description: Ensure DNS Server is not enabled
+    ftp-server-disabled:
+      data:
+        Ubuntu-16.04:
+        - vsftpd:
+            tag: CIS-2.2.9
+        - proftpd:
+            tag: CIS-2.2.9
+        - pure-ftpd:
+            tag: CIS-2.2.9
+      description: Ensure FTP Server is not enabled
+    http-server-disabled:
+      data:
+        Ubuntu-16.04:
+        - apache2:
+            tag: CIS-2.2.10
+      description: Ensure HTTP server is not enabled
+    imap-pop3-server-disabled:
+      data:
+        Ubuntu-16.04:
+        - dovecot:
+            tag: CIS-2.2.11
+      description: Ensure IMAP and POP3 server is not enabled
+    samba-server-disabled:
+      data:
+        Ubuntu-16.04:
+        - samba:
+            tag: CIS-2.2.12
+      description: Ensure Samba is not enabled
+    http-proxy-server-disabled:
+      data:
+        Ubuntu-16.04:
+        - squid:
+            tag: CIS-2.2.13
+      description: Ensure HTTP Proxy Server is not enabled
+    snmp-server-disabled:
+      data:
+        Ubuntu-16.04:
+        - snmpd:
+            tag: CIS-2.2.14
+      description: Ensure SNMP Server is not enabled
+    nis-server-disabled:
+      data:
+        Ubuntu-16.04:
+        - nis:
+            tag: CIS-2.2.17
+      description: Ensure NIS Server is not enabled
+    rsh-socket-disabled:
+      data:
+        Ubuntu-16.04:
+        - rsh.socket:
+            tag: CIS-2.1.6
+      description: Ensure rsh Server is not enabled
+    rlogin-socket-disabled:
+      data:
+        Ubuntu-16.04:
+        - rlogin.socket:
+            tag: CIS-2.1.6
+      description: Ensure rsh Server is not enabled
+    rexec-socket-disabled:
+      data:
+        Ubuntu-16.04:
+        - rexec.socket:
+            tag: CIS-2.1.6
+      description: Ensure rsh Server is not enabled
+    telnet-server-disabled:
+      data:
+        Ubuntu-16.04:
+        - telnet.socket:
+            tag: CIS-2.1.8
+      description: Ensure telnet server is not enabled
+    rsync-service-disabled:
+      data:
+        Ubuntu-16.04:
+        - rsync:
+            tag: CIS-2.2.16
+      description: Ensure rsync service is not enabled

--- a/hubblestack_nova_profiles/cis/debian-9-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9-level-1-scored-v1-0-0.yaml
@@ -1,112 +1,30 @@
 grep:
   whitelist:
-    disable_mount_cramfs:
+    single_user_mode_check:
       data:
-        Ubuntu-16.04:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: cramfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.1
-      description: Ensure mounting of cramfs filesystems is disabled
-    disable_mount_freevxfs:
+        Debian*9:
+        - /etc/shadow:
+            pattern: '^root:[*\!]:'
+            tag: CIS-1.4.3
+      description: Ensure authentication required for single user mode
+    mounts_home_partition_nodev:
       data:
-        Ubuntu-16.04:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: freevxfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.2
-      description: Ensure mounting of freevxfs filesystems is disabled
-    disable_mount_jffs2:
-      data:
-        Ubuntu-16.04:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: jffs2
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.3
-      description: Ensure mounting of jffs2 filesystems is disabled
-    disable_mount_hfs:
-      data:
-        Ubuntu-16.04:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.4
-      description: Ensure mounting of hfs filesystems is disabled
-    disable_mount_hfsplus:
-      data:
-        Ubuntu-16.04:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: hfsplus
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.5
-      description: Ensure mounting of hfsplus filesystems is disabled
-    disable_mount_squashfs:
-      data:
-        Ubuntu-16.04:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: squashfs
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.6
-      description: Ensure mounting of squashfs filesystems is disabled
-    disable_mount_udf:
-      data:
-        Ubuntu-16.04:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: udf
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.7
-      description: Ensure mounting of udf filesystems is disabled
-    disable_mount_fat:
-      data:
-        Ubuntu-16.04:
-        - /etc/modprobe.d:
-            match_output: /bin/true
-            pattern: vfat
-            grep_args:
-              - '-r'
-            tag: CIS-1.1.1.8
-      description: Ensure mounting of FAT filesystems is disabled
-    mounts_dev_shm_partition_nodev:
-      data:
-        Ubuntu-16.04:
+        Debian*9:
         - /proc/mounts:
             match_output: nodev
-            pattern: /dev/shm
+            pattern: /home
             tag: CIS-1.1.14
-      description: Ensure nodev option set on /dev/shm partition
-    mounts_dev_shm_partition_noexec:
+      description: Ensure nodev option set on /home partition
+    mounts_tmp_partition:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /proc/mounts:
-            match_output: noexec
-            pattern: /dev/shm
-            tag: CIS-1.1.16
-      description: Ensure noexec option set on /dev/shm partition
-    mounts_dev_shm_partition_nosuid:
-      data:
-        Ubuntu-16.04:
-        - /proc/mounts:
-            match_output: nosuid
-            pattern: /dev/shm
-            tag: CIS-1.1.15
-      description: Ensure nosuid option set on /dev/shm partition
+            pattern: /tmp
+            tag: CIS-1.1.2
+      description: Ensure /tmp is configured
     mounts_tmp_partition_nodev:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /proc/mounts:
             match_output: nodev
             pattern: /tmp
@@ -114,55 +32,95 @@ grep:
       description: Ensure nodev option set on /tmp partition
     mounts_tmp_partition_nosuid:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /proc/mounts:
             match_output: nosuid
             pattern: /tmp
             tag: CIS-1.1.4
       description: Ensure nosuid option set on /tmp partition
+    mounts_tmp_partition_noexec:
+      data:
+        Debian*9:
+        - /proc/mounts:
+            match_output: noexec
+            pattern: /tmp
+            tag: CIS-1.1.5
+      description: Ensure noexec option set on /tmp partition
     mount_var_tmp_partition_nodev:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /proc/mounts:
             match_output: nodev
             pattern: /var/tmp
-            tag: CIS-1.1.7
+            tag: CIS-1.1.8
       description: Ensure nodev option set on /var/tmp partition
     mount_var_tmp_partition_nosuid:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /proc/mounts:
             match_output: nosuid
             pattern: /var/tmp
-            tag: CIS-1.1.8
+            tag: CIS-1.1.9
       description: Ensure nosuid option set on /var/tmp partition
     mount_var_tmp_partition_noexec:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /proc/mounts:
             match_output: noexec
             pattern: /var/tmp
-            tag: CIS-1.1.9
+            tag: CIS-1.1.10
       description: Ensure noexec option set on /var/tmp partition
+    mounts_dev_shm_partition_nodev:
+      data:
+        Debian*9:
+        - /proc/mounts:
+            match_output: nodev
+            pattern: /dev/shm
+            tag: CIS-1.1.15
+      description: Ensure nodev option set on /dev/shm partition
+    mounts_dev_shm_partition_nosuid:
+      data:
+        Debian*9:
+        - /proc/mounts:
+            match_output: nosuid
+            pattern: /dev/shm
+            tag: CIS-1.1.16
+      description: Ensure nosuid option set on /dev/shm partition
+    mounts_dev_shm_partition_noexec:
+      data:
+        Debian*9:
+        - /proc/mounts:
+            match_output: noexec
+            pattern: /dev/shm
+            tag: CIS-1.1.17
+      description: Ensure noexec option set on /dev/shm partition
     aide_filesystem_scans:
       data:
-        Ubuntu-16.04:
-        - /var/spool/cron/crontabs/root:
-#            match_output: '0 5 * * * /usr/bin/aide --check'
+        Debian*9:
+        - /etc/cron.d:
             pattern: aide
+            grep_args:
+              - '-r'
             tag: CIS-1.3.2
       description: Ensure filesystem integrity is regularly checked
+    boot_loader_passwd:
+      data:
+        Debian*9:
+        - /boot/grub/grub.cfg:
+            pattern: password
+            tag: CIS-1.4.2
+      description: Ensure bootloader password is set
     core_hard_limit:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/security/limits.conf:
             match_output: '0'
             pattern: hard core
             tag: CIS-1.5.1
       description: Ensure core dumps are restricted
-    ntp_restrict_default:
+    configure_ntp:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/ntp.conf:
             pattern: '^restrict'
             match_output: default
@@ -177,17 +135,19 @@ grep:
             pattern: RUNASUSER=
             tag: CIS-2.2.1.2
       description: Ensure NTP is configured
-    local_mta:
+    configure_chrony:
       data:
-        Ubuntu-16.04:
-          - /etc/postfix/main.cf:
-              pattern: '^inet_interfaces'
-              match_output: localhost
-              tag: CIS-2.2.15
-      description: Ensure mail transfer agent is configured for local-only mode
+        Debian*9:
+        - /etc/chrony.conf:
+            tag: CIS-2.2.1.3
+            pattern: '^server'
+        - /etc/sysconfig/chronyd:
+            tag: CIS-2.2.1.3
+            pattern: 'chrony'
+      description: Ensure chrony is configured
     rsync:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/default/rsync:
             pattern: ^RSYNC_ENABLE
             match_output: 'false'
@@ -195,54 +155,53 @@ grep:
       description: Ensure rsync service is not enabled
     hosts_allow:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/hosts.allow:
             pattern: ALL
             tag: CIS-3.4.2
       description: Ensure /etc/hosts.allow is configured
     hosts_deny:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/hosts.deny:
             pattern:  ALL
             tag: CIS-3.4.3
       description: Ensure /etc/hosts.deny is configured
     firewall_default_deny:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/iptables/rules.v4:
             pattern: :INPUT
             match_output: DROP
-            tag: CIS-3.6.2
+            tag: CIS-3.5.1.1
         - /etc/iptables/rules.v4:
             pattern: :FORWARD
             match_pattern: DROP
-            tag: CIS-3.6.2
+            tag: CIS-3.5.1.1
         - /etc/iptables/rules.v4:
             pattern: :OUTPUT
             match_output: DROP
-            tag: CIS-3.6.2
+            tag: CIS-3.5.1.1
       description: Ensure default deny firewall policy
     firewall_accept_lo:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/iptables/rules.v4:
             pattern: '"\-A INPUT \-i lo \-j"'
             match_output: ACCEPT
-            tag: CIS-3.6.3
+            tag: CIS-3.5.1.2
         - /etc/iptables/rules.v4:
             pattern: '"\-A OUTPUT \-o lo \-j"'
             match_output: ACCEPT
-            tag: CIS-3.6.3
+            tag: CIS-3.5.1.2
         - /etc/iptables/rules.v4:
             pattern: '"\-A INPUT \-s 127.0.0.0/8 \-j"'
             match_output: DROP
-            tag: CIS-3.6.3
+            tag: CIS-3.5.1.2
       description: Ensure loopback traffic is configured
-#3.6.5 is not implemented as need code changes
     rsyslog_file_perms:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/rsyslog.conf:
             pattern: '^\$FileCreateMode'
             match_output: '0640'
@@ -251,14 +210,38 @@ grep:
       description: Ensure rsyslog default file permissions configured
     rsyslog_remote_logging:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/rsyslog.conf:
             pattern: ^*.*[^I][^I]*@
             tag: CIS-4.2.1.4
       description: Ensure rsyslog is configured to send logs to a remote log host
+    syslog-ng_file_perms:
+      data:
+        Debian*9:
+        - /etc/syslog-ng/syslog-ng.conf:
+            pattern: ^options
+            match_output: 'perm(0640)'
+            tag: CIS-4.2.2.3
+      description: Ensure syslog-ng default file permissions configured
+    lockout_account:
+      data:
+        Debian*9:
+        - /etc/pam.d/system-auth:
+            pattern: '"^auth\s+required\s+pam_faillock\.so.*"'
+            match_output: deny=5
+            grep_args:
+              - '-E'
+            tag: CIS-5.3.2
+        - /etc/pam.d/password-auth:
+            pattern: '"^auth\s+required\s+pam_faillock\.so.*"'
+            match_output: deny=5
+            grep_args:
+              - '-E'
+            tag: CIS-5.3.2
+      description: Ensure lockout for failed password attempts is configured
     pam_password_reuse:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/pam.d/common-password:
             pattern: remember
             match_output: 'remember=5'
@@ -266,128 +249,128 @@ grep:
       description: Ensure password reuse is limited
     ssh_version_2:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/ssh/sshd_config:
             pattern: ^Protocol
             match_output: Protocol\s+2
             match_output_regex: True
-            tag: CIS-5.2.2
+            tag: CIS-5.2.4
       description: Ensure SSH Protocol is set to 2
     ssh_log_level:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/ssh/sshd_config:
             pattern: ^LogLevel
             match_output: LogLevel\s+INFO
             match_output_regex: True
-            tag: CIS-5.2.3
+            tag: CIS-5.2.5
       description: Ensure SSH LogLevel is set to INFO
     ssh_disable_xforward:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/ssh/sshd_config:
             pattern: ^X11Forwarding
             match_output: X11Forwarding\s+no
             match_output_regex: True
-            tag: CIS-5.2.4
+            tag: CIS-5.2.6
       description: Ensure SSH X11 forwarding is disabled
     ssh_auth_retries:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/ssh/sshd_config:
             pattern: ^MaxAuthTries
             match_output_regex: True
             match_output: "^MaxAuthTries +[1-4]$"
-            tag: CIS-5.2.5
+            tag: CIS-5.2.7
       description: Ensure SSH MaxAuthTries is set to 4 or less
     ssh_ignore_rhosts:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/ssh/sshd_config:
             pattern: ^IgnoreRhosts
             match_output: IgnoreRhosts\s+yes
             match_output_regex: True
-            tag: CIS-5.2.6
+            tag: CIS-5.2.8
       description: Ensure SSH IgnoreRhosts is enabled
     ssh_hostbased_auth:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/ssh/sshd_config:
             pattern: ^HostbasedAuthentication
             match_output: HostbasedAuthentication\s+no
             match_output_regex: True
-            tag: CIS-5.2.7
+            tag: CIS-5.2.9
       description: Ensure SSH HostbasedAuthentication is disabled
     ssh_permit_root:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/ssh/sshd_config:
             pattern: ^PermitRootLogin
             match_output: PermitRootLogin\s+no
             match_output_regex: True
-            tag: CIS-5.2.8
+            tag: CIS-5.2.10
       description: Ensure SSH root login is disabled
     ssh_permit_empty_pw:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/ssh/sshd_config:
             pattern: ^PermitEmptyPasswords
             match_output: PermitEmptyPasswords\s+no
             match_output_regex: True
-            tag: CIS-5.2.9
+            tag: CIS-5.2.11
       description: Ensure SSH PermitEmptyPasswords is disabled
     ssh_permit_user_env:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/ssh/sshd_config:
             pattern: ^PermitUserEnvironment
             match_output: PermitUserEnvironment\s+no
             match_output_regex: True
-            tag: CIS-5.2.10
+            tag: CIS-5.2.12
       description: Ensure SSH PermitUserEnvironment is disabled
     sshd_idle_timeout:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/ssh/sshd_config:
             pattern: ^ClientAliveInterval
             match_output: ^ClientAliveInterval +([1-2]{0,1}\d{1,2}|300)$
             match_output_regex: True
-            tag: CIS-5.2.12
+            tag: CIS-5.2.16
         - /etc/ssh/sshd_config:
             pattern: ClientAliveCountMax
             match_output: "^ClientAliveCountMax +[0-3]$"
             match_output_regex: True
-            tag: CIS-5.2.12
+            tag: CIS-5.2.16
       description: Ensure SSH Idle Timeout Interval is configured
     sshd_gracetime:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/ssh/sshd_config:
             pattern: ^LoginGraceTime
             match_output: ^LoginGraceTime ([0-5]{0,1}\d|60|1m)$
             match_output_regex: True
-            tag: CIS-5.2.13
+            tag: CIS-5.2.17
       description: Ensure SSH LoginGraceTime is set to one minute or less
     ssh_limit_access:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/ssh/sshd_config:
             pattern: '^AllowUsers|^AllowGroups|^DenyUsers|^DenyGroups'
             grep_args:
               - '-E'
-            tag: CIS-5.2.14
+            tag: CIS-5.2.18
       description:  Ensure SSH access is limited
     sshd_banner:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/ssh/sshd_config:
             match_output: "/etc/issue.net"
             pattern: ^Banner
-            tag: CIS-5.2.15
+            tag: CIS-5.2.19
       description: Ensure SSH warning banner is configured
     pam_pwquality_try_first_pass:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/pam.d/common-password:
             match_output: try_first_pass
             pattern: pam_pwquality.so
@@ -419,7 +402,7 @@ grep:
       description: Ensure password creation requirements are configured
     password_hash:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/pam.d/common-password:
             pattern: '"^password\s.*\w+.*\s+pam_unix.so\s+\w+\s"'
             match_output: sha512
@@ -429,7 +412,7 @@ grep:
       description: Ensure password hashing algorithm is SHA-512
     limit_su_access:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/pam.d/su:
             pattern: pam_wheel.so
             match_output: use_uid
@@ -440,7 +423,7 @@ grep:
       description: Ensure access to the su command is restricted
     password_max_days:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/login.defs:
             pattern: PASS_MAX_DAYS
             match_output: '90'
@@ -448,7 +431,7 @@ grep:
       description: Ensure password expiration is 90 days or less
     password_min_days:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/login.defs:
             pattern: PASS_MIN_DAYS
             match_output: '7'
@@ -456,7 +439,7 @@ grep:
       description: Ensure minimum days between password changes is 7 or more
     password_warn_days:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/login.defs:
             pattern: PASS_WARN_AGE
             match_output: '7'
@@ -464,7 +447,7 @@ grep:
       description: Ensure password expiration warning days is 7 or more
     default_umask:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/bash.bashrc:
             pattern: umask
             match_pattern: '0[2367]7'
@@ -480,15 +463,189 @@ grep:
       description: Ensure default user umask is 027 or more restrictive
     passwd_inactive:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/default/useradd:
             pattern: INACTIVE=30
             tag: CIS-5.4.1.4
       description: Ensure inactive password lock is 30 days or less
   blacklist:
+    disable_mount_cramfs:
+      data:
+        Debian*9:
+        - /proc/modules:
+            pattern: "^cramfs "
+            tag: CIS-1.1.1.1
+      description: Ensure mounting of cramfs filesystems is disabled
+    disable_mount_freevxfs:
+      data:
+        Debian*9:
+        - /proc/modules:
+            pattern: "^freevxfs "
+            tag: CIS-1.1.1.2
+      description: Ensure mounting of freevxfs filesystems is disabled
+    disable_mount_jffs2:
+      data:
+        Debian*9:
+        - /proc/modules:
+            pattern: "^jffs2 "
+            tag: CIS-1.1.1.3
+      description: Ensure mounting of jffs2 filesystems is disabled
+    disable_mount_hfs:
+      data:
+        Debian*9:
+        - /proc/modules:
+            pattern: "^hfs "
+            tag: CIS-1.1.1.4
+      description: Ensure mounting of hfs filesystems is disabled
+    disable_mount_hfsplus:
+      data:
+        Debian*9:
+        - /proc/modules:
+            pattern: "^hfsplus "
+            tag: CIS-1.1.1.5
+      description: Ensure mounting of hfsplus filesystems is disabled
+    disable_mount_squashfs:
+      data:
+        Debian*9:
+        - /proc/modules:
+            pattern: "^squashfs "
+            tag: CIS-1.1.1.6
+      description: Ensure mounting of squashfs filesystems is disabled
+    disable_mount_udf:
+      data:
+        Debian*9:
+        - /proc/modules:
+            pattern: "^udf "
+            tag: CIS-1.1.1.7
+      description: Ensure mounting of udf filesystems is disabled
+    disable_mount_fat:
+      data:
+        Debian*9:
+        - /proc/modules:
+            pattern: "^vfat "
+            tag: CIS-1.1.1.8
+      description: Ensure mounting of FAT filesystems is disabled
+    chargen_disabled:
+      data:
+        Debian*9:
+        - /etc/xinetd.d/chargen-dgram:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.1.1
+            match_on_file_missing: False
+        - /etc/xinetd.d/chargen-stream:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.1.1
+            match_on_file_missing: False
+      description: Ensure chargen services are not enabled
+    daytime_disabled:
+      data:
+        Debian*9:
+        - /etc/xinetd.d/daytime-dgram:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.1.2
+            match_on_file_missing: False
+        - /etc/xinetd.d/daytime-stream:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.1.2
+            match_on_file_missing: False
+      description: Ensure daytime services are not enabled
+    discard_disabled:
+      data:
+        Debian*9:
+        - /etc/xinetd.d/discard-dgram:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.1.3
+            match_on_file_missing: False
+        - /etc/xinetd.d/discard-stream:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.1.3
+            match_on_file_missing: False
+      description: Ensure discard services are not enabled
+    echo_disabled:
+      data:
+        Debian*9:
+        - /etc/xinetd.d/echo-dgram:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.1.4
+            match_on_file_missing: False
+        - /etc/xinetd.d/echo-stream:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.1.4
+            match_on_file_missing: False
+      description: Ensure echo services are not enabled
+    time_disabled:
+      data:
+        Debian*9:
+        - /etc/xinetd.d/time-dgram:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.1.5
+            match_on_file_missing: False
+        - /etc/xinetd.d/time-stream:
+            pattern: disable
+            match_output: 'no'
+            tag: CIS-2.1.1.5
+            match_on_file_missing: False
+      description: Ensure time services are not enabled
+    banner_os_info_motd:
+      data:
+        Debian*9:
+        - /etc/motd:
+            pattern: '"(\\\v|\\\r|\\\m|\\\s)"'
+            grep_args:
+              - '-E'
+            tag: CIS-1.7.1.1
+      description: Ensure message of the day is configured properly
+    legacy_passwd_entries_passwd:
+      data:
+        Debian*9:
+        - /etc/passwd:
+            pattern: '^+'
+            tag: CIS-6.2.2
+      description: Ensure no legacy "+" entries exist in /etc/passwd File
+    legacy_entries_shadow:
+      data:
+        Debian*9:
+        - /etc/shadow:
+            pattern: '^+'
+            tag: CIS-6.2.3
+      description: Ensure no legacy "+" entries exist in /etc/shadow File
+    legacy_entries_group:
+      data:
+        Debian*9:
+        - /etc/group:
+            pattern: '^+'
+            tag: CIS-6.2.4
+      description: Ensure no legacy "+" entries exist in /etc/group File
+    ensure_local_login_warning:
+      data:
+        Debian*9:
+        - /etc/issue:
+            pattern: '"(\\\v|\\\r|\\\m|\\\s)"'
+            grep_args:
+              - '-E'
+            tag: CIS-1.7.1.2
+      description: Ensure local login warning banner is configured properly
+    ensure_remote_login_warning:
+      data:
+        Debian*9:
+        - /etc/issue.net:
+            pattern: '"(\\\v|\\\r|\\\m|\\\s)"'
+            grep_args:
+              - '-E'
+            tag: CIS-1.7.1.3
+      description: Ensure remote login warning banner is configured properly
     talkd:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/xinetd*:
             pattern: '^talk'
             grep_args:
@@ -502,7 +659,7 @@ grep:
       description: Ensure talk server is not enabled
     telnet:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/xinetd*:
             pattern: '^telnet'
             greps_args:
@@ -511,396 +668,269 @@ grep:
       description: Ensure Telnet Server is not Enabled
     tftp:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - /etc/xinetd*:
             pattern: '^tftp'
             grep_args:
               - '-r'
             tag: CIS-2.1.9
       description: Ensure tftp server is not enabled
-    chargen:
-      data:
-        Ubuntu-16.04:
-        - /etc/xinetd.d/chargen:
-            match_output: '^\s*disable\s*=\s*no'
-            pattern: chargen-stream
-            match_output_regex: True
-            grep_args:
-              - '-B'
-              - '3'
-            tag: CIS-2.1.1
-        - /etc/xinetd.d/chargen:
-            match_output: '^\s*disable\s*=\s*no'
-            pattern: chargen-dgram
-            match_output_regex: True
-            grep_args:
-              - '-B'
-              - '3'
-            tag: CIS-2.1.1
-      description: Ensure Chargen Services are not Enabled
-    daytime:
-      data:
-        Ubuntu-16.04:
-        - /etc/xinetd.d/daytime:
-            match_output: '^\s*disable\s*=\s*no'
-            pattern: daytime-stream
-            match_output_regex: True
-            grep_args:
-              - '-B'
-              - '3'
-            tag: CIS-2.1.2
-        - /etc/xinetd.d/daytime:
-            match_output: '^\s*disable\s*=\s*no'
-            pattern: daytime-dgram
-            match_output_regex: True
-            grep_args:
-              - '-B'
-              - '3'
-            tag: CIS-2.1.2
-      description: Ensure daytime services are not enabled
-    echo:
-      data:
-        Ubuntu-16.04:
-        - /etc/xinetd.d/echo:
-            match_output: '^\s*disable\s*=\s*no'
-            pattern: echo-stream
-            match_output_regex: True
-            grep_args:
-              - '-B'
-              - '3'
-            tag: CIS-2.1.4
-        - /etc/xinetd.d/echo:
-            match_output: '^\s*disable\s*=\s*no'
-            pattern: echo-dgram
-            match_output_regex: True
-            grep_args:
-              - '-B'
-              - '3'
-            tag: CIS-2.1.4
-      description: Ensure echo services are not enabled
-    discard:
-      data:
-        Ubuntu-16.04:
-        - /etc/xinetd.d/discard:
-            match_output: '^\s*disable\s*=\s*no'
-            pattern: discard-stream
-            match_output_regex: True
-            grep_args:
-              - '-B'
-              - '3'
-            tag: CIS-2.1.3
-        - /etc/xinetd.d/discard:
-            match_output: '^\s*disable\s*=\s*no'
-            pattern: discard-dgram
-            match_output_regex: True
-            grep_args:
-              - '-B'
-              - '3'
-            tag: CIS-2.1.3
-      description: Ensure discard services are not enabled
-    time:
-      data:
-        Ubuntu-16.04:
-        - /etc/xinetd.d/time:
-            match_output: '^\s*disable\s*=\s*no'
-            pattern: time-stream
-            match_output_regex: True
-            grep_args:
-              - '-B'
-              - '3'
-            tag: CIS-2.1.5
-        - /etc/xinetd.d/time:
-            match_output: '^\s*disable\s*=\s*no'
-            pattern: time-dgram
-            match_output_regex: True
-            grep_args:
-              - '-B'
-              - '3'
-            tag: CIS-2.1.5
-      description: Ensure time Services are not Enabled
-    banner_os_info_motd:
-      data:
-        Ubuntu-16.04:
-        - /etc/motd:
-            pattern: '\v'
-            tag: CIS-1.7.1.1
-        - /etc/motd:
-            pattern: '\r'
-            tag: CIS-1.7.1.1
-        - /etc/motd:
-            pattern: '\m'
-            tag: CIS-1.7.1.1
-        - /etc/motd:
-            pattern: '\s'
-            tag: CIS-1.7.1.1
-      description: Ensure message of the day is configured properly
-    legacy_entries_passwd:
-      data:
-        Ubuntu-16.04:
-        - /etc/passwd:
-            pattern: '^+'
-            tag: CIS-6.2.2
-      description: Ensure No Legacy "+" Entries Exist in /etc/passwd File
-    legacy_entries_shadow:
-      data:
-        Ubuntu-16.04:
-        - /etc/shadow:
-            pattern: '^+'
-            tag: CIS-6.2.3
-      description: Ensure No Legacy "+" Entries Exist in /etc/shadow File
-    legacy_entries_group:
-      data:
-        Ubuntu-16.04:
-        - /etc/group:
-            pattern: '^+'
-            tag: CIS-6.2.4
-      description: Ensure No Legacy "+" Entries Exist in /etc/group File
 
 service:
   blacklist:
     autofs:
       data:
-        Ubuntu-16.04:
-        - autofs: CIS-1.1.21
+        Debian*9:
+        - autofs: CIS-1.1.22
       description: Disable Automounting
-    xinetd:
-      data:
-        Ubuntu-16.04:
-          - xinetd: CIS-2.1.10
-      description: Ensure xinetd is not enabled
     avahi_daemon:
       data:
-        Ubuntu-16.04:
+        Debian*9:
           - avahi-daemon: CIS-2.2.3
       description: Ensure Avahi Server is not enabled
     cups:
       data:
-        Ubuntu-16.04:
+        Debian*9:
           - cups: CIS-2.2.4
       description: Ensure CUPS is not enabled
     dhcp-server:
       data:
-        Ubuntu-16.04:
+        Debian*9:
           - isc-dhcp-server: CIS-2.2.5
           - isc-dhcp-server6: CIS-2.2.5
       description: Ensure DHCP Server is not enabled
     slapd:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - slapd: CIS-2.2.6
       description: Ensure LDAP server is not enabled
     nfs-service:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - nfs-kernel-server: CIS-2.2.7
       description: Ensure NFS and RPC are not enabled
     rpc-bind-service:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - rpcbind: CIS-2.2.7
       description: Ensure NFS and RPC are not enabled
     bind9:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - bind9: CIS-2.2.8
       description: Ensure DNS Server is not enabled
     http-server-service:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - apache2: CIS-2.2.10
       description: Ensure HTTP server is not enabled
     imap-pop3-server-service:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - dovecot: CIS-2.2.11
       description: Ensure IMAP and POP3 server is not enabled
 
   whitelist:
-    rsyslog:
+    syslog-ng_running:
       data:
-        Ubuntu-16.04:
-          - rsyslog: CIS-4.2.1.1
-      description: Ensure the rsyslog Service is enabled
+        Debian*9:
+        - syslog-ng: CIS-4.2.2.1
+      description: Ensure syslog-ng service is enabled
     cron:
       data:
-        Ubuntu-16.04:
+        Debian*9:
           - cron: CIS-5.1.1
       description: Enable cron Daemon
 
 sysctl:
   disable_suid_dumpable:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - fs.suid_dumpable:
           match_output: '0'
           tag: CIS-1.5.1
     description: Restrict Core Dumps
   randomize_va_space:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - kernel.randomize_va_space:
           match_output: '2'
           tag: CIS-1.5.3
     description: Ensure address space layout randomization (ASLR) is enabled
   disable_ip4_ip_forward:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - net.ipv4.ip_forward:
           match_output: '0'
           tag: CIS-3.1.1
     description: Ensure IP forwarding is disabled
   disable_packet_redirect:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - net.ipv4.conf.all.send_redirects:
           match_output: '0'
           tag: CIS-3.1.2
     description: Ensure packet redirect sending is disabled
   disable_source_routed_packets:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - net.ipv4.conf.all.accept_source_route:
           match_output: '0'
           tag: CIS-3.2.1
     description: Ensure source routed packets are not accepted
   disable_icmp_redirect:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - net.ipv4.conf.all.accept_redirects:
           match_output: '0'
           tag: CIS-3.2.2
     description: Ensure ICMP redirects are not accepted
   disable_secure_icmp_redirect:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - net.ipv4.conf.all.secure_redirects:
           match_output: '0'
           tag: CIS-3.2.3
     description: Ensure secure ICMP redirects are not accepted
   log_martians:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - net.ipv4.conf.all.log_martians:
           match_output: '1'
           tag: CIS-3.2.4
     description: Ensure suspicious packets are logged
   ignore_broadcast:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - net.ipv4.icmp_echo_ignore_broadcasts:
           match_output: '1'
           tag: CIS-3.2.5
     description: Ensure broadcast ICMP requests are ignored
   bogus_errors:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - net.ipv4.icmp_ignore_bogus_error_responses:
           match_output: '1'
           tag: CIS-3.2.6
     description: Ensure bogus ICMP responses are ignored
   rp_filter:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - net.ipv4.conf.all.rp_filter:
           match_output: '1'
           tag: CIS-3.2.7
     description: Ensure Reverse Path Filtering is enabled
   tcp_syncookies:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - net.ipv4.tcp_syncookies:
           match_output: '1'
           tag: CIS-3.2.8
     description: Ensure TCP SYN Cookies is enabled
+  ipv6_adverts:
+    data:
+      Debian*9:
+      - net.ipv6.conf.all.accept_ra:
+          match_output: '0'
+          tag: CIS-3.2.9
+      - net.ipv6.conf.default.accept_ra:
+          match_output: '0'
+          tag: CIS-3.2.9
+    description: Ensure IPv6 router advertisements are not accepted
 
 pkg:
   blacklist:
+    xinetd:
+      data:
+        Debian*9:
+          - xinetd: CIS-2.1.1
+      description: Ensure xinetd is not installed
+    openbsd-inetd:
+      data:
+        Debian*9:
+        - openbsd-inetd: CIS-2.1.2
+      description: Ensure openbsd-inetd is not installed
     prelink:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - prelink: CIS-1.5.4
       description: Ensure prelink is disabled
     nis:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - nis: CIS-2.3.1
       description: Ensure NIS Client is not installed
     talkd:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - talkd: CIS-2.1.7
       description: Ensure Talk Server is not installed
     telnet-server:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - telnetd: CIS-2.1.8
       description: Ensure Telnet Server is not installed
     telnet-client:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - telnet: CIS-2.3.4
-      description: Ensure Telnet Client is not installed
+      description: Ensure telnet client is not installed
     ldap-client:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - ldap-utils: CIS-2.3.5
-      description: Ensure LDAP Client is not installed
+      description: Ensure LDAP client is not installed
     talk:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - talk: CIS-2.3.3
-      description: Ensure Talk Client is not installed
+      description: Ensure talk client is not installed
     xserver:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - xserver-xorg-core\*: CIS-2.2.2
-      description: Ensure the X Window System is not installed
+      description: Ensure X Window System is not installed
     biosdevname:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - biosdevname: CIS-6.17
       description: Ensure biosdevname is not enabled
     rsh-server:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - rsh-server: CIS-2.1.6
       description: Ensure rsh server is not enabled
     rsh-client:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - rsh-client: CIS-2.3.2
         - rsh-redone-client: CIS-2.3.2
       description: Ensure rsh client is not installed
   whitelist:
     ntp:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - ntp: CIS-2.2.1.2
       description: Configure Network Time Protocol (NTP)
     aide:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - aide: CIS-1.3.1
       description: Ensure AIDE is installed
     tcpd:
       data:
-        Ubuntu-16.04:
-        - tcpd: CIS-3.4.1
+        Debian*9:
+        - tcpd: CIS-3.3.1
       description: Ensure TCP Wrappers is installed
-    rsyslog:
-      data:
-        Ubuntu-16.04:
-        - rsyslog: CIS-4.2.3
-      description: Ensure rsyslog is installed
     iptables:
       data:
-        Ubuntu-16.04:
-        - iptables: CIS-3.6.1
+        Debian*9:
+        - iptables: CIS-3.5.3
       description: Ensure iptables is installed
 stat:
   grub_cfg_perms:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /boot/grub/grub.cfg:
           gid: 0
           group: root
@@ -912,31 +942,31 @@ stat:
     description: Ensure permissions on bootloader config are configured
   hosts_allow_perms:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/hosts.allow:
           gid: 0
           group: root
           mode: 644
           allow_more_strict: true
-          tag: CIS-3.4.4
+          tag: CIS-3.3.4
           uid: 0
           user: root
     description: Ensure permissions on /etc/hosts.allow are configured
   hosts_deny_perms:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/hosts.deny:
           gid: 0
           group: root
           mode: 644
           allow_more_strict: true
-          tag: CIS-3.4.5
+          tag: CIS-3.3.5
           uid: 0
           user: root
     description: Ensure permissions on /etc/hosts.deny are configured
   crontab_own_perms:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/crontab:
           gid: 0
           group: root
@@ -948,7 +978,7 @@ stat:
     description:  Ensure permissions on /etc/crontab are configured
   cron_hourly_own_perms:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/cron.hourly:
           gid: 0
           group: root
@@ -960,7 +990,7 @@ stat:
     description:  Ensure permissions on /etc/cron.hourly are configured
   cron_daily_own_perms:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/cron.daily:
           gid: 0
           group: root
@@ -972,7 +1002,7 @@ stat:
     description:  Ensure permissions on /etc/cron.daily are configured
   cron_weekly_own_perms:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/cron.weekly:
           gid: 0
           group: root
@@ -984,7 +1014,7 @@ stat:
     description:  Ensure permissions on /etc/cron.weekly are configured
   cron_monthly_own_perms:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/cron.monthly:
           gid: 0
           group: root
@@ -996,7 +1026,7 @@ stat:
     description:  Ensure permissions on /etc/cron.monthly are configured
   cron_d_own_perms:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/cron.d:
           gid: 0
           group: root
@@ -1008,7 +1038,7 @@ stat:
     description:  Ensure permissions on /etc/cron.d are configured
   at_cron_allow:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/cron.deny:
           gid: null
           group: null
@@ -1042,7 +1072,7 @@ stat:
     description: Ensure at/cron is restricted to authorized users
   sshd_config:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/ssh/sshd_config:
           uid: 0
           gid: 0
@@ -1052,9 +1082,20 @@ stat:
           allow_more_strict: true
           tag: CIS-5.2.1
     description: Ensure permissions on /etc/ssh/sshd_config are configured
+  warning_banner_motd:
+    data:
+      Debian*9:
+      - /etc/motd:
+          gid: 0
+          group: root
+          mode: 644
+          tag: CIS-1.7.1.4
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/motd are configured
   banner_files_issue:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/issue:
           uid: 0
           gid: 0
@@ -1064,9 +1105,20 @@ stat:
           allow_more_strict: true
           tag: CIS-1.7.1.5
     description: Ensure permissions on /etc/issue are configured
+  banner_files_issue_net:
+    data:
+      Debian*9:
+      - /etc/issue.net:
+          gid: 0
+          group: root
+          mode: 644
+          tag: CIS-1.7.1.6
+          uid: 0
+          user: root
+    description: Ensure permissions on /etc/issue.net are configured
   passwd_perms:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/passwd:
           uid: 0
           gid: 0
@@ -1077,7 +1129,7 @@ stat:
     description: Ensure permissions on /etc/passwd are configured
   shadow_perms:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/shadow:
           uid: 0
           gid: 42
@@ -1088,7 +1140,7 @@ stat:
     description: Ensure permissions on /etc/shadow are configured
   group_perms:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/group:
           uid: 0
           gid: 0
@@ -1099,7 +1151,7 @@ stat:
     description: Ensure permissions on /etc/group are configured
   gshadow_owner_group:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/gshadow:
           uid: 0
           gid: 42
@@ -1109,7 +1161,7 @@ stat:
     description: Ensure permissions on /etc/gshadow are configured
   passwd-_own_perm:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/passwd-:
           gid: 0
           group: root
@@ -1120,7 +1172,7 @@ stat:
     description: Ensure permissions on /etc/passwd- are configured
   shadow-_own_perm:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/shadow-:
           gid: 0
           group: root
@@ -1131,7 +1183,7 @@ stat:
     description: 'Ensure permissions on /etc/shadow- are configured'
   group-_own_perm:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/group-:
           gid: 0
           group: root
@@ -1142,7 +1194,7 @@ stat:
     description: 'Ensure permissions on /etc/group- are configured'
   gshadow-_own_perm:
     data:
-      Ubuntu-16.04:
+      Debian*9:
       - /etc/gshadow-:
           gid: 0
           group: root
@@ -1152,15 +1204,23 @@ stat:
           user: root
     description: 'Ensure permissions on /etc/gshadow- are configured'
 misc:
-  sticky_bit_on_world_writable_directories:
+  mail_configured_for_local_only_mode:
     data:
-      Ubuntu-16.04:
-        tag: CIS-1.1.20
-        function: sticky_bit_on_world_writable_dirs
-    description: Ensure sticky bit is set on all world-writable directories
+      Debian*9:
+        tag: CIS-2.2.15
+        function: mail_conf_check
+    description: Ensure mail transfer agent is configured for local-only mode
+  check_any_package:
+    data:
+      Debian*9:
+        tag: CIS-4.2.3
+        function: check_if_any_pkg_installed
+        args:
+          - rsyslog, syslog-ng
+    description: Ensure rsyslog or syslog-ng is installed
   check_log_files_permission:
     data:
-      Ubuntu-16.04:
+      Debian*9:
        tag: CIS-4.2.4
        function: check_directory_files_permission
        args:
@@ -1169,21 +1229,20 @@ misc:
     description: Ensure permissions on all logfiles are configured
   system_account_non_login:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-5.4.2
         function: system_account_non_login
     description: Ensure system accounts are non-login
-    control: Code change required for filtering the users by their login shell
   default_group_for_root_account:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-5.4.3
         function: default_group_for_root
     description: 'Ensure default group for the root account is GID 0'
   sshd_approved_macs:
     data:
-      Ubuntu-16.04:
-       tag: CIS-5.2.11
+      Debian*9:
+       tag: CIS-5.2.14
        function: check_list_values
        args:
          - /etc/ssh/sshd_config
@@ -1194,45 +1253,41 @@ misc:
          - null
          - ','
     description: Ensure only approved MAC algorithms are used
-  no_world_writable_file:
+  sshd_approved_ciphers:
     data:
-      Ubuntu-16.04:
-        tag: CIS-6.1.10
-        function: world_writable_file
-    description: Ensure no world writable files exist
-  no_unowned_file_or_directories:
-    data:
-      Ubuntu-16.04:
-        tag: CIS-6.1.11
-        function: unowned_files_or_dir
-    description: Ensure no unowned files or directories exist
-  no_ungrouped_file_or_directories:
-    data:
-      Ubuntu-16.04:
-        tag: CIS-6.1.12
-        function: ungrouped_files_or_dir
-    description: Ensure no ungrouped files or directories exist
+      Debian*9:
+       tag: CIS-5.2.13
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^Ciphers'
+         - '^Ciphers(.*)$'
+         - null
+         - 'aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com,chacha20-poly1305@openssh.com'
+         - null
+         - ','
+    description: Ensure only approved ciphers are used
   ensure_password_fields_non_empty:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.1
         function: check_password_fields_not_empty
     description: Ensure password fields are not empty
   root_is_only_uid_0_account:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.5
         function: root_is_only_uid_0_account
     description: 'Ensure root is the only UID 0 account'
   check_path_integrity:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.6
         function: check_path_integrity
     description: Ensure root PATH Integrity
   valid_home_directory:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.7
         function: check_all_users_home_directory
         args:
@@ -1240,13 +1295,13 @@ misc:
     description: 'Ensure all users home directories exist'
   home_directory_permission:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.8
         function: check_users_home_directory_permissions
     description: 'Ensure users home directories permissions are 750 or more restrictive'
   user_own_home_directory:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.9
         function: check_users_own_their_home
         args:
@@ -1254,61 +1309,61 @@ misc:
     description: Ensure users own their home directories
   check_users_dot_files_not_writable:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.10
         function: check_users_dot_files
     description: Ensure users dot files are not group or world writable
   check_users_not_forward_files:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.11
         function: check_users_forward_files
     description: 'Ensure no users have .forward files'
   check_no_users_netrc_files:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.12
         function: check_users_netrc_files
     description: Ensure no users have .netrc files
   check_netrc_files_not_world_writable:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.13
         function: check_netrc_files_accessibility
     description: 'Ensure users .netrc Files are not group or world accessible'
   check_no_users_have_rhosts_files:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.14
         function: check_users_rhosts_files
     description: Ensure no users have .rhosts files
   check_groups_validity_in_systemfiles:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.15
         function: check_groups_validity
     description: Ensure all groups in /etc/passwd exist in /etc/group
   no_duplicate_sid:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.16
         function: check_duplicate_uids
     description: Ensure no duplicate UIDs exist
   no_duplicate_gid:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.17
         function: check_duplicate_gids
     description: Ensure no duplicate GIDs exist
   check_duplicate_unames_exist:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.18
         function: check_duplicate_unames
     description: Ensure no duplicate user names exist
   check_duplicate_gnames_exist:
     data:
-      Ubuntu-16.04:
+      Debian*9:
         tag: CIS-6.2.19
         function: check_duplicate_gnames
     description: Ensure no duplicate group names exist
@@ -1316,62 +1371,62 @@ systemctl:
   whitelist:
     rsyslog_enabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - rsyslog:
            tag: CIS-4.2.1.1
       description: Ensure rsyslog Service is enabled
     cron_deamon_enabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - cron:
            tag: CIS-5.1.1
       description: Ensure cron daemon is enabled
   blacklist:
     avahi-daemon-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - avahi-daemon:
             tag: CIS-2.2.3
       description: Ensure Avahi Server is not enabled
     cups-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - cups:
             tag: CIS-2.2.4
       description: Ensure CUPS is not enabled
     dhcpd-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - isc-dhcp-server:
             tag: CIS-2.2.5
       description: Ensure DHCP Server is not enabled
     ldap-server-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - slapd:
             tag: CIS-2.2.6
       description: Ensure LDAP server is not enabled
     nfs-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - nfs-kernel-server:
-            tag: CIS-2.2.7
+            tag:  CIS-2.2.7
       description: Ensure NFS and RPC are not enabled
 #    rpc-disabled:
 #      data:
-#        Ubuntu-16.04:
+#        Debian*9:
 #        - rpcbind:
 #            tag: CIS-2.2.7
 #      description: Ensure NFS and RPC are not enabled(rpcbind-systemctl)
     dns-server-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - bind9:
             tag: CIS-2.2.8
       description: Ensure DNS Server is not enabled
     ftp-server-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - vsftpd:
             tag: CIS-2.2.9
         - proftpd:
@@ -1381,67 +1436,67 @@ systemctl:
       description: Ensure FTP Server is not enabled
     http-server-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - apache2:
             tag: CIS-2.2.10
       description: Ensure HTTP server is not enabled
     imap-pop3-server-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - dovecot:
             tag: CIS-2.2.11
       description: Ensure IMAP and POP3 server is not enabled
     samba-server-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - samba:
             tag: CIS-2.2.12
       description: Ensure Samba is not enabled
     http-proxy-server-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - squid:
             tag: CIS-2.2.13
       description: Ensure HTTP Proxy Server is not enabled
     snmp-server-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - snmpd:
             tag: CIS-2.2.14
       description: Ensure SNMP Server is not enabled
     nis-server-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - nis:
             tag: CIS-2.2.17
       description: Ensure NIS Server is not enabled
     rsh-socket-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - rsh.socket:
             tag: CIS-2.1.6
       description: Ensure rsh Server is not enabled
     rlogin-socket-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - rlogin.socket:
             tag: CIS-2.1.6
       description: Ensure rsh Server is not enabled
     rexec-socket-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - rexec.socket:
             tag: CIS-2.1.6
       description: Ensure rsh Server is not enabled
     telnet-server-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - telnet.socket:
             tag: CIS-2.1.8
       description: Ensure telnet server is not enabled
     rsync-service-disabled:
       data:
-        Ubuntu-16.04:
+        Debian*9:
         - rsync:
             tag: CIS-2.2.16
       description: Ensure rsync service is not enabled

--- a/hubblestack_nova_profiles/cis/debian-9.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9.yaml
@@ -566,7 +566,7 @@ sysctl:
             match_output: '0'
     description: Disable ICMP Redirect Acceptance
 
-  icmp_redirect_acceptance:
+  icmp_secure_redirect_acceptance:
     data:
       Debian*9:
         - 'net.ipv4.conf.all.secure_redirects':

--- a/hubblestack_nova_profiles/cis/distribution-independent-linux-level-1-all-v1-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/distribution-independent-linux-level-1-all-v1-1-0.yaml
@@ -455,13 +455,6 @@ grep:
             pattern: hard core
             tag: CIS-1.5.1
       description: Ensure core dumps are restricted
-    rsyslog_remote_logging:
-      data:
-        '*':
-        - /etc/rsyslog.conf:
-            pattern: ^*.*[^I][^I]*@
-            tag: CIS-4.2.1.4
-      description: Ensure rsyslog is configured to send logs to a remote log host
     sshd_banner:
       data:
         '*':

--- a/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-5-level-1-scored-v2-2-0.yaml
@@ -473,9 +473,6 @@ pkg:
         Red Hat Enterprise Linux Server-5:
         - cronie-anacron: CIS-6.1.1
       description: Enable anacron Daemon
-    firewalld:
-      data: {}
-      description: Enable firewalld (Scored)
     rsyslog:
       data:
         Red Hat Enterprise Linux Server-5:

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v1-0-0.yaml
@@ -441,9 +441,6 @@ pkg:
         Red Hat Enterprise Linux Server-6:
         - cronie-anacron: CIS-6.1.1
       description: Enable anacron Daemon (Scored)
-    firewalld:
-      data: {}
-      description: Enable firewalld (Scored)
     iptables:
       data:
         Red Hat Enterprise Linux Server-6:

--- a/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-6-level-1-scored-v2-0-1.yaml
@@ -279,7 +279,7 @@ stat:
             user: 'root'
             uid: 0
             group: 'root'
-            uid: 0
+            gid: 0
     description: Ensure permissions on /etc/passwd- are configured
 
   shadow_perm:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v1-0-0.yaml
@@ -204,9 +204,6 @@ grep:
             pattern: wheel
             tag: CIS-6.5
       description: Restrict Access to the su Command
-    pam_cracklib_try_first_pass:
-      data: {}
-      description: PAM cracklib policy
     passwd_change_min_days:
       data:
         Red Hat Enterprise Linux Server-7:
@@ -450,9 +447,6 @@ pkg:
         Red Hat Enterprise Linux Server-7:
         - firewalld: CIS-4.7
       description: Enable firewalld
-    iptables:
-      data: {}
-      description: Install IPtables
     rsyslog:
       data:
         Red Hat Enterprise Linux Server-7:
@@ -710,9 +704,6 @@ sysctl:
           match_output: '1'
           tag: CIS-4.2.6
     description: Enable Bad Error Message Protection
-  exec_shield:
-    data: {}
-    description: Configure ExecShield
   icmp_redirect_acceptance:
     data:
       Red Hat Enterprise Linux Server-7:
@@ -754,9 +745,6 @@ sysctl:
           match_output: '2'
           tag: CIS-1.6.2
     description: Enable Randomized Virtual Memory Region Placement
-  restrict_suid_core_dumps:
-    data: {}
-    description: Restrict SUID Core Dumps
   send_packet_redirect:
     data:
       Red Hat Enterprise Linux Server-7:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -658,7 +658,7 @@ pkg:
         Red Hat Enterprise Linux Server-7:
         - ypserv: CIS-2.2.16
       description: Ensure NIS Server is not enabled
-    rsh:
+    rsh-server:
       data:
         Red Hat Enterprise Linux Server-7:
         - rsh-server: CIS-2.2.17
@@ -1261,7 +1261,7 @@ misc:
     data:
       Red Hat Enterprise Linux Server-7:
         tag: CIS-6.2.8
-        function: check_users_home_directory_permissions 
+        function: check_users_home_directory_permissions
     description: Ensure users home directories permissions are 750 or more restrictive
   user_own_home_directory:
     data:
@@ -1311,7 +1311,7 @@ misc:
     data:
       Red Hat Enterprise Linux Server-7:
         tag: CIS-6.2.16
-        function: check_duplicate_uids 
+        function: check_duplicate_uids
     description: Ensure no duplicate UIDs exist
   no_duplicate_gid:
     data:

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -644,7 +644,7 @@ pkg:
         Red Hat Enterprise Linux Workstation-7:
         - ypserv: CIS-2.2.16
       description: Ensure NIS Server is not enabled
-    rsh:
+    rsh-server:
       data:
         Red Hat Enterprise Linux Workstation-7:
         - rsh-server: CIS-2.2.17

--- a/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhelw-7-level-1-scored-v2-1-0.yaml
@@ -465,13 +465,6 @@ grep:
             pattern: hard core
             tag: CIS-1.5.1
       description: Ensure core dumps are restricted
-    rsyslog_remote_logging:
-      data:
-        Red Hat Enterprise Linux Workstation-7:
-        - /etc/rsyslog.conf:
-            pattern: ^*.*[^I][^I]*@
-            tag: CIS-4.2.1.4
-      description: Ensure rsyslog is configured to send logs to a remote log host
     sshd_approved_cipher:
       data:
         Red Hat Enterprise Linux Workstation-7:

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
@@ -1350,12 +1350,14 @@ systemctl:
     ldap-server-disabled:
       data:
         Ubuntu-16.04:
-        - slapd: CIS-2.2.6
+        - slapd:
+            tag: CIS-2.2.6
       description: Ensure LDAP server is not enabled
     nfs-disabled:
       data:
         Ubuntu-16.04:
-        - nfs-kernel-server: CIS-2.2.7
+        - nfs-kernel-server:
+            tag: CIS-2.2.7
       description: Ensure NFS and RPC are not enabled
 #    rpc-disabled:
 #      data:

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
@@ -921,7 +921,6 @@ stat:
           tag: CIS-3.4.4
           uid: 0
           user: root
-          tag: CIS-3.4.4
     description: Ensure permissions on /etc/hosts.allow are configured
   hosts_deny_perms:
     data:
@@ -934,7 +933,6 @@ stat:
           tag: CIS-3.4.5
           uid: 0
           user: root
-          tag: CIS-3.4.5
     description: Ensure permissions on /etc/hosts.deny are configured
   crontab_own_perms:
     data:
@@ -1175,7 +1173,7 @@ misc:
         tag: CIS-5.4.2
         function: system_account_non_login
     description: Ensure system accounts are non-login
-    control: Code change required for filtering the users by their login shell 
+    control: Code change required for filtering the users by their login shell
   default_group_for_root_account:
     data:
       Ubuntu-16.04:

--- a/hubblestack_nova_profiles/cis/windows-2016-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/windows-2016-level-1-scored-v1-0-0.yaml
@@ -500,7 +500,7 @@ win_secedit:
               match_output: 'Lock Workstation' # can be anything but No Action
               value_type: 'equal'
       description: (l1) ensure 'interactive logon - smart card removal behavior' is set to 'lock workstation' or higher
-    microsoft_network_client_digitally_sign_communications_ :
+    microsoft_network_require_client_digitally_sign_communications_ :
       data:
         'Microsoft Windows Server 2016*':
           - 'MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters\RequireSecuritySignature':
@@ -532,7 +532,7 @@ win_secedit:
               match_output: '16'
               value_type: 'less'
       description: (l1) ensure 'microsoft network server - amount of idle time required before suspending session' is set to '15 or fewer minute(s), but not 0'
-    microsoft_network_server_digitally_sign_communications_ :
+    microsoft_network_server_require_digitally_sign_communications_ :
       data:
         'Microsoft Windows Server 2016*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\RequireSecuritySignature':
@@ -540,7 +540,7 @@ win_secedit:
               match_output: '1'
               value_type: 'equal'
       description: (l1) ensure 'microsoft network server - digitally sign communications (always)' is set to 'enabled'
-    microsoft_network_server_digitally_sign_communications_ :
+    microsoft_network_server_enable_digitally_sign_communications_ :
       data:
         'Microsoft Windows Server 2016*':
           - 'MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters\EnableSecuritySignature':
@@ -1419,7 +1419,7 @@ win_reg:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft Services\AdmPwd\PasswordComplexity':
               tag: CIS-18.2.4
-              match_output: '4' 
+              match_output: '4'
               value_type: 'equal'
       description: 'Ensure Password Settings - Password Complexity is set to Enabled - Large letters + small letters + numbers + special characters '
     Password Settings_ Password Length :
@@ -1595,7 +1595,7 @@ win_reg:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\System\CurrentControlSet\Policies\EarlyLaunch\DriverLoadPolicy':
               tag: CIS-18.8.11.1
-              match_output: '3' 
+              match_output: '3'
               value_type: 'equal'
       description: (l1) ensure 'boot-start driver initialization policy' is set to 'enabled -  good, unknown and bad but critical'
     Configure registry policy processing_ Do not apply during periodic background processing :
@@ -1814,7 +1814,7 @@ win_reg:
               match_output: '0'
               value_type: 'equal'
       description: (l1) ensure 'do not preserve zone information in file attachments' is set to 'disabled'
-    Always install with elevated privileges :
+    Always install with elevated privileges HKU :
       data:
         'Microsoft Windows Server 2016*':
           - 'HKEY_USERS\<SID>\Software\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated':
@@ -2151,7 +2151,7 @@ win_reg:
               match_output: '0'
               value_type: 'equal'
       description: (l1) ensure 'allow user control over installs' is set to 'disabled'
-    Always install with elevated privileges :
+    Always install with elevated privileges HKLM :
       data:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated':
@@ -2183,7 +2183,7 @@ win_reg:
               match_output: '0'
               value_type: 'equal'
       description: (l1) ensure 'turn on powershell transcription' is set to 'disabled'
-    Allow Basic authentication :
+    Allow Basic authentication client :
       data:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client\AllowBasic':
@@ -2191,7 +2191,7 @@ win_reg:
               match_output: '0'
               value_type: 'equal'
       description: (l1) ensure 'allow basic authentication' is set to 'disabled'
-    Allow unencrypted traffic :
+    Allow unencrypted traffic client :
       data:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client\AllowUnencryptedTraffic':
@@ -2207,7 +2207,7 @@ win_reg:
               match_output: '0'
               value_type: 'equal'
       description: (l1) ensure 'disallow digest authentication' is set to 'enabled'
-    Allow Basic authentication :
+    Allow Basic authentication service:
       data:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service\AllowBasic':
@@ -2215,7 +2215,7 @@ win_reg:
               match_output: '0'
               value_type: 'equal'
       description: (l1) ensure 'allow basic authentication' is set to 'disabled'
-    Allow unencrypted traffic :
+    Allow unencrypted traffic service:
       data:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service\AllowUnencryptedTraffic':
@@ -2231,7 +2231,7 @@ win_reg:
               match_output: '1'
               value_type: 'equal'
       description: (l1) ensure 'disallow winrm from storing runas credentials' is set to 'enabled'
-    Configure Automatic Updates :
+    Enable Configure Automatic Updates:
       data:
         'Microsoft Windows Server 2016*':
           - 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU\NoAutoUpdate':

--- a/hubblestack_nova_profiles/top.nova
+++ b/hubblestack_nova_profiles/top.nova
@@ -14,7 +14,7 @@ nova:
   'G@osfinger:Debian*8':
     - cis.debian-8-level-1-scored-v1-0-0
   'G@osfinger:Debian*9':
-    - cis.debian-9
+    - cis.debian-9-level-1-scored-v1-0-0
   'G@osfinger:Red*Hat*Enterprise*Linux*Server-6':
     - cis.rhels-6-level-1-scored-v2-0-1
   'G@osfinger:Red*Hat*Enterprise*Linux*Server-7':


### PR DESCRIPTION
Added new checks:
*CIS-1.1.2 -- Ensure separate partition exists for /tmp(Scored)
*CIS-1.1.5 -- Ensure noexec option set on /tmp partition (Scored)
*CIS-1.1.14 -- Ensure nodev option set on /home partition (Scored)
*CIS-1.4.2 -- Ensure bootloader password is set (Scored)
*CIS-1.4.3 -- Ensure authentication required for single user mode (Scored)
*CIS-1.7.1.2 -- Ensure local login warning banner is configured properly (Scored)
*CIS-1.7.1.4 -- Ensure permissions on /etc/motd are configured (Scored)
*CIS-1.7.1.6 -- Ensure permissions on /etc/issue.net are configured (Scored)
*CIS-2.2.1.3 -- Ensure chrony is configured (Scored)
*CIS-3.2.9 -- Ensure IPv6 router advertisements are not accepted (Scored)
*CIS-4.2.3 -- Ensure rsyslog or syslog-ng is installed (Scored)
*CIS-4.2.2.1 -- Ensure syslog-ng service is enabled (Scored)
*CIS-4.2.2.3 -- Ensure syslog-ng default file permissions configured (Scored)
*CIS-5.2.13 -- Ensure only strong ciphers are used (Scored)
*CIS-5.2.14 -- Ensure only strong MAC algorithms are used (Scored)
*CIS-5.3.2 -- Ensure lockout for failed password attempts is configured (Scored)

Fixed check control number:
*CIS-1.1.9 -> CIS-1.1.10 -- Ensure noexec option set on /var/tmp partition (Scored)
*CIS-1.1.16 -> CIS-1.1.17 -- Ensure noexec option set on /dev/shm partition (Scored)
*CIS-1.1.21 -> CIS-1.1.22 -- Disable Automounting (Scored)
*CIS-3.4.1 -> CIS-3.3.1 -- Ensure TCP Wrappers is installed (Scored)
*CIS-3.4.4 -> CIS-3.3.4 -- Ensure permissions on /etc/hosts.allow are configured (Scored)
*CIS-3.4.5 -> CIS-3.3.5 -- Ensure permissions on /etc/hosts.deny are configured (Scored)
*CIS-3.6.2 -> CIS-3.5.1.1 -- Ensure default deny firewall policy (Scored)
*CIS-3.6.3 -> CIS-3.5.1.2 -- Ensure loopback traffic is configured (Scored)
*CIS-3.6.1 -> CIS-3.5.3 -- Ensure iptables is installed (Scored)
*CIS-5.2.12 -> CIS-5.2.16 -- Ensure SSH Idle Timeout Interval is configured (Scored)
*CIS-5.2.13 -> CIS-5.2.17 -- Ensure SSH LoginGraceTime is set to one minute or less (Scored)
*CIS-5.2.14 -> CIS-5.2.18 -- Ensure SSH access is limited (Scored)
*CIS-5.2.15 -> CIS-5.2.19 -- Ensure SSH warning banner is configured (Scored)

Checks not added:
CIS-1.1.21 -- Ensure sticky bit is set on all world-writable directories (Scored)
CIS-1.7.2 -- Ensure GDM login banner is configured (Scored)
CIS-3.5.1.4 -- Ensure firewall rules exist for all open ports (Scored)
CIS-3.5.2.1 -- Ensure IPv6 default deny firewall policy (Scored)
CIS-3.5.2.2 -- Ensure IPv6 loopback traffic is configured (Scored)
CIS-5.2.2 -- Ensure permissions on SSH private host key files are configured (Scored)
CIS-5.2.3 -- Ensure permissions on SSH public host key files are configured (Scored)
CIS-5.2.15 -- Ensure only strong Key Exchange algorithms are used (Scored)
CIS-5.4.1.5 -- Ensure all users last password change date is in the past (Scored)
CIS-6.1.10 -- Ensure no world writable files exist (Scored)
CIS-6.1.11 -- Ensure no unowned files or directories exist (Scored)
CIS-6.1.12 -- Ensure no ungrouped files or directories exist (Scored)
CIS-6.2.20 -- Ensure shadow group is empty (Scored)