### PR TITLE
 Disable check_users_dot_files checks

### DIFF
--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-0-0.yaml
@@ -1179,28 +1179,28 @@ sysctl:
           tag: CIS-3.2.8
     description: Ensure TCP SYN Cookies is enabled
 
-#misc:
-#  ensure_password_fields_non_empty:
-#    data:
-#      'Amazon*Linux*2016*':
-#       tag: CIS-6.2.1
-#       function: check_password_fields_not_empty
-#       description: Ensure password fields are not empty
-#  default_group_for_root_account:
-#    data:
-#      'Amazon*Linux*2016*':
-#       tag: CIS-5.4.3
-#       function: default_group_for_root
-#       description: Ensure default group for the root account is GID 0
-#  system_account_non_login:
-#    data:
-#      'Amazon*Linux*2016*':
-#       tag: CIS-5.4.2
-#       function: system_account_non_login
-#       description: Ensure system accounts are non-login
-#  root_is_only_uid_0_account:
-#    data:
-#      'Amazon*Linux*2016*':
-#       tag: CIS-6.2.5
-#       function: root_is_only_uid_0_account
-#       description: Ensure root is the only UID 0 account
+misc:
+  ensure_password_fields_non_empty:
+    data:
+      'Amazon*Linux*2016*':
+       tag: CIS-6.2.1
+       function: check_password_fields_not_empty
+       description: Ensure password fields are not empty
+  default_group_for_root_account:
+    data:
+      'Amazon*Linux*2016*':
+       tag: CIS-5.4.3
+       function: default_group_for_root
+       description: Ensure default group for the root account is GID 0
+  system_account_non_login:
+    data:
+      'Amazon*Linux*2016*':
+       tag: CIS-5.4.2
+       function: system_account_non_login
+       description: Ensure system accounts are non-login
+  root_is_only_uid_0_account:
+    data:
+      'Amazon*Linux*2016*':
+       tag: CIS-6.2.5
+       function: root_is_only_uid_0_account
+       description: Ensure root is the only UID 0 account

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-1-0.yaml
@@ -1174,125 +1174,125 @@ sysctl:
           tag: CIS-3.2.8
     description: Ensure TCP SYN Cookies is enabled
 
-#misc:
-#  ensure_password_fields_non_empty:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.1
-#        function: check_password_fields_not_empty
-#    description: Ensure password fields are not empty
-#  check_log_files_permission:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-4.2.4
-#        function: check_directory_files_permission
-#        args:
-#          - /var/log
-#          - 740
-#    description: Ensure permissions on all logfiles are configured
-#  default_group_for_root_account:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-5.4.3
-#        function: default_group_for_root
-#    description: Ensure permissions on all logfiles are configured
-#  system_account_non_login:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-5.4.2
-#        function: system_account_non_login
-#    description: Ensure system accounts are non-login
-#  root_is_only_uid_0_account:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.5
-#        function: root_is_only_uid_0_account
-#    description: Ensure root is the only UID 0 account
-#  check_path_integrity:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.6
-#        function: check_path_integrity
-#    description: Ensure root PATH Integrity
-#  valid_home_directory:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.7
-#        function: check_all_users_home_directory
-#        args:
-#          - 1000
-#    description: 'Ensure all users home directories exist'
-#  home_directory_permission:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.8
-#        function: check_users_home_directory_permissions
-#    description: 'Ensure users home directories permissions are 750 or more restrictive'
-#  user_own_home_directory:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.9
-#        function: check_users_own_their_home
-#        args:
-#          - 1000
-#    description: Ensure users own their home directories
-#  check_users_dot_files_not_writable:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.10
-#        function: check_users_dot_files
-#    description: Ensure users dot files are not group or world writable
-#  check_users_not_forward_files:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.11
-#        function: check_users_forward_files
-#    description: 'Ensure no users have .forward files'
-#  check_no_users_netrc_files:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.12
-#        function: check_users_netrc_files
-#    description: Ensure no users have .netrc files
-#  check_netrc_files_not_world_writable:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.13
-#        function: check_netrc_files_accessibility
-#    description: Ensure users .netrc Files are not group or world accessible
-#  check_no_users_have_rhosts_files:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.14
-#        function: check_users_rhosts_files
-#    description: Ensure no users have .rhosts files
-#  check_groups_validity_in_systemfiles:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.15
-#        function: check_groups_validity
-#    description: Ensure all groups in /etc/passwd exist in /etc/group
-#  no_duplicate_sid:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.16
-#        function: check_duplicate_uids
-#    description: Ensure no duplicate UIDs exist
-#  no_duplicate_gid:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.17
-#        function: check_duplicate_gids
-#    description: Ensure no duplicate GIDs exist
-#  check_duplicate_unames_exist:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.18
-#        function: check_duplicate_unames
-#    description: Ensure no duplicate user names exist
-#  check_duplicate_gnames_exist:
-#    data:
-#      'Amazon*Linux*':
-#        tag: CIS-6.2.19
-#        function: check_duplicate_gnames
-#    description: Ensure no duplicate group names exist
+misc:
+  ensure_password_fields_non_empty:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.1
+        function: check_password_fields_not_empty
+    description: Ensure password fields are not empty
+  check_log_files_permission:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-4.2.4
+        function: check_directory_files_permission
+        args:
+          - /var/log
+          - 740
+    description: Ensure permissions on all logfiles are configured
+  default_group_for_root_account:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-5.4.3
+        function: default_group_for_root
+    description: Ensure permissions on all logfiles are configured
+  system_account_non_login:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-5.4.2
+        function: system_account_non_login
+    description: Ensure system accounts are non-login
+  root_is_only_uid_0_account:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.5
+        function: root_is_only_uid_0_account
+    description: Ensure root is the only UID 0 account
+  check_path_integrity:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.6
+        function: check_path_integrity
+    description: Ensure root PATH Integrity
+  valid_home_directory:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.7
+        function: check_all_users_home_directory
+        args:
+          - 1000
+    description: 'Ensure all users home directories exist'
+  home_directory_permission:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.8
+        function: check_users_home_directory_permissions
+    description: 'Ensure users home directories permissions are 750 or more restrictive'
+  user_own_home_directory:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.9
+        function: check_users_own_their_home
+        args:
+          - 1000
+    description: Ensure users own their home directories
+  check_users_dot_files_not_writable:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.10
+        function: check_users_dot_files
+    description: Ensure users dot files are not group or world writable
+  check_users_not_forward_files:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.11
+        function: check_users_forward_files
+    description: 'Ensure no users have .forward files'
+  check_no_users_netrc_files:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.12
+        function: check_users_netrc_files
+    description: Ensure no users have .netrc files
+  check_netrc_files_not_world_writable:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.13
+        function: check_netrc_files_accessibility
+    description: Ensure users .netrc Files are not group or world accessible
+  check_no_users_have_rhosts_files:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.14
+        function: check_users_rhosts_files
+    description: Ensure no users have .rhosts files
+  check_groups_validity_in_systemfiles:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.15
+        function: check_groups_validity
+    description: Ensure all groups in /etc/passwd exist in /etc/group
+  no_duplicate_sid:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.16
+        function: check_duplicate_uids
+    description: Ensure no duplicate UIDs exist
+  no_duplicate_gid:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.17
+        function: check_duplicate_gids
+    description: Ensure no duplicate GIDs exist
+  check_duplicate_unames_exist:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.18
+        function: check_duplicate_unames
+    description: Ensure no duplicate user names exist
+  check_duplicate_gnames_exist:
+    data:
+      'Amazon*Linux*':
+        tag: CIS-6.2.19
+        function: check_duplicate_gnames
+    description: Ensure no duplicate group names exist

--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-1-0.yaml
@@ -1236,12 +1236,12 @@ misc:
         args:
           - 1000
     description: Ensure users own their home directories
-  check_users_dot_files_not_writable:
-    data:
-      'Amazon*Linux*':
-        tag: CIS-6.2.10
-        function: check_users_dot_files
-    description: Ensure users dot files are not group or world writable
+#  check_users_dot_files_not_writable:
+#    data:
+#      'Amazon*Linux*':
+#        tag: CIS-6.2.10
+#        function: check_users_dot_files
+#    description: Ensure users dot files are not group or world writable
   check_users_not_forward_files:
     data:
       'Amazon*Linux*':

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-1.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-1-1.yaml
@@ -1176,44 +1176,44 @@ systemctl:
             tag: CIS-2.2.21
       description: Ensure talk server is not enabled
 
-#misc:
-#  mail_configured_for_local_only_mode:
-#    data:
-#      CentOS Linux-7:
-#       tag: CIS-2.2.15
-#       function: mail_conf_check
-#       description: Ensure mail transfer agent is configured for local-only mode
-#  check_any_package:
-#    data:
-#      CentOS Linux-7:
-#       tag: CIS-4.2.3
-#       function: check_if_any_pkg_installed
-#       args:
-#         - rsyslog, syslog-ng
-#       description: Ensure rsyslog or syslog-ng is installed
-#  check_netrc_files_permission:
-#    data:
-#      CentOS Linux-7:
-#       tag: CIS-6.2.13
-#       function: check_netrc_files_accessibility
-#       description: Ensure users' .netrc Files are not group or world accessible
-#  user_rhosts_files_check:
-#    data:
-#      CentOS Linux-7:
-#       tag: CIS-6.2.14
-#       function: check_users_rhosts_files
-#       description: Ensure no users have .rhosts files
-#  sshd_approved_macs:
-#    data:
-#      CentOS Linux-7:
-#       tag: CIS-5.2.12
-#       function: check_list_values
-#       args:
-#         - /etc/ssh/sshd_config
-#         - '^MACs'
-#         - '^MACs(.*)$'
-#         - null
-#         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
-#         - null
-#         - ','
-#       description: Ensure only approved MAC algorithms are used
+misc:
+  mail_configured_for_local_only_mode:
+    data:
+      CentOS Linux-7:
+       tag: CIS-2.2.15
+       function: mail_conf_check
+       description: Ensure mail transfer agent is configured for local-only mode
+  check_any_package:
+    data:
+      CentOS Linux-7:
+       tag: CIS-4.2.3
+       function: check_if_any_pkg_installed
+       args:
+         - rsyslog, syslog-ng
+       description: Ensure rsyslog or syslog-ng is installed
+  check_netrc_files_permission:
+    data:
+      CentOS Linux-7:
+       tag: CIS-6.2.13
+       function: check_netrc_files_accessibility
+       description: Ensure users' .netrc Files are not group or world accessible
+  user_rhosts_files_check:
+    data:
+      CentOS Linux-7:
+       tag: CIS-6.2.14
+       function: check_users_rhosts_files
+       description: Ensure no users have .rhosts files
+  sshd_approved_macs:
+    data:
+      CentOS Linux-7:
+       tag: CIS-5.2.12
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^MACs'
+         - '^MACs(.*)$'
+         - null
+         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+         - null
+         - ','
+       description: Ensure only approved MAC algorithms are used

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-2-0.yaml
@@ -1310,12 +1310,12 @@ misc:
         args:
           - 1000
     description: Ensure users own their home directories
-  check_users_dot_files_not_writable:
-    data:
-      CentOS Linux-7:
-        tag: CIS-6.2.10
-        function: check_users_dot_files
-    description: Ensure users dot files are not group or world writable
+#  check_users_dot_files_not_writable:
+#    data:
+#      CentOS Linux-7:
+#        tag: CIS-6.2.10
+#        function: check_users_dot_files
+#    description: Ensure users dot files are not group or world writable
   check_users_not_forward_files:
     data:
       CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-2-0.yaml
@@ -1234,167 +1234,167 @@ systemctl:
             tag: CIS-2.2.21
       description: Ensure talk server is not enabled
 
-#misc:
-#  mail_configured_for_local_only_mode:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-2.2.15
-#        function: mail_conf_check
-#    description: Ensure mail transfer agent is configured for local-only mode
-#  check_any_package:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-4.2.3
-#        function: check_if_any_pkg_installed
-#        args:
-#          - rsyslog, syslog-ng
-#    description: Ensure rsyslog or syslog-ng is installed
-#  check_log_files_permission:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-4.2.4
-#        function: check_directory_files_permission
-#        args:
-#          - /var/log
-#          - 740
-#    description: Ensure permissions on all logfiles are configured
-#  system_account_non_login:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-5.4.2
-#        function: system_account_non_login
-#    description: Ensure system accounts are non-login
-#  default_group_for_root_account:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-5.4.3
-#        function: default_group_for_root
-#    description: Ensure default group for the root account is GID 0
-#  ensure_password_fields_non_empty:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.1
-#        function: check_password_fields_not_empty
-#    description: Ensure password fields are not empty
-#  root_is_only_uid_0_account:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.5
-#        function: root_is_only_uid_0_account
-#    description: Ensure root is the only UID 0 account
-#  check_path_integrity:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.6
-#        function: check_path_integrity
-#    description: Ensure root PATH Integrity
-#  valid_home_directory:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.7
-#        function: check_all_users_home_directory
-#        args:
-#          - 1000
-#    description: 'Ensure all users home directories exist'
-#  home_directory_permission:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.8
-#        function: check_users_home_directory_permissions
-#    description: 'Ensure users home directories permissions are 750 or more restrictive'
-#  user_own_home_directory:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.9
-#        function: check_users_own_their_home
-#        args:
-#          - 1000
-#    description: Ensure users own their home directories
-#  check_users_dot_files_not_writable:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.10
-#        function: check_users_dot_files
-#    description: Ensure users dot files are not group or world writable
-#  check_users_not_forward_files:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.11
-#        function: check_users_forward_files
-#    description: 'Ensure no users have .forward files'
-#  check_no_users_netrc_files:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.12
-#        function: check_users_netrc_files
-#    description: Ensure no users have .netrc files
-#  check_netrc_files_not_world_writable:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.13
-#        function: check_netrc_files_accessibility
-#    description: Ensure users .netrc Files are not group or world accessible
-#  check_no_users_have_rhosts_files:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.14
-#        function: check_users_rhosts_files
-#    description: Ensure no users have .rhosts files
-#  check_groups_validity_in_systemfiles:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.15
-#        function: check_groups_validity
-#    description: Ensure all groups in /etc/passwd exist in /etc/group
-#  no_duplicate_sid:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.16
-#        function: check_duplicate_uids
-#    description: Ensure no duplicate UIDs exist
-#  no_duplicate_gid:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.17
-#        function: check_duplicate_gids
-#    description: Ensure no duplicate GIDs exist
-#  check_duplicate_unames_exist:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.18
-#        function: check_duplicate_unames
-#    description: Ensure no duplicate user names exist
-#  check_duplicate_gnames_exist:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-6.2.19
-#        function: check_duplicate_gnames
-#    description: Ensure no duplicate group names exist
-#  sshd_approved_macs:
-#    data:
-#      CentOS Linux-7:
-#        tag: CIS-5.2.11
-#        function: check_list_values
-#        args:
-#          - /etc/ssh/sshd_config
-#          - '^MACs'
-#          - '^MACs(.*)$'
-#          - null
-#          - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
-#          - null
-#          - ','
-#    description: Ensure only approved MAC algorithms are used
-#  sshd_approved_ciphers:
-#    data:
-#      CentOS Linux-7:
-#       tag: CIS-5.2.11.1
-#       function: check_list_values
-#       args:
-#         - /etc/ssh/sshd_config
-#         - '^Ciphers'
-#         - '^Ciphers(.*)$'
-#         - null
-#         - 'aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com,chacha20-poly1305@openssh.com'
-#         - null
-#         - ','
-#    description: Ensure only approved ciphers are used
+misc:
+  mail_configured_for_local_only_mode:
+    data:
+      CentOS Linux-7:
+        tag: CIS-2.2.15
+        function: mail_conf_check
+    description: Ensure mail transfer agent is configured for local-only mode
+  check_any_package:
+    data:
+      CentOS Linux-7:
+        tag: CIS-4.2.3
+        function: check_if_any_pkg_installed
+        args:
+          - rsyslog, syslog-ng
+    description: Ensure rsyslog or syslog-ng is installed
+  check_log_files_permission:
+    data:
+      CentOS Linux-7:
+        tag: CIS-4.2.4
+        function: check_directory_files_permission
+        args:
+          - /var/log
+          - 740
+    description: Ensure permissions on all logfiles are configured
+  system_account_non_login:
+    data:
+      CentOS Linux-7:
+        tag: CIS-5.4.2
+        function: system_account_non_login
+    description: Ensure system accounts are non-login
+  default_group_for_root_account:
+    data:
+      CentOS Linux-7:
+        tag: CIS-5.4.3
+        function: default_group_for_root
+    description: Ensure default group for the root account is GID 0
+  ensure_password_fields_non_empty:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.1
+        function: check_password_fields_not_empty
+    description: Ensure password fields are not empty
+  root_is_only_uid_0_account:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.5
+        function: root_is_only_uid_0_account
+    description: Ensure root is the only UID 0 account
+  check_path_integrity:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.6
+        function: check_path_integrity
+    description: Ensure root PATH Integrity
+  valid_home_directory:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.7
+        function: check_all_users_home_directory
+        args:
+          - 1000
+    description: 'Ensure all users home directories exist'
+  home_directory_permission:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.8
+        function: check_users_home_directory_permissions
+    description: 'Ensure users home directories permissions are 750 or more restrictive'
+  user_own_home_directory:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.9
+        function: check_users_own_their_home
+        args:
+          - 1000
+    description: Ensure users own their home directories
+  check_users_dot_files_not_writable:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.10
+        function: check_users_dot_files
+    description: Ensure users dot files are not group or world writable
+  check_users_not_forward_files:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.11
+        function: check_users_forward_files
+    description: 'Ensure no users have .forward files'
+  check_no_users_netrc_files:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.12
+        function: check_users_netrc_files
+    description: Ensure no users have .netrc files
+  check_netrc_files_not_world_writable:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.13
+        function: check_netrc_files_accessibility
+    description: Ensure users .netrc Files are not group or world accessible
+  check_no_users_have_rhosts_files:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.14
+        function: check_users_rhosts_files
+    description: Ensure no users have .rhosts files
+  check_groups_validity_in_systemfiles:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.15
+        function: check_groups_validity
+    description: Ensure all groups in /etc/passwd exist in /etc/group
+  no_duplicate_sid:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.16
+        function: check_duplicate_uids
+    description: Ensure no duplicate UIDs exist
+  no_duplicate_gid:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.17
+        function: check_duplicate_gids
+    description: Ensure no duplicate GIDs exist
+  check_duplicate_unames_exist:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.18
+        function: check_duplicate_unames
+    description: Ensure no duplicate user names exist
+  check_duplicate_gnames_exist:
+    data:
+      CentOS Linux-7:
+        tag: CIS-6.2.19
+        function: check_duplicate_gnames
+    description: Ensure no duplicate group names exist
+  sshd_approved_macs:
+    data:
+      CentOS Linux-7:
+        tag: CIS-5.2.11
+        function: check_list_values
+        args:
+          - /etc/ssh/sshd_config
+          - '^MACs'
+          - '^MACs(.*)$'
+          - null
+          - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+          - null
+          - ','
+    description: Ensure only approved MAC algorithms are used
+  sshd_approved_ciphers:
+    data:
+      CentOS Linux-7:
+       tag: CIS-5.2.11.1
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^Ciphers'
+         - '^Ciphers(.*)$'
+         - null
+         - 'aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com,chacha20-poly1305@openssh.com'
+         - null
+         - ','
+    description: Ensure only approved ciphers are used

--- a/hubblestack_nova_profiles/cis/coreos-level-1.yaml
+++ b/hubblestack_nova_profiles/cis/coreos-level-1.yaml
@@ -427,218 +427,218 @@ stat:
           uid: 0
           user: root
     description: Ensure that /etc/systemd/system directory ownership is set to root:root
-#misc:
-#  system_account_non_login:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-5.4.2
-#       function: system_account_non_login
-#       description: Ensure system accounts are non-login
-#  default_group_for_root_account:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-5.4.3
-#       function: default_group_for_root
-#       description: Ensure default group for the root account is GID 0
-#  root_is_only_uid_0_account:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-6.2.5
-#       function: root_is_only_uid_0_account
-#       description: Ensure root is the only UID 0 account
-#  ensure_nodev_option_on_/tmp:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-1.1.3
-#       function: test_mount_attrs
-#       args:
-#         - /tmp
-#         - nodev
-#         - soft
-#       description: Ensure nodev option set on /tmp partition
-#  ensure_nosuid_option_on_/tmp:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-1.1.4
-#       function: test_mount_attrs
-#       args:
-#         - /tmp
-#         - nosuid
-#         - soft
-#       description: Ensure nosuid option set on /tmp partition
-#  ensure_noexec_option_on_/tmp:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-1.1.5
-#       function: test_mount_attrs
-#       args:
-#         - /tmp
-#         - noexec
-#         - soft
-#       description: Ensure noexec option set on /tmp partition
-#  ensure_nodev_option_on_/dev/shm:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-1.1.15
-#       function: test_mount_attrs
-#       args:
-#         - /dev/shm
-#         - nodev
-#         - soft
-#       description: Ensure nodev option set on /dev/shm partition
-#  ensure_nosuid_option_on_/dev/shm:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-1.1.16
-#       function: test_mount_attrs
-#       args:
-#         - /dev/shm
-#         - nosuid
-#         - soft
-#       description: Ensure nosuid option set on /dev/shm partition
-#  ensure_noexec_option_on_/dev/shm:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-1.1.17
-#       function: test_mount_attrs
-#       args:
-#         - /dev/shm
-#         - noexec
-#         - soft
-#       description: Ensure noexec option set on /dev/shm partition
-#  ensure_path_integrity:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-6.2.6
-#       function: check_path_integrity
-#       description: Ensure root PATH Integrity
-#  docker_directory_permissions:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-7.6
-#       function: restrict_permissions
-#       args:
-#        - /etc/docker
-#        - 755
-#       description: Ensure that /etc/docker directory permissions are set to 755 or more restrictive
-#  time_sync:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-7.1
-#       function: check_time_synchronization
-#       description: Ensure that some service running to synchronize system time
-#  check_duplicate_uids:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-6.1.16
-#       function: check_duplicate_uids
-#       description: Ensure no duplicate UIDs exist
-#  check_duplicate_gids:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-6.2.17
-#       function: check_duplicate_gids
-#       description: Ensure no duplicate GIDs exist
-#  check_duplicate_unames:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-6.2.18
-#       function: check_duplicate_unames
-#       description: Ensure no duplicate user names exist
-#  check_duplicate_gnames:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-6.2.19
-#       function: check_duplicate_gnames
-#       description: Ensure no duplicate group names exist
-#  restrict_core_dumps:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-1.5.1
-#       function: check_core_dumps
-#       description: Ensure core dumps are restricted
-#  check_log_files_permission:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-4.2.4
-#       function: check_directory_files_permission
-#       args:
-#        - /var/log
-#        - 740
-#       description: Ensure permissions on all logfiles are configured
-#  systemd_system_permission:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-7.3
-#       function: restrict_permissions
-#       args:
-#        - /etc/systemd/system
-#        - 755
-#       description: Ensure that /etc/systemd/system directory permissions are set to 755 or more restrictive
-#  journald_enabled:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-7.7
-#       function: check_service_status
-#       args:
-#         - systemd-journald
-#         - enabled
-#       description: Ensure systemd-journald service is enabled
-#  sshd_idle_timeout:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-5.2.13
-#       function: check_ssh_timeout_config
-#       description: Ensure SSH Idle Timeout Interval is configured
-#  all_users_home_directory:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-6.2.7
-#       function: check_all_users_home_directory
-#       args:
-#         - 1000
-#       description: Ensure all users' home directories exist
-#  all_users_home_directory_permission:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-6.2.8
-#       function: check_users_home_directory_permissions
-#       description: Ensure users' home directories permissions are 750 or more restrictive
-#  all_users_own_their_home:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-6.2.9
-#       function: check_users_own_their_home
-#       args:
-#         - 1000
-#       description: Ensure users own their home directories
-#  users_dot_file_check:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-6.2.10
-#       function: check_users_dot_files
-#       description: Ensure users' dot files are not group or world writable
-#  users_forward_files_check:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-6.2.11
-#       function: check_users_forward_files
-#       description: Ensure no users have .forward files
-#  users_netrc_files_check:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-6.2.12
-#       function: check_users_netrc_files
-#       description: Ensure no users have .netrc files
-#  check_groups_validity:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-6.2.15
-#       function: check_groups_validity
-#       description: Ensure all groups in /etc/passwd exist in /etc/group
-#  enable_reverse_path_filtering:
-#    data:
-#      '*CoreOS*':
-#       tag: CIS-3.2.7
-#       function: ensure_reverse_path_filtering
-#       description: Ensure Reverse Path Filtering is enabled
+misc:
+  system_account_non_login:
+    data:
+      '*CoreOS*':
+       tag: CIS-5.4.2
+       function: system_account_non_login
+       description: Ensure system accounts are non-login
+  default_group_for_root_account:
+    data:
+      '*CoreOS*':
+       tag: CIS-5.4.3
+       function: default_group_for_root
+       description: Ensure default group for the root account is GID 0
+  root_is_only_uid_0_account:
+    data:
+      '*CoreOS*':
+       tag: CIS-6.2.5
+       function: root_is_only_uid_0_account
+       description: Ensure root is the only UID 0 account
+  ensure_nodev_option_on_/tmp:
+    data:
+      '*CoreOS*':
+       tag: CIS-1.1.3
+       function: test_mount_attrs
+       args:
+         - /tmp
+         - nodev
+         - soft
+       description: Ensure nodev option set on /tmp partition
+  ensure_nosuid_option_on_/tmp:
+    data:
+      '*CoreOS*':
+       tag: CIS-1.1.4
+       function: test_mount_attrs
+       args:
+         - /tmp
+         - nosuid
+         - soft
+       description: Ensure nosuid option set on /tmp partition
+  ensure_noexec_option_on_/tmp:
+    data:
+      '*CoreOS*':
+       tag: CIS-1.1.5
+       function: test_mount_attrs
+       args:
+         - /tmp
+         - noexec
+         - soft
+       description: Ensure noexec option set on /tmp partition
+  ensure_nodev_option_on_/dev/shm:
+    data:
+      '*CoreOS*':
+       tag: CIS-1.1.15
+       function: test_mount_attrs
+       args:
+         - /dev/shm
+         - nodev
+         - soft
+       description: Ensure nodev option set on /dev/shm partition
+  ensure_nosuid_option_on_/dev/shm:
+    data:
+      '*CoreOS*':
+       tag: CIS-1.1.16
+       function: test_mount_attrs
+       args:
+         - /dev/shm
+         - nosuid
+         - soft
+       description: Ensure nosuid option set on /dev/shm partition
+  ensure_noexec_option_on_/dev/shm:
+    data:
+      '*CoreOS*':
+       tag: CIS-1.1.17
+       function: test_mount_attrs
+       args:
+         - /dev/shm
+         - noexec
+         - soft
+       description: Ensure noexec option set on /dev/shm partition
+  ensure_path_integrity:
+    data:
+      '*CoreOS*':
+       tag: CIS-6.2.6
+       function: check_path_integrity
+       description: Ensure root PATH Integrity
+  docker_directory_permissions:
+    data:
+      '*CoreOS*':
+       tag: CIS-7.6
+       function: restrict_permissions
+       args:
+        - /etc/docker
+        - 755
+       description: Ensure that /etc/docker directory permissions are set to 755 or more restrictive
+  time_sync:
+    data:
+      '*CoreOS*':
+       tag: CIS-7.1
+       function: check_time_synchronization
+       description: Ensure that some service running to synchronize system time
+  check_duplicate_uids:
+    data:
+      '*CoreOS*':
+       tag: CIS-6.1.16
+       function: check_duplicate_uids
+       description: Ensure no duplicate UIDs exist
+  check_duplicate_gids:
+    data:
+      '*CoreOS*':
+       tag: CIS-6.2.17
+       function: check_duplicate_gids
+       description: Ensure no duplicate GIDs exist
+  check_duplicate_unames:
+    data:
+      '*CoreOS*':
+       tag: CIS-6.2.18
+       function: check_duplicate_unames
+       description: Ensure no duplicate user names exist
+  check_duplicate_gnames:
+    data:
+      '*CoreOS*':
+       tag: CIS-6.2.19
+       function: check_duplicate_gnames
+       description: Ensure no duplicate group names exist
+  restrict_core_dumps:
+    data:
+      '*CoreOS*':
+       tag: CIS-1.5.1
+       function: check_core_dumps
+       description: Ensure core dumps are restricted
+  check_log_files_permission:
+    data:
+      '*CoreOS*':
+       tag: CIS-4.2.4
+       function: check_directory_files_permission
+       args:
+        - /var/log
+        - 740
+       description: Ensure permissions on all logfiles are configured
+  systemd_system_permission:
+    data:
+      '*CoreOS*':
+       tag: CIS-7.3
+       function: restrict_permissions
+       args:
+        - /etc/systemd/system
+        - 755
+       description: Ensure that /etc/systemd/system directory permissions are set to 755 or more restrictive
+  journald_enabled:
+    data:
+      '*CoreOS*':
+       tag: CIS-7.7
+       function: check_service_status
+       args:
+         - systemd-journald
+         - enabled
+       description: Ensure systemd-journald service is enabled
+  sshd_idle_timeout:
+    data:
+      '*CoreOS*':
+       tag: CIS-5.2.13
+       function: check_ssh_timeout_config
+       description: Ensure SSH Idle Timeout Interval is configured
+  all_users_home_directory:
+    data:
+      '*CoreOS*':
+       tag: CIS-6.2.7
+       function: check_all_users_home_directory
+       args:
+         - 1000
+       description: Ensure all users' home directories exist
+  all_users_home_directory_permission:
+    data:
+      '*CoreOS*':
+       tag: CIS-6.2.8
+       function: check_users_home_directory_permissions
+       description: Ensure users' home directories permissions are 750 or more restrictive
+  all_users_own_their_home:
+    data:
+      '*CoreOS*':
+       tag: CIS-6.2.9
+       function: check_users_own_their_home
+       args:
+         - 1000
+       description: Ensure users own their home directories
+  users_dot_file_check:
+    data:
+      '*CoreOS*':
+       tag: CIS-6.2.10
+       function: check_users_dot_files
+       description: Ensure users' dot files are not group or world writable
+  users_forward_files_check:
+    data:
+      '*CoreOS*':
+       tag: CIS-6.2.11
+       function: check_users_forward_files
+       description: Ensure no users have .forward files
+  users_netrc_files_check:
+    data:
+      '*CoreOS*':
+       tag: CIS-6.2.12
+       function: check_users_netrc_files
+       description: Ensure no users have .netrc files
+  check_groups_validity:
+    data:
+      '*CoreOS*':
+       tag: CIS-6.2.15
+       function: check_groups_validity
+       description: Ensure all groups in /etc/passwd exist in /etc/group
+  enable_reverse_path_filtering:
+    data:
+      '*CoreOS*':
+       tag: CIS-3.2.7
+       function: ensure_reverse_path_filtering
+       description: Ensure Reverse Path Filtering is enabled

--- a/hubblestack_nova_profiles/cis/coreos-level-1.yaml
+++ b/hubblestack_nova_profiles/cis/coreos-level-1.yaml
@@ -612,12 +612,12 @@ misc:
        args:
          - 1000
        description: Ensure users own their home directories
-  users_dot_file_check:
-    data:
-      '*CoreOS*':
-       tag: CIS-6.2.10
-       function: check_users_dot_files
-       description: Ensure users' dot files are not group or world writable
+#  users_dot_file_check:
+#    data:
+#      '*CoreOS*':
+#       tag: CIS-6.2.10
+#       function: check_users_dot_files
+#       description: Ensure users' dot files are not group or world writable
   users_forward_files_check:
     data:
       '*CoreOS*':

--- a/hubblestack_nova_profiles/cis/debian-9-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9-level-1-scored-v1-0-0.yaml
@@ -1203,170 +1203,170 @@ stat:
           uid: 0
           user: root
     description: 'Ensure permissions on /etc/gshadow- are configured'
-#misc:
-#  mail_configured_for_local_only_mode:
-#    data:
-#      Debian*9:
-#        tag: CIS-2.2.15
-#        function: mail_conf_check
-#    description: Ensure mail transfer agent is configured for local-only mode
-#  check_any_package:
-#    data:
-#      Debian*9:
-#        tag: CIS-4.2.3
-#        function: check_if_any_pkg_installed
-#        args:
-#          - rsyslog, syslog-ng
-#    description: Ensure rsyslog or syslog-ng is installed
-#  check_log_files_permission:
-#    data:
-#      Debian*9:
-#       tag: CIS-4.2.4
-#       function: check_directory_files_permission
-#       args:
-#        - /var/log
-#        - 740
-#    description: Ensure permissions on all logfiles are configured
-#  system_account_non_login:
-#    data:
-#      Debian*9:
-#        tag: CIS-5.4.2
-#        function: system_account_non_login
-#    description: Ensure system accounts are non-login
-#  default_group_for_root_account:
-#    data:
-#      Debian*9:
-#        tag: CIS-5.4.3
-#        function: default_group_for_root
-#    description: 'Ensure default group for the root account is GID 0'
-#  sshd_approved_macs:
-#    data:
-#      Debian*9:
-#       tag: CIS-5.2.14
-#       function: check_list_values
-#       args:
-#         - /etc/ssh/sshd_config
-#         - '^MACs'
-#         - '^MACs(.*)$'
-#         - null
-#         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
-#         - null
-#         - ','
-#    description: Ensure only approved MAC algorithms are used
-#  sshd_approved_ciphers:
-#    data:
-#      Debian*9:
-#       tag: CIS-5.2.13
-#       function: check_list_values
-#       args:
-#         - /etc/ssh/sshd_config
-#         - '^Ciphers'
-#         - '^Ciphers(.*)$'
-#         - null
-#         - 'aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com,chacha20-poly1305@openssh.com'
-#         - null
-#         - ','
-#    description: Ensure only approved ciphers are used
-#  ensure_password_fields_non_empty:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.1
-#        function: check_password_fields_not_empty
-#    description: Ensure password fields are not empty
-#  root_is_only_uid_0_account:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.5
-#        function: root_is_only_uid_0_account
-#    description: 'Ensure root is the only UID 0 account'
-#  check_path_integrity:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.6
-#        function: check_path_integrity
-#    description: Ensure root PATH Integrity
-#  valid_home_directory:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.7
-#        function: check_all_users_home_directory
-#        args:
-#        - 1000
-#    description: 'Ensure all users home directories exist'
-#  home_directory_permission:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.8
-#        function: check_users_home_directory_permissions
-#    description: 'Ensure users home directories permissions are 750 or more restrictive'
-#  user_own_home_directory:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.9
-#        function: check_users_own_their_home
-#        args:
-#        - 1000
-#    description: Ensure users own their home directories
-#  check_users_dot_files_not_writable:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.10
-#        function: check_users_dot_files
-#    description: Ensure users dot files are not group or world writable
-#  check_users_not_forward_files:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.11
-#        function: check_users_forward_files
-#    description: 'Ensure no users have .forward files'
-#  check_no_users_netrc_files:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.12
-#        function: check_users_netrc_files
-#    description: Ensure no users have .netrc files
-#  check_netrc_files_not_world_writable:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.13
-#        function: check_netrc_files_accessibility
-#    description: 'Ensure users .netrc Files are not group or world accessible'
-#  check_no_users_have_rhosts_files:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.14
-#        function: check_users_rhosts_files
-#    description: Ensure no users have .rhosts files
-#  check_groups_validity_in_systemfiles:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.15
-#        function: check_groups_validity
-#    description: Ensure all groups in /etc/passwd exist in /etc/group
-#  no_duplicate_sid:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.16
-#        function: check_duplicate_uids
-#    description: Ensure no duplicate UIDs exist
-#  no_duplicate_gid:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.17
-#        function: check_duplicate_gids
-#    description: Ensure no duplicate GIDs exist
-#  check_duplicate_unames_exist:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.18
-#        function: check_duplicate_unames
-#    description: Ensure no duplicate user names exist
-#  check_duplicate_gnames_exist:
-#    data:
-#      Debian*9:
-#        tag: CIS-6.2.19
-#        function: check_duplicate_gnames
-#    description: Ensure no duplicate group names exist
+misc:
+  mail_configured_for_local_only_mode:
+    data:
+      Debian*9:
+        tag: CIS-2.2.15
+        function: mail_conf_check
+    description: Ensure mail transfer agent is configured for local-only mode
+  check_any_package:
+    data:
+      Debian*9:
+        tag: CIS-4.2.3
+        function: check_if_any_pkg_installed
+        args:
+          - rsyslog, syslog-ng
+    description: Ensure rsyslog or syslog-ng is installed
+  check_log_files_permission:
+    data:
+      Debian*9:
+       tag: CIS-4.2.4
+       function: check_directory_files_permission
+       args:
+        - /var/log
+        - 740
+    description: Ensure permissions on all logfiles are configured
+  system_account_non_login:
+    data:
+      Debian*9:
+        tag: CIS-5.4.2
+        function: system_account_non_login
+    description: Ensure system accounts are non-login
+  default_group_for_root_account:
+    data:
+      Debian*9:
+        tag: CIS-5.4.3
+        function: default_group_for_root
+    description: 'Ensure default group for the root account is GID 0'
+  sshd_approved_macs:
+    data:
+      Debian*9:
+       tag: CIS-5.2.14
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^MACs'
+         - '^MACs(.*)$'
+         - null
+         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+         - null
+         - ','
+    description: Ensure only approved MAC algorithms are used
+  sshd_approved_ciphers:
+    data:
+      Debian*9:
+       tag: CIS-5.2.13
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^Ciphers'
+         - '^Ciphers(.*)$'
+         - null
+         - 'aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com,chacha20-poly1305@openssh.com'
+         - null
+         - ','
+    description: Ensure only approved ciphers are used
+  ensure_password_fields_non_empty:
+    data:
+      Debian*9:
+        tag: CIS-6.2.1
+        function: check_password_fields_not_empty
+    description: Ensure password fields are not empty
+  root_is_only_uid_0_account:
+    data:
+      Debian*9:
+        tag: CIS-6.2.5
+        function: root_is_only_uid_0_account
+    description: 'Ensure root is the only UID 0 account'
+  check_path_integrity:
+    data:
+      Debian*9:
+        tag: CIS-6.2.6
+        function: check_path_integrity
+    description: Ensure root PATH Integrity
+  valid_home_directory:
+    data:
+      Debian*9:
+        tag: CIS-6.2.7
+        function: check_all_users_home_directory
+        args:
+        - 1000
+    description: 'Ensure all users home directories exist'
+  home_directory_permission:
+    data:
+      Debian*9:
+        tag: CIS-6.2.8
+        function: check_users_home_directory_permissions
+    description: 'Ensure users home directories permissions are 750 or more restrictive'
+  user_own_home_directory:
+    data:
+      Debian*9:
+        tag: CIS-6.2.9
+        function: check_users_own_their_home
+        args:
+        - 1000
+    description: Ensure users own their home directories
+  check_users_dot_files_not_writable:
+    data:
+      Debian*9:
+        tag: CIS-6.2.10
+        function: check_users_dot_files
+    description: Ensure users dot files are not group or world writable
+  check_users_not_forward_files:
+    data:
+      Debian*9:
+        tag: CIS-6.2.11
+        function: check_users_forward_files
+    description: 'Ensure no users have .forward files'
+  check_no_users_netrc_files:
+    data:
+      Debian*9:
+        tag: CIS-6.2.12
+        function: check_users_netrc_files
+    description: Ensure no users have .netrc files
+  check_netrc_files_not_world_writable:
+    data:
+      Debian*9:
+        tag: CIS-6.2.13
+        function: check_netrc_files_accessibility
+    description: 'Ensure users .netrc Files are not group or world accessible'
+  check_no_users_have_rhosts_files:
+    data:
+      Debian*9:
+        tag: CIS-6.2.14
+        function: check_users_rhosts_files
+    description: Ensure no users have .rhosts files
+  check_groups_validity_in_systemfiles:
+    data:
+      Debian*9:
+        tag: CIS-6.2.15
+        function: check_groups_validity
+    description: Ensure all groups in /etc/passwd exist in /etc/group
+  no_duplicate_sid:
+    data:
+      Debian*9:
+        tag: CIS-6.2.16
+        function: check_duplicate_uids
+    description: Ensure no duplicate UIDs exist
+  no_duplicate_gid:
+    data:
+      Debian*9:
+        tag: CIS-6.2.17
+        function: check_duplicate_gids
+    description: Ensure no duplicate GIDs exist
+  check_duplicate_unames_exist:
+    data:
+      Debian*9:
+        tag: CIS-6.2.18
+        function: check_duplicate_unames
+    description: Ensure no duplicate user names exist
+  check_duplicate_gnames_exist:
+    data:
+      Debian*9:
+        tag: CIS-6.2.19
+        function: check_duplicate_gnames
+    description: Ensure no duplicate group names exist
 systemctl:
   whitelist:
     rsyslog_enabled:

--- a/hubblestack_nova_profiles/cis/debian-9-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9-level-1-scored-v1-0-0.yaml
@@ -1307,11 +1307,11 @@ misc:
         args:
         - 1000
     description: Ensure users own their home directories
-  check_users_dot_files_not_writable:
-    data:
-      Debian*9:
-        tag: CIS-6.2.10
-        function: check_users_dot_files
+#  check_users_dot_files_not_writable:
+#    data:
+#      Debian*9:
+#        tag: CIS-6.2.10
+#        function: check_users_dot_files
     description: Ensure users dot files are not group or world writable
   check_users_not_forward_files:
     data:

--- a/hubblestack_nova_profiles/cis/distribution-independent-linux-level-1-all-v1-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/distribution-independent-linux-level-1-all-v1-1-0.yaml
@@ -1295,12 +1295,12 @@ misc:
         args:
         - 1000
     description: Ensure users own their home directories
-  check_users_dot_files_not_writable:
-    data:
-      '*':
-        tag: CIS-6.2.10
-        function: check_users_dot_files
-    description: Ensure users dot files are not group or world writable
+#  check_users_dot_files_not_writable:
+#    data:
+#      '*':
+#        tag: CIS-6.2.10
+#        function: check_users_dot_files
+#    description: Ensure users dot files are not group or world writable
   check_users_not_forward_files:
     data:
       '*':

--- a/hubblestack_nova_profiles/cis/distribution-independent-linux-level-1-all-v1-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/distribution-independent-linux-level-1-all-v1-1-0.yaml
@@ -1225,133 +1225,133 @@ systemctl:
             tag: CIS-2.1.7
       description: Ensure talk server is not enabled
 
-#misc:
-#  mail_configured_for_local_only_mode:
-#    data:
-#      '*':
-#        tag: CIS-2.2.15
-#        function: mail_conf_check
-#    description: Ensure mail transfer agent is configured for local-only mode
-#  check_any_package:
-#    data:
-#      '*':
-#        tag: CIS-4.2.3
-#        function: check_if_any_pkg_installed
-#        args:
-#          - rsyslog, syslog-ng
-#    description: Ensure rsyslog or syslog-ng is installed
-#  system_account_non_login:
-#    data:
-#      '*':
-#        tag: CIS-5.4.2
-#        function: system_account_non_login
-#    description: Ensure system accounts are non-login
-#  default_group_for_root_account:
-#    data:
-#      '*':
-#        tag: CIS-5.4.3
-#        function: default_group_for_root
-#    description: Ensure default group for the root account is GID 0
-#  check_log_files_permission:
-#    data:
-#      '*':
-#        tag: CIS-4.2.4
-#        function: check_directory_files_permission
-#        args:
-#          - /var/log
-#          - 740
-#    description: Ensure permissions on all logfiles are configured
-#  ensure_password_fields_non_empty:
-#    data:
-#      '*':
-#        tag: CIS-6.2.1
-#        function: check_password_fields_not_empty
-#    description: Ensure password fields are not empty
-#  check_path_integrity:
-#    data:
-#      '*':
-#        tag: CIS-6.2.6
-#        function: check_path_integrity
-#    description: Ensure root PATH Integrity
-#  valid_home_directory:
-#    data:
-#      '*':
-#        tag: CIS-6.2.7
-#        function: check_all_users_home_directory
-#        args:
-#        - 1000
-#    description: 'Ensure all users home directories exist'
-#  home_directory_permission:
-#    data:
-#      '*':
-#        tag: CIS-6.2.8
-#        function: check_users_home_directory_permissions
-#    description: 'Ensure users home directories permissions are 750 or more restrictive'
-#  user_own_home_directory:
-#    data:
-#      '*':
-#        tag: CIS-6.2.9
-#        function: check_users_own_their_home
-#        args:
-#        - 1000
-#    description: Ensure users own their home directories
-#  check_users_dot_files_not_writable:
-#    data:
-#      '*':
-#        tag: CIS-6.2.10
-#        function: check_users_dot_files
-#    description: Ensure users dot files are not group or world writable
-#  check_users_not_forward_files:
-#    data:
-#      '*':
-#        tag: CIS-6.2.11
-#        function: check_users_forward_files
-#    description: 'Ensure no users have .forward files'
-#  check_no_users_netrc_files:
-#    data:
-#      '*':
-#        tag: CIS-6.2.12
-#        function: check_users_netrc_files
-#    description: Ensure no users have .netrc files
-#  check_netrc_files_permission:
-#    data:
-#      '*':
-#        tag: CIS-6.2.13
-#        function: check_netrc_files_accessibility
-#    description: Ensure users .netrc Files are not group or world accessible
-#  user_rhosts_files_check:
-#    data:
-#      '*':
-#        tag: CIS-6.2.14
-#        function: check_users_rhosts_files
-#    description: Ensure no users have .rhosts files
-#  check_groups_validity_in_systemfiles:
-#    data:
-#      '*':
-#        tag: CIS-6.2.15
-#        function: check_groups_validity
-#    description: Ensure all groups in /etc/passwd exist in /etc/group
-#  no_duplicate_sid:
-#    data:
-#      '*':
-#        tag: CIS-6.2.16
-#        function: check_duplicate_uids
-#    description: Ensure no duplicate UIDs exist
-#  no_duplicate_gid:
-#    data:
-#      '*':
-#        tag: CIS-6.2.17
-#        function: check_duplicate_gids
-#    description: Ensure no duplicate GIDs exist
-#  check_duplicate_unames_exist:
-#    data:
-#      '*':
-#        tag: CIS-6.2.18
-#        function: check_duplicate_unames
-#    description: Ensure no duplicate user names exist
-#  check_duplicate_gnames_exist:
-#    data:
-#      '*':
-#        tag: CIS-6.2.19
-#        function: check_duplicate_gnames
-#    description: Ensure no duplicate group names exist
+misc:
+  mail_configured_for_local_only_mode:
+    data:
+      '*':
+        tag: CIS-2.2.15
+        function: mail_conf_check
+    description: Ensure mail transfer agent is configured for local-only mode
+  check_any_package:
+    data:
+      '*':
+        tag: CIS-4.2.3
+        function: check_if_any_pkg_installed
+        args:
+          - rsyslog, syslog-ng
+    description: Ensure rsyslog or syslog-ng is installed
+  system_account_non_login:
+    data:
+      '*':
+        tag: CIS-5.4.2
+        function: system_account_non_login
+    description: Ensure system accounts are non-login
+  default_group_for_root_account:
+    data:
+      '*':
+        tag: CIS-5.4.3
+        function: default_group_for_root
+    description: Ensure default group for the root account is GID 0
+  check_log_files_permission:
+    data:
+      '*':
+        tag: CIS-4.2.4
+        function: check_directory_files_permission
+        args:
+          - /var/log
+          - 740
+    description: Ensure permissions on all logfiles are configured
+  ensure_password_fields_non_empty:
+    data:
+      '*':
+        tag: CIS-6.2.1
+        function: check_password_fields_not_empty
+    description: Ensure password fields are not empty
+  check_path_integrity:
+    data:
+      '*':
+        tag: CIS-6.2.6
+        function: check_path_integrity
+    description: Ensure root PATH Integrity
+  valid_home_directory:
+    data:
+      '*':
+        tag: CIS-6.2.7
+        function: check_all_users_home_directory
+        args:
+        - 1000
+    description: 'Ensure all users home directories exist'
+  home_directory_permission:
+    data:
+      '*':
+        tag: CIS-6.2.8
+        function: check_users_home_directory_permissions
+    description: 'Ensure users home directories permissions are 750 or more restrictive'
+  user_own_home_directory:
+    data:
+      '*':
+        tag: CIS-6.2.9
+        function: check_users_own_their_home
+        args:
+        - 1000
+    description: Ensure users own their home directories
+  check_users_dot_files_not_writable:
+    data:
+      '*':
+        tag: CIS-6.2.10
+        function: check_users_dot_files
+    description: Ensure users dot files are not group or world writable
+  check_users_not_forward_files:
+    data:
+      '*':
+        tag: CIS-6.2.11
+        function: check_users_forward_files
+    description: 'Ensure no users have .forward files'
+  check_no_users_netrc_files:
+    data:
+      '*':
+        tag: CIS-6.2.12
+        function: check_users_netrc_files
+    description: Ensure no users have .netrc files
+  check_netrc_files_permission:
+    data:
+      '*':
+        tag: CIS-6.2.13
+        function: check_netrc_files_accessibility
+    description: Ensure users .netrc Files are not group or world accessible
+  user_rhosts_files_check:
+    data:
+      '*':
+        tag: CIS-6.2.14
+        function: check_users_rhosts_files
+    description: Ensure no users have .rhosts files
+  check_groups_validity_in_systemfiles:
+    data:
+      '*':
+        tag: CIS-6.2.15
+        function: check_groups_validity
+    description: Ensure all groups in /etc/passwd exist in /etc/group
+  no_duplicate_sid:
+    data:
+      '*':
+        tag: CIS-6.2.16
+        function: check_duplicate_uids
+    description: Ensure no duplicate UIDs exist
+  no_duplicate_gid:
+    data:
+      '*':
+        tag: CIS-6.2.17
+        function: check_duplicate_gids
+    description: Ensure no duplicate GIDs exist
+  check_duplicate_unames_exist:
+    data:
+      '*':
+        tag: CIS-6.2.18
+        function: check_duplicate_unames
+    description: Ensure no duplicate user names exist
+  check_duplicate_gnames_exist:
+    data:
+      '*':
+        tag: CIS-6.2.19
+        function: check_duplicate_gnames
+    description: Ensure no duplicate group names exist

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -1173,161 +1173,161 @@ sysctl:
           match_output: '1'
           tag: CIS-3.2.8
     description: Ensure TCP SYN Cookies is enabled
-#misc:
-#  check_any_package:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#       tag: CIS-4.2.3
-#       function: check_if_any_pkg_installed
-#       args:
-#         - rsyslog, syslog-ng
-#    description: Ensure rsyslog or syslog-ng is installed
-#  check_log_files_permission:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#       tag: CIS-4.2.4
-#       function: check_directory_files_permission
-#       args:
-#        - /var/log
-#        - 740
-#    description: Ensure permissions on all logfiles are configured
-#  sshd_approved_macs:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#       tag: CIS-5.2.12
-#       function: check_list_values
-#       args:
-#         - /etc/ssh/sshd_config
-#         - '^MACs'
-#         - '^MACs(.*)$'
-#         - null
-#         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
-#         - null
-#         - ','
-#    description: Ensure only approved MAC algorithms are used
-#  sshd_approved_ciphers:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#       tag: CIS-5.2.11
-#       function: check_list_values
-#       args:
-#         - /etc/ssh/sshd_config
-#         - '^Ciphers'
-#         - '^Ciphers(.*)$'
-#         - null
-#         - 'aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com,chacha20-poly1305@openssh.com'
-#         - null
-#         - ','
-#    description: Ensure only approved ciphers are used
-#  system_account_non_login:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-5.4.2
-#        function: system_account_non_login
-#    description: Ensure system accounts are non-login
-#  default_group_for_root_account:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-5.4.3
-#        function: default_group_for_root
-#    description: Ensure default group for the root account is GID 0
-#  ensure_password_fields_non_empty:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.1
-#        function: check_password_fields_not_empty
-#    description: Ensure password fields are not empty
-#  root_is_only_uid_0_account:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.5
-#        function: root_is_only_uid_0_account
-#    description: Ensure root is the only UID 0 account
-#  check_path_integrity:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.6
-#        function: check_path_integrity
-#    description: Ensure root PATH Integrity
-#  valid_home_directory:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.7
-#        function: check_all_users_home_directory
-#        args:
-#        - 1000
-#    description: Ensure all users home directories exist
-#  home_directory_permission:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.8
-#        function: check_users_home_directory_permissions
-#    description: Ensure users home directories permissions are 750 or more restrictive
-#  user_own_home_directory:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.9
-#        function: check_users_own_their_home
-#        args:
-#        - 1000
-#    description: Ensure users own their home directories
-#  check_users_dot_files_not_writable:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.10
-#        function: check_users_dot_files
-#    description: Ensure users dot files are not group or world writable
-#  check_users_not_forward_files:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.11
-#        function: check_users_forward_files
-#    description: Ensure no users have .forward files
-#  check_no_users_netrc_files:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.12
-#        function: check_users_netrc_files
-#    description: Ensure no users have .netrc files
-#  check_netrc_files_not_world_writable:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.13
-#        function: check_netrc_files_accessibility
-#    description: Ensure users .netrc Files are not group or world accessible
-#  check_no_users_have_rhosts_files:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.14
-#        function: check_users_rhosts_files
-#    description: Ensure no users have .rhosts files
-#  check_groups_validity_in_systemfiles:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.15
-#        function: check_groups_validity
-#    description: Ensure all groups in /etc/passwd exist in /etc/group
-#  no_duplicate_sid:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.16
-#        function: check_duplicate_uids
-#    description: Ensure no duplicate UIDs exist
-#  no_duplicate_gid:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.17
-#        function: check_duplicate_gids
-#    description: Ensure no duplicate GIDs exist
-#  check_duplicate_unames_exist:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.18
-#        function: check_duplicate_unames
-#    description: Ensure no duplicate user names exist
-#  check_duplicate_gnames_exist:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.19
-#        function: check_duplicate_gnames
-#    description: Ensure no duplicate group names exist
+misc:
+  check_any_package:
+    data:
+      Red Hat Enterprise Linux Server-7:
+       tag: CIS-4.2.3
+       function: check_if_any_pkg_installed
+       args:
+         - rsyslog, syslog-ng
+    description: Ensure rsyslog or syslog-ng is installed
+  check_log_files_permission:
+    data:
+      Red Hat Enterprise Linux Server-7:
+       tag: CIS-4.2.4
+       function: check_directory_files_permission
+       args:
+        - /var/log
+        - 740
+    description: Ensure permissions on all logfiles are configured
+  sshd_approved_macs:
+    data:
+      Red Hat Enterprise Linux Server-7:
+       tag: CIS-5.2.12
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^MACs'
+         - '^MACs(.*)$'
+         - null
+         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+         - null
+         - ','
+    description: Ensure only approved MAC algorithms are used
+  sshd_approved_ciphers:
+    data:
+      Red Hat Enterprise Linux Server-7:
+       tag: CIS-5.2.11
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^Ciphers'
+         - '^Ciphers(.*)$'
+         - null
+         - 'aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com,chacha20-poly1305@openssh.com'
+         - null
+         - ','
+    description: Ensure only approved ciphers are used
+  system_account_non_login:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-5.4.2
+        function: system_account_non_login
+    description: Ensure system accounts are non-login
+  default_group_for_root_account:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-5.4.3
+        function: default_group_for_root
+    description: Ensure default group for the root account is GID 0
+  ensure_password_fields_non_empty:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.1
+        function: check_password_fields_not_empty
+    description: Ensure password fields are not empty
+  root_is_only_uid_0_account:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.5
+        function: root_is_only_uid_0_account
+    description: Ensure root is the only UID 0 account
+  check_path_integrity:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.6
+        function: check_path_integrity
+    description: Ensure root PATH Integrity
+  valid_home_directory:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.7
+        function: check_all_users_home_directory
+        args:
+        - 1000
+    description: Ensure all users home directories exist
+  home_directory_permission:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.8
+        function: check_users_home_directory_permissions
+    description: Ensure users home directories permissions are 750 or more restrictive
+  user_own_home_directory:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.9
+        function: check_users_own_their_home
+        args:
+        - 1000
+    description: Ensure users own their home directories
+  check_users_dot_files_not_writable:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.10
+        function: check_users_dot_files
+    description: Ensure users dot files are not group or world writable
+  check_users_not_forward_files:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.11
+        function: check_users_forward_files
+    description: Ensure no users have .forward files
+  check_no_users_netrc_files:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.12
+        function: check_users_netrc_files
+    description: Ensure no users have .netrc files
+  check_netrc_files_not_world_writable:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.13
+        function: check_netrc_files_accessibility
+    description: Ensure users .netrc Files are not group or world accessible
+  check_no_users_have_rhosts_files:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.14
+        function: check_users_rhosts_files
+    description: Ensure no users have .rhosts files
+  check_groups_validity_in_systemfiles:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.15
+        function: check_groups_validity
+    description: Ensure all groups in /etc/passwd exist in /etc/group
+  no_duplicate_sid:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.16
+        function: check_duplicate_uids
+    description: Ensure no duplicate UIDs exist
+  no_duplicate_gid:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.17
+        function: check_duplicate_gids
+    description: Ensure no duplicate GIDs exist
+  check_duplicate_unames_exist:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.18
+        function: check_duplicate_unames
+    description: Ensure no duplicate user names exist
+  check_duplicate_gnames_exist:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.19
+        function: check_duplicate_gnames
+    description: Ensure no duplicate group names exist

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -1271,12 +1271,12 @@ misc:
         args:
         - 1000
     description: Ensure users own their home directories
-  check_users_dot_files_not_writable:
-    data:
-      Red Hat Enterprise Linux Server-7:
-        tag: CIS-6.2.10
-        function: check_users_dot_files
-    description: Ensure users dot files are not group or world writable
+#  check_users_dot_files_not_writable:
+#    data:
+#      Red Hat Enterprise Linux Server-7:
+#        tag: CIS-6.2.10
+#        function: check_users_dot_files
+#    description: Ensure users dot files are not group or world writable
   check_users_not_forward_files:
     data:
       Red Hat Enterprise Linux Server-7:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-2-0.yaml
@@ -1233,167 +1233,167 @@ sysctl:
           match_output: '1'
           tag: CIS-3.2.8
     description: Ensure TCP SYN Cookies is enabled
-#misc:
-#  mail_configured_for_local_only_mode:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-2.2.15
-#        function: mail_conf_check
-#    description: Ensure mail transfer agent is configured for local-only mode
-#  check_any_package:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#       tag: CIS-4.2.3
-#       function: check_if_any_pkg_installed
-#       args:
-#         - rsyslog, syslog-ng
-#    description: Ensure rsyslog or syslog-ng is installed
-#  check_log_files_permission:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#       tag: CIS-4.2.4
-#       function: check_directory_files_permission
-#       args:
-#        - /var/log
-#        - 740
-#    description: Ensure permissions on all logfiles are configured
-#  sshd_approved_macs:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#       tag: CIS-5.2.11
-#       function: check_list_values
-#       args:
-#         - /etc/ssh/sshd_config
-#         - '^MACs'
-#         - '^MACs(.*)$'
-#         - null
-#         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
-#         - null
-#         - ','
-#    description: Ensure only approved MAC algorithms are used
-#  sshd_approved_ciphers:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#       tag: CIS-5.2.11.1
-#       function: check_list_values
-#       args:
-#         - /etc/ssh/sshd_config
-#         - '^Ciphers'
-#         - '^Ciphers(.*)$'
-#         - null
-#         - 'aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com,chacha20-poly1305@openssh.com'
-#         - null
-#         - ','
-#    description: Ensure only approved ciphers are used
-#  system_account_non_login:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-5.4.2
-#        function: system_account_non_login
-#    description: Ensure system accounts are non-login
-#  default_group_for_root_account:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-5.4.3
-#        function: default_group_for_root
-#    description: Ensure default group for the root account is GID 0
-#  ensure_password_fields_non_empty:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.1
-#        function: check_password_fields_not_empty
-#    description: Ensure password fields are not empty
-#  root_is_only_uid_0_account:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.5
-#        function: root_is_only_uid_0_account
-#    description: Ensure root is the only UID 0 account
-#  check_path_integrity:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.6
-#        function: check_path_integrity
-#    description: Ensure root PATH Integrity
-#  valid_home_directory:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.7
-#        function: check_all_users_home_directory
-#        args:
-#        - 1000
-#    description: Ensure all users home directories exist
-#  home_directory_permission:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.8
-#        function: check_users_home_directory_permissions
-#    description: Ensure users home directories permissions are 750 or more restrictive
-#  user_own_home_directory:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.9
-#        function: check_users_own_their_home
-#        args:
-#        - 1000
-#    description: Ensure users own their home directories
-#  check_users_dot_files_not_writable:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.10
-#        function: check_users_dot_files
-#    description: Ensure users dot files are not group or world writable
-#  check_users_not_forward_files:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.11
-#        function: check_users_forward_files
-#    description: Ensure no users have .forward files
-#  check_no_users_netrc_files:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.12
-#        function: check_users_netrc_files
-#    description: Ensure no users have .netrc files
-#  check_netrc_files_not_world_writable:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.13
-#        function: check_netrc_files_accessibility
-#    description: Ensure users .netrc Files are not group or world accessible
-#  check_no_users_have_rhosts_files:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.14
-#        function: check_users_rhosts_files
-#    description: Ensure no users have .rhosts files
-#  check_groups_validity_in_systemfiles:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.15
-#        function: check_groups_validity
-#    description: Ensure all groups in /etc/passwd exist in /etc/group
-#  no_duplicate_sid:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.16
-#        function: check_duplicate_uids
-#    description: Ensure no duplicate UIDs exist
-#  no_duplicate_gid:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.17
-#        function: check_duplicate_gids
-#    description: Ensure no duplicate GIDs exist
-#  check_duplicate_unames_exist:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.18
-#        function: check_duplicate_unames
-#    description: Ensure no duplicate user names exist
-#  check_duplicate_gnames_exist:
-#    data:
-#      Red Hat Enterprise Linux Server-7:
-#        tag: CIS-6.2.19
-#        function: check_duplicate_gnames
-#    description: Ensure no duplicate group names exist
+misc:
+  mail_configured_for_local_only_mode:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-2.2.15
+        function: mail_conf_check
+    description: Ensure mail transfer agent is configured for local-only mode
+  check_any_package:
+    data:
+      Red Hat Enterprise Linux Server-7:
+       tag: CIS-4.2.3
+       function: check_if_any_pkg_installed
+       args:
+         - rsyslog, syslog-ng
+    description: Ensure rsyslog or syslog-ng is installed
+  check_log_files_permission:
+    data:
+      Red Hat Enterprise Linux Server-7:
+       tag: CIS-4.2.4
+       function: check_directory_files_permission
+       args:
+        - /var/log
+        - 740
+    description: Ensure permissions on all logfiles are configured
+  sshd_approved_macs:
+    data:
+      Red Hat Enterprise Linux Server-7:
+       tag: CIS-5.2.11
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^MACs'
+         - '^MACs(.*)$'
+         - null
+         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+         - null
+         - ','
+    description: Ensure only approved MAC algorithms are used
+  sshd_approved_ciphers:
+    data:
+      Red Hat Enterprise Linux Server-7:
+       tag: CIS-5.2.11.1
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^Ciphers'
+         - '^Ciphers(.*)$'
+         - null
+         - 'aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com,chacha20-poly1305@openssh.com'
+         - null
+         - ','
+    description: Ensure only approved ciphers are used
+  system_account_non_login:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-5.4.2
+        function: system_account_non_login
+    description: Ensure system accounts are non-login
+  default_group_for_root_account:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-5.4.3
+        function: default_group_for_root
+    description: Ensure default group for the root account is GID 0
+  ensure_password_fields_non_empty:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.1
+        function: check_password_fields_not_empty
+    description: Ensure password fields are not empty
+  root_is_only_uid_0_account:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.5
+        function: root_is_only_uid_0_account
+    description: Ensure root is the only UID 0 account
+  check_path_integrity:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.6
+        function: check_path_integrity
+    description: Ensure root PATH Integrity
+  valid_home_directory:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.7
+        function: check_all_users_home_directory
+        args:
+        - 1000
+    description: Ensure all users home directories exist
+  home_directory_permission:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.8
+        function: check_users_home_directory_permissions
+    description: Ensure users home directories permissions are 750 or more restrictive
+  user_own_home_directory:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.9
+        function: check_users_own_their_home
+        args:
+        - 1000
+    description: Ensure users own their home directories
+  check_users_dot_files_not_writable:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.10
+        function: check_users_dot_files
+    description: Ensure users dot files are not group or world writable
+  check_users_not_forward_files:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.11
+        function: check_users_forward_files
+    description: Ensure no users have .forward files
+  check_no_users_netrc_files:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.12
+        function: check_users_netrc_files
+    description: Ensure no users have .netrc files
+  check_netrc_files_not_world_writable:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.13
+        function: check_netrc_files_accessibility
+    description: Ensure users .netrc Files are not group or world accessible
+  check_no_users_have_rhosts_files:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.14
+        function: check_users_rhosts_files
+    description: Ensure no users have .rhosts files
+  check_groups_validity_in_systemfiles:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.15
+        function: check_groups_validity
+    description: Ensure all groups in /etc/passwd exist in /etc/group
+  no_duplicate_sid:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.16
+        function: check_duplicate_uids
+    description: Ensure no duplicate UIDs exist
+  no_duplicate_gid:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.17
+        function: check_duplicate_gids
+    description: Ensure no duplicate GIDs exist
+  check_duplicate_unames_exist:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.18
+        function: check_duplicate_unames
+    description: Ensure no duplicate user names exist
+  check_duplicate_gnames_exist:
+    data:
+      Red Hat Enterprise Linux Server-7:
+        tag: CIS-6.2.19
+        function: check_duplicate_gnames
+    description: Ensure no duplicate group names exist

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-2-0.yaml
@@ -1337,12 +1337,12 @@ misc:
         args:
         - 1000
     description: Ensure users own their home directories
-  check_users_dot_files_not_writable:
-    data:
-      Red Hat Enterprise Linux Server-7:
-        tag: CIS-6.2.10
-        function: check_users_dot_files
-    description: Ensure users dot files are not group or world writable
+#  check_users_dot_files_not_writable:
+#    data:
+#      Red Hat Enterprise Linux Server-7:
+#        tag: CIS-6.2.10
+#        function: check_users_dot_files
+#    description: Ensure users dot files are not group or world writable
   check_users_not_forward_files:
     data:
       Red Hat Enterprise Linux Server-7:

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
@@ -1252,12 +1252,12 @@ misc:
         args:
         - 1000
     description: Ensure users own their home directories
-  check_users_dot_files_not_writable:
-    data:
-      Ubuntu-16.04:
-        tag: CIS-6.2.10
-        function: check_users_dot_files
-    description: Ensure users dot files are not group or world writable
+#  check_users_dot_files_not_writable:
+#    data:
+#      Ubuntu-16.04:
+#        tag: CIS-6.2.10
+#        function: check_users_dot_files
+#    description: Ensure users dot files are not group or world writable
   check_users_not_forward_files:
     data:
       Ubuntu-16.04:

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
@@ -1151,167 +1151,167 @@ stat:
           uid: 0
           user: root
     description: 'Ensure permissions on /etc/gshadow- are configured'
-#misc:
-#  sticky_bit_on_world_writable_directories:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-1.1.20
-#        function: sticky_bit_on_world_writable_dirs
-#    description: Ensure sticky bit is set on all world-writable directories
-#  check_log_files_permission:
-#    data:
-#      Ubuntu-16.04:
-#       tag: CIS-4.2.4
-#       function: check_directory_files_permission
-#       args:
-#        - /var/log
-#        - 740
-#    description: Ensure permissions on all logfiles are configured
-#  system_account_non_login:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-5.4.2
-#        function: system_account_non_login
-#    description: Ensure system accounts are non-login
-#    control: Code change required for filtering the users by their login shell
-#  default_group_for_root_account:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-5.4.3
-#        function: default_group_for_root
-#    description: 'Ensure default group for the root account is GID 0'
-#  sshd_approved_macs:
-#    data:
-#      Ubuntu-16.04:
-#       tag: CIS-5.2.11
-#       function: check_list_values
-#       args:
-#         - /etc/ssh/sshd_config
-#         - '^MACs'
-#         - '^MACs(.*)$'
-#         - null
-#         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
-#         - null
-#         - ','
-#    description: Ensure only approved MAC algorithms are used
-#  no_world_writable_file:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.1.10
-#        function: world_writable_file
-#    description: Ensure no world writable files exist
-#  no_unowned_file_or_directories:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.1.11
-#        function: unowned_files_or_dir
-#    description: Ensure no unowned files or directories exist
-#  no_ungrouped_file_or_directories:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.1.12
-#        function: ungrouped_files_or_dir
-#    description: Ensure no ungrouped files or directories exist
-#  ensure_password_fields_non_empty:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.1
-#        function: check_password_fields_not_empty
-#    description: Ensure password fields are not empty
-#  root_is_only_uid_0_account:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.5
-#        function: root_is_only_uid_0_account
-#    description: 'Ensure root is the only UID 0 account'
-#  check_path_integrity:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.6
-#        function: check_path_integrity
-#    description: Ensure root PATH Integrity
-#  valid_home_directory:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.7
-#        function: check_all_users_home_directory
-#        args:
-#        - 1000
-#    description: 'Ensure all users home directories exist'
-#  home_directory_permission:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.8
-#        function: check_users_home_directory_permissions
-#    description: 'Ensure users home directories permissions are 750 or more restrictive'
-#  user_own_home_directory:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.9
-#        function: check_users_own_their_home
-#        args:
-#        - 1000
-#    description: Ensure users own their home directories
-#  check_users_dot_files_not_writable:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.10
-#        function: check_users_dot_files
-#    description: Ensure users dot files are not group or world writable
-#  check_users_not_forward_files:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.11
-#        function: check_users_forward_files
-#    description: 'Ensure no users have .forward files'
-#  check_no_users_netrc_files:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.12
-#        function: check_users_netrc_files
-#    description: Ensure no users have .netrc files
-#  check_netrc_files_not_world_writable:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.13
-#        function: check_netrc_files_accessibility
-#    description: 'Ensure users .netrc Files are not group or world accessible'
-#  check_no_users_have_rhosts_files:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.14
-#        function: check_users_rhosts_files
-#    description: Ensure no users have .rhosts files
-#  check_groups_validity_in_systemfiles:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.15
-#        function: check_groups_validity
-#    description: Ensure all groups in /etc/passwd exist in /etc/group
-#  no_duplicate_sid:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.16
-#        function: check_duplicate_uids
-#    description: Ensure no duplicate UIDs exist
-#  no_duplicate_gid:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.17
-#        function: check_duplicate_gids
-#    description: Ensure no duplicate GIDs exist
-#  check_duplicate_unames_exist:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.18
-#        function: check_duplicate_unames
-#    description: Ensure no duplicate user names exist
-#  check_duplicate_gnames_exist:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.19
-#        function: check_duplicate_gnames
-#    description: Ensure no duplicate group names exist
+misc:
+  sticky_bit_on_world_writable_directories:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-1.1.20
+        function: sticky_bit_on_world_writable_dirs
+    description: Ensure sticky bit is set on all world-writable directories
+  check_log_files_permission:
+    data:
+      Ubuntu-16.04:
+       tag: CIS-4.2.4
+       function: check_directory_files_permission
+       args:
+        - /var/log
+        - 740
+    description: Ensure permissions on all logfiles are configured
+  system_account_non_login:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-5.4.2
+        function: system_account_non_login
+    description: Ensure system accounts are non-login
+    control: Code change required for filtering the users by their login shell
+  default_group_for_root_account:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-5.4.3
+        function: default_group_for_root
+    description: 'Ensure default group for the root account is GID 0'
+  sshd_approved_macs:
+    data:
+      Ubuntu-16.04:
+       tag: CIS-5.2.11
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^MACs'
+         - '^MACs(.*)$'
+         - null
+         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+         - null
+         - ','
+    description: Ensure only approved MAC algorithms are used
+  no_world_writable_file:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.1.10
+        function: world_writable_file
+    description: Ensure no world writable files exist
+  no_unowned_file_or_directories:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.1.11
+        function: unowned_files_or_dir
+    description: Ensure no unowned files or directories exist
+  no_ungrouped_file_or_directories:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.1.12
+        function: ungrouped_files_or_dir
+    description: Ensure no ungrouped files or directories exist
+  ensure_password_fields_non_empty:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.1
+        function: check_password_fields_not_empty
+    description: Ensure password fields are not empty
+  root_is_only_uid_0_account:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.5
+        function: root_is_only_uid_0_account
+    description: 'Ensure root is the only UID 0 account'
+  check_path_integrity:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.6
+        function: check_path_integrity
+    description: Ensure root PATH Integrity
+  valid_home_directory:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.7
+        function: check_all_users_home_directory
+        args:
+        - 1000
+    description: 'Ensure all users home directories exist'
+  home_directory_permission:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.8
+        function: check_users_home_directory_permissions
+    description: 'Ensure users home directories permissions are 750 or more restrictive'
+  user_own_home_directory:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.9
+        function: check_users_own_their_home
+        args:
+        - 1000
+    description: Ensure users own their home directories
+  check_users_dot_files_not_writable:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.10
+        function: check_users_dot_files
+    description: Ensure users dot files are not group or world writable
+  check_users_not_forward_files:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.11
+        function: check_users_forward_files
+    description: 'Ensure no users have .forward files'
+  check_no_users_netrc_files:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.12
+        function: check_users_netrc_files
+    description: Ensure no users have .netrc files
+  check_netrc_files_not_world_writable:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.13
+        function: check_netrc_files_accessibility
+    description: 'Ensure users .netrc Files are not group or world accessible'
+  check_no_users_have_rhosts_files:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.14
+        function: check_users_rhosts_files
+    description: Ensure no users have .rhosts files
+  check_groups_validity_in_systemfiles:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.15
+        function: check_groups_validity
+    description: Ensure all groups in /etc/passwd exist in /etc/group
+  no_duplicate_sid:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.16
+        function: check_duplicate_uids
+    description: Ensure no duplicate UIDs exist
+  no_duplicate_gid:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.17
+        function: check_duplicate_gids
+    description: Ensure no duplicate GIDs exist
+  check_duplicate_unames_exist:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.18
+        function: check_duplicate_unames
+    description: Ensure no duplicate user names exist
+  check_duplicate_gnames_exist:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.19
+        function: check_duplicate_gnames
+    description: Ensure no duplicate group names exist
 systemctl:
   whitelist:
     rsyslog_enabled:

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-1-0.yaml
@@ -1235,12 +1235,12 @@ misc:
         args:
         - 1000
     description: Ensure users own their home directories
-  check_users_dot_files_not_writable:
-    data:
-      Ubuntu-16.04:
-        tag: CIS-6.2.10
-        function: check_users_dot_files
-    description: Ensure users dot files are not group or world writable
+#  check_users_dot_files_not_writable:
+#    data:
+#      Ubuntu-16.04:
+#        tag: CIS-6.2.10
+#        function: check_users_dot_files
+#    description: Ensure users dot files are not group or world writable
   check_users_not_forward_files:
     data:
       Ubuntu-16.04:

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-1-0.yaml
@@ -1158,143 +1158,143 @@ stat:
           uid: 0
           user: root
     description: 'Ensure permissions on /etc/gshadow- are configured'
-#misc:
-#  check_log_files_permission:
-#    data:
-#      Ubuntu-16.04:
-#       tag: CIS-4.2.4
-#       function: check_directory_files_permission
-#       args:
-#        - /var/log
-#        - 740
-#    description: Ensure permissions on all logfiles are configured
-#  system_account_non_login:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-5.4.2
-#        function: system_account_non_login
-#    description: Ensure system accounts are non-login
-#    control: Code change required for filtering the users by their login shell
-#  default_group_for_root_account:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-5.4.3
-#        function: default_group_for_root
-#    description: 'Ensure default group for the root account is GID 0'
-#  sshd_approved_macs:
-#    data:
-#      Ubuntu-16.04:
-#       tag: CIS-5.2.11
-#       function: check_list_values
-#       args:
-#         - /etc/ssh/sshd_config
-#         - '^MACs'
-#         - '^MACs(.*)$'
-#         - null
-#         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
-#         - null
-#         - ','
-#    description: Ensure only approved MAC algorithms are used
-#  ensure_password_fields_non_empty:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.1
-#        function: check_password_fields_not_empty
-#    description: Ensure password fields are not empty
-#  root_is_only_uid_0_account:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.5
-#        function: root_is_only_uid_0_account
-#    description: 'Ensure root is the only UID 0 account'
-#  check_path_integrity:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.6
-#        function: check_path_integrity
-#    description: Ensure root PATH Integrity
-#  valid_home_directory:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.7
-#        function: check_all_users_home_directory
-#        args:
-#        - 1000
-#    description: 'Ensure all users home directories exist'
-#  home_directory_permission:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.8
-#        function: check_users_home_directory_permissions
-#    description: 'Ensure users home directories permissions are 750 or more restrictive'
-#  user_own_home_directory:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.9
-#        function: check_users_own_their_home
-#        args:
-#        - 1000
-#    description: Ensure users own their home directories
-#  check_users_dot_files_not_writable:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.10
-#        function: check_users_dot_files
-#    description: Ensure users dot files are not group or world writable
-#  check_users_not_forward_files:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.11
-#        function: check_users_forward_files
-#    description: 'Ensure no users have .forward files'
-#  check_no_users_netrc_files:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.12
-#        function: check_users_netrc_files
-#    description: Ensure no users have .netrc files
-#  check_netrc_files_not_world_writable:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.13
-#        function: check_netrc_files_accessibility
-#    description: 'Ensure users .netrc Files are not group or world accessible'
-#  check_no_users_have_rhosts_files:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.14
-#        function: check_users_rhosts_files
-#    description: Ensure no users have .rhosts files
-#  check_groups_validity_in_systemfiles:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.15
-#        function: check_groups_validity
-#    description: Ensure all groups in /etc/passwd exist in /etc/group
-#  no_duplicate_sid:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.16
-#        function: check_duplicate_uids
-#    description: Ensure no duplicate UIDs exist
-#  no_duplicate_gid:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.17
-#        function: check_duplicate_gids
-#    description: Ensure no duplicate GIDs exist
-#  check_duplicate_unames_exist:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.18
-#        function: check_duplicate_unames
-#    description: Ensure no duplicate user names exist
-#  check_duplicate_gnames_exist:
-#    data:
-#      Ubuntu-16.04:
-#        tag: CIS-6.2.19
-#        function: check_duplicate_gnames
-#    description: Ensure no duplicate group names exist
+misc:
+  check_log_files_permission:
+    data:
+      Ubuntu-16.04:
+       tag: CIS-4.2.4
+       function: check_directory_files_permission
+       args:
+        - /var/log
+        - 740
+    description: Ensure permissions on all logfiles are configured
+  system_account_non_login:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-5.4.2
+        function: system_account_non_login
+    description: Ensure system accounts are non-login
+    control: Code change required for filtering the users by their login shell
+  default_group_for_root_account:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-5.4.3
+        function: default_group_for_root
+    description: 'Ensure default group for the root account is GID 0'
+  sshd_approved_macs:
+    data:
+      Ubuntu-16.04:
+       tag: CIS-5.2.11
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^MACs'
+         - '^MACs(.*)$'
+         - null
+         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+         - null
+         - ','
+    description: Ensure only approved MAC algorithms are used
+  ensure_password_fields_non_empty:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.1
+        function: check_password_fields_not_empty
+    description: Ensure password fields are not empty
+  root_is_only_uid_0_account:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.5
+        function: root_is_only_uid_0_account
+    description: 'Ensure root is the only UID 0 account'
+  check_path_integrity:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.6
+        function: check_path_integrity
+    description: Ensure root PATH Integrity
+  valid_home_directory:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.7
+        function: check_all_users_home_directory
+        args:
+        - 1000
+    description: 'Ensure all users home directories exist'
+  home_directory_permission:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.8
+        function: check_users_home_directory_permissions
+    description: 'Ensure users home directories permissions are 750 or more restrictive'
+  user_own_home_directory:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.9
+        function: check_users_own_their_home
+        args:
+        - 1000
+    description: Ensure users own their home directories
+  check_users_dot_files_not_writable:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.10
+        function: check_users_dot_files
+    description: Ensure users dot files are not group or world writable
+  check_users_not_forward_files:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.11
+        function: check_users_forward_files
+    description: 'Ensure no users have .forward files'
+  check_no_users_netrc_files:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.12
+        function: check_users_netrc_files
+    description: Ensure no users have .netrc files
+  check_netrc_files_not_world_writable:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.13
+        function: check_netrc_files_accessibility
+    description: 'Ensure users .netrc Files are not group or world accessible'
+  check_no_users_have_rhosts_files:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.14
+        function: check_users_rhosts_files
+    description: Ensure no users have .rhosts files
+  check_groups_validity_in_systemfiles:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.15
+        function: check_groups_validity
+    description: Ensure all groups in /etc/passwd exist in /etc/group
+  no_duplicate_sid:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.16
+        function: check_duplicate_uids
+    description: Ensure no duplicate UIDs exist
+  no_duplicate_gid:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.17
+        function: check_duplicate_gids
+    description: Ensure no duplicate GIDs exist
+  check_duplicate_unames_exist:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.18
+        function: check_duplicate_unames
+    description: Ensure no duplicate user names exist
+  check_duplicate_gnames_exist:
+    data:
+      Ubuntu-16.04:
+        tag: CIS-6.2.19
+        function: check_duplicate_gnames
+    description: Ensure no duplicate group names exist
 systemctl:
   whitelist:
     rsyslog_enabled:

--- a/hubblestack_nova_profiles/cis/ubuntu-1804-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1804-level-1-scored-v1-0-0.yaml
@@ -1198,143 +1198,143 @@ stat:
           uid: 0
           user: root
     description: 'Ensure permissions on /etc/gshadow- are configured'
-#misc:
-#  check_log_files_permission:
-#    data:
-#      Ubuntu-18.04:
-#       tag: CIS-4.2.4
-#       function: check_directory_files_permission
-#       args:
-#        - /var/log
-#        - 740
-#    description: Ensure permissions on all logfiles are configured
-#  system_account_non_login:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-5.4.2
-#        function: system_account_non_login
-#    description: Ensure system accounts are non-login
-#    control: Code change required for filtering the users by their login shell
-#  default_group_for_root_account:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-5.4.3
-#        function: default_group_for_root
-#    description: 'Ensure default group for the root account is GID 0'
-#  sshd_approved_macs:
-#    data:
-#      Ubuntu-18.04:
-#       tag: CIS-5.2.11
-#       function: check_list_values
-#       args:
-#         - /etc/ssh/sshd_config
-#         - '^MACs'
-#         - '^MACs(.*)$'
-#         - null
-#         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
-#         - null
-#         - ','
-#    description: Ensure only approved MAC algorithms are used
-#  ensure_password_fields_non_empty:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.1
-#        function: check_password_fields_not_empty
-#    description: Ensure password fields are not empty
-#  root_is_only_uid_0_account:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.5
-#        function: root_is_only_uid_0_account
-#    description: 'Ensure root is the only UID 0 account'
-#  check_path_integrity:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.6
-#        function: check_path_integrity
-#    description: Ensure root PATH Integrity
-#  valid_home_directory:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.7
-#        function: check_all_users_home_directory
-#        args:
-#        - 1000
-#    description: 'Ensure all users home directories exist'
-#  home_directory_permission:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.8
-#        function: check_users_home_directory_permissions
-#    description: 'Ensure users home directories permissions are 750 or more restrictive'
-#  user_own_home_directory:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.9
-#        function: check_users_own_their_home
-#        args:
-#        - 1000
-#    description: Ensure users own their home directories
-#  check_users_dot_files_not_writable:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.10
-#        function: check_users_dot_files
-#    description: Ensure users dot files are not group or world writable
-#  check_users_not_forward_files:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.11
-#        function: check_users_forward_files
-#    description: 'Ensure no users have .forward files'
-#  check_no_users_netrc_files:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.12
-#        function: check_users_netrc_files
-#    description: Ensure no users have .netrc files
-#  check_netrc_files_not_world_writable:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.13
-#        function: check_netrc_files_accessibility
-#    description: 'Ensure users .netrc Files are not group or world accessible'
-#  check_no_users_have_rhosts_files:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.14
-#        function: check_users_rhosts_files
-#    description: Ensure no users have .rhosts files
-#  check_groups_validity_in_systemfiles:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.15
-#        function: check_groups_validity
-#    description: Ensure all groups in /etc/passwd exist in /etc/group
-#  no_duplicate_sid:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.16
-#        function: check_duplicate_uids
-#    description: Ensure no duplicate UIDs exist
-#  no_duplicate_gid:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.17
-#        function: check_duplicate_gids
-#    description: Ensure no duplicate GIDs exist
-#  check_duplicate_unames_exist:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.18
-#        function: check_duplicate_unames
-#    description: Ensure no duplicate user names exist
-#  check_duplicate_gnames_exist:
-#    data:
-#      Ubuntu-18.04:
-#        tag: CIS-6.2.19
-#        function: check_duplicate_gnames
-#    description: Ensure no duplicate group names exist
+misc:
+  check_log_files_permission:
+    data:
+      Ubuntu-18.04:
+       tag: CIS-4.2.4
+       function: check_directory_files_permission
+       args:
+        - /var/log
+        - 740
+    description: Ensure permissions on all logfiles are configured
+  system_account_non_login:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-5.4.2
+        function: system_account_non_login
+    description: Ensure system accounts are non-login
+    control: Code change required for filtering the users by their login shell
+  default_group_for_root_account:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-5.4.3
+        function: default_group_for_root
+    description: 'Ensure default group for the root account is GID 0'
+  sshd_approved_macs:
+    data:
+      Ubuntu-18.04:
+       tag: CIS-5.2.11
+       function: check_list_values
+       args:
+         - /etc/ssh/sshd_config
+         - '^MACs'
+         - '^MACs(.*)$'
+         - null
+         - hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+         - null
+         - ','
+    description: Ensure only approved MAC algorithms are used
+  ensure_password_fields_non_empty:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.1
+        function: check_password_fields_not_empty
+    description: Ensure password fields are not empty
+  root_is_only_uid_0_account:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.5
+        function: root_is_only_uid_0_account
+    description: 'Ensure root is the only UID 0 account'
+  check_path_integrity:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.6
+        function: check_path_integrity
+    description: Ensure root PATH Integrity
+  valid_home_directory:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.7
+        function: check_all_users_home_directory
+        args:
+        - 1000
+    description: 'Ensure all users home directories exist'
+  home_directory_permission:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.8
+        function: check_users_home_directory_permissions
+    description: 'Ensure users home directories permissions are 750 or more restrictive'
+  user_own_home_directory:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.9
+        function: check_users_own_their_home
+        args:
+        - 1000
+    description: Ensure users own their home directories
+  check_users_dot_files_not_writable:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.10
+        function: check_users_dot_files
+    description: Ensure users dot files are not group or world writable
+  check_users_not_forward_files:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.11
+        function: check_users_forward_files
+    description: 'Ensure no users have .forward files'
+  check_no_users_netrc_files:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.12
+        function: check_users_netrc_files
+    description: Ensure no users have .netrc files
+  check_netrc_files_not_world_writable:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.13
+        function: check_netrc_files_accessibility
+    description: 'Ensure users .netrc Files are not group or world accessible'
+  check_no_users_have_rhosts_files:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.14
+        function: check_users_rhosts_files
+    description: Ensure no users have .rhosts files
+  check_groups_validity_in_systemfiles:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.15
+        function: check_groups_validity
+    description: Ensure all groups in /etc/passwd exist in /etc/group
+  no_duplicate_sid:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.16
+        function: check_duplicate_uids
+    description: Ensure no duplicate UIDs exist
+  no_duplicate_gid:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.17
+        function: check_duplicate_gids
+    description: Ensure no duplicate GIDs exist
+  check_duplicate_unames_exist:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.18
+        function: check_duplicate_unames
+    description: Ensure no duplicate user names exist
+  check_duplicate_gnames_exist:
+    data:
+      Ubuntu-18.04:
+        tag: CIS-6.2.19
+        function: check_duplicate_gnames
+    description: Ensure no duplicate group names exist
 systemctl:
   whitelist:
     rsyslog_enabled:

--- a/hubblestack_nova_profiles/cis/ubuntu-1804-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1804-level-1-scored-v1-0-0.yaml
@@ -1275,12 +1275,12 @@ misc:
         args:
         - 1000
     description: Ensure users own their home directories
-  check_users_dot_files_not_writable:
-    data:
-      Ubuntu-18.04:
-        tag: CIS-6.2.10
-        function: check_users_dot_files
-    description: Ensure users dot files are not group or world writable
+#  check_users_dot_files_not_writable:
+#    data:
+#      Ubuntu-18.04:
+#        tag: CIS-6.2.10
+#        function: check_users_dot_files
+#    description: Ensure users dot files are not group or world writable
   check_users_not_forward_files:
     data:
       Ubuntu-18.04:


### PR DESCRIPTION
We had a host with a bunch of stuff in the dotfiles of a system user and
the find command called by this check was impacting the system.

We'll need to figure out a safer way to do this check.

This also reverts https://github.com/hubblestack/hubblestack_data/pull/146 which was too broad.