### PR TITLE
Disable /var/log permission check

### DIFF
--- a/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/amazon-level-1-scored-v2-1-0.yaml
@@ -1181,15 +1181,15 @@ misc:
         tag: CIS-6.2.1
         function: check_password_fields_not_empty
     description: Ensure password fields are not empty
-  check_log_files_permission:
-    data:
-      'Amazon*Linux*':
-        tag: CIS-4.2.4
-        function: check_directory_files_permission
-        args:
-          - /var/log
-          - 740
-    description: Ensure permissions on all logfiles are configured
+#  check_log_files_permission:
+#    data:
+#      'Amazon*Linux*':
+#        tag: CIS-4.2.4
+#        function: check_directory_files_permission
+#        args:
+#          - /var/log
+#          - 740
+#    description: Ensure permissions on all logfiles are configured
   default_group_for_root_account:
     data:
       'Amazon*Linux*':

--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-2-0.yaml
@@ -1249,15 +1249,15 @@ misc:
         args:
           - rsyslog, syslog-ng
     description: Ensure rsyslog or syslog-ng is installed
-  check_log_files_permission:
-    data:
-      CentOS Linux-7:
-        tag: CIS-4.2.4
-        function: check_directory_files_permission
-        args:
-          - /var/log
-          - 740
-    description: Ensure permissions on all logfiles are configured
+#  check_log_files_permission:
+#    data:
+#      CentOS Linux-7:
+#        tag: CIS-4.2.4
+#        function: check_directory_files_permission
+#        args:
+#          - /var/log
+#          - 740
+#    description: Ensure permissions on all logfiles are configured
   system_account_non_login:
     data:
       CentOS Linux-7:

--- a/hubblestack_nova_profiles/cis/coreos-level-1.yaml
+++ b/hubblestack_nova_profiles/cis/coreos-level-1.yaml
@@ -557,15 +557,15 @@ misc:
        tag: CIS-1.5.1
        function: check_core_dumps
        description: Ensure core dumps are restricted
-  check_log_files_permission:
-    data:
-      '*CoreOS*':
-       tag: CIS-4.2.4
-       function: check_directory_files_permission
-       args:
-        - /var/log
-        - 740
-       description: Ensure permissions on all logfiles are configured
+#  check_log_files_permission:
+#    data:
+#      '*CoreOS*':
+#       tag: CIS-4.2.4
+#       function: check_directory_files_permission
+#       args:
+#        - /var/log
+#        - 740
+#       description: Ensure permissions on all logfiles are configured
   systemd_system_permission:
     data:
       '*CoreOS*':

--- a/hubblestack_nova_profiles/cis/debian-9-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/debian-9-level-1-scored-v1-0-0.yaml
@@ -1218,15 +1218,15 @@ misc:
         args:
           - rsyslog, syslog-ng
     description: Ensure rsyslog or syslog-ng is installed
-  check_log_files_permission:
-    data:
-      Debian*9:
-       tag: CIS-4.2.4
-       function: check_directory_files_permission
-       args:
-        - /var/log
-        - 740
-    description: Ensure permissions on all logfiles are configured
+#  check_log_files_permission:
+#    data:
+#      Debian*9:
+#       tag: CIS-4.2.4
+#       function: check_directory_files_permission
+#       args:
+#        - /var/log
+#        - 740
+#    description: Ensure permissions on all logfiles are configured
   system_account_non_login:
     data:
       Debian*9:

--- a/hubblestack_nova_profiles/cis/distribution-independent-linux-level-1-all-v1-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/distribution-independent-linux-level-1-all-v1-1-0.yaml
@@ -1252,15 +1252,15 @@ misc:
         tag: CIS-5.4.3
         function: default_group_for_root
     description: Ensure default group for the root account is GID 0
-  check_log_files_permission:
-    data:
-      '*':
-        tag: CIS-4.2.4
-        function: check_directory_files_permission
-        args:
-          - /var/log
-          - 740
-    description: Ensure permissions on all logfiles are configured
+#  check_log_files_permission:
+#    data:
+#      '*':
+#        tag: CIS-4.2.4
+#        function: check_directory_files_permission
+#        args:
+#          - /var/log
+#          - 740
+#    description: Ensure permissions on all logfiles are configured
   ensure_password_fields_non_empty:
     data:
       '*':

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-1-0.yaml
@@ -1182,15 +1182,15 @@ misc:
        args:
          - rsyslog, syslog-ng
     description: Ensure rsyslog or syslog-ng is installed
-  check_log_files_permission:
-    data:
-      Red Hat Enterprise Linux Server-7:
-       tag: CIS-4.2.4
-       function: check_directory_files_permission
-       args:
-        - /var/log
-        - 740
-    description: Ensure permissions on all logfiles are configured
+#  check_log_files_permission:
+#    data:
+#      Red Hat Enterprise Linux Server-7:
+#       tag: CIS-4.2.4
+#       function: check_directory_files_permission
+#       args:
+#        - /var/log
+#        - 740
+#    description: Ensure permissions on all logfiles are configured
   sshd_approved_macs:
     data:
       Red Hat Enterprise Linux Server-7:

--- a/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/rhels-7-level-1-scored-v2-2-0.yaml
@@ -1248,15 +1248,15 @@ misc:
        args:
          - rsyslog, syslog-ng
     description: Ensure rsyslog or syslog-ng is installed
-  check_log_files_permission:
-    data:
-      Red Hat Enterprise Linux Server-7:
-       tag: CIS-4.2.4
-       function: check_directory_files_permission
-       args:
-        - /var/log
-        - 740
-    description: Ensure permissions on all logfiles are configured
+#  check_log_files_permission:
+#    data:
+#      Red Hat Enterprise Linux Server-7:
+#       tag: CIS-4.2.4
+#       function: check_directory_files_permission
+#       args:
+#        - /var/log
+#        - 740
+#    description: Ensure permissions on all logfiles are configured
   sshd_approved_macs:
     data:
       Red Hat Enterprise Linux Server-7:

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-0-0.yaml
@@ -1158,15 +1158,15 @@ misc:
         tag: CIS-1.1.20
         function: sticky_bit_on_world_writable_dirs
     description: Ensure sticky bit is set on all world-writable directories
-  check_log_files_permission:
-    data:
-      Ubuntu-16.04:
-       tag: CIS-4.2.4
-       function: check_directory_files_permission
-       args:
-        - /var/log
-        - 740
-    description: Ensure permissions on all logfiles are configured
+#  check_log_files_permission:
+#    data:
+#      Ubuntu-16.04:
+#       tag: CIS-4.2.4
+#       function: check_directory_files_permission
+#       args:
+#        - /var/log
+#        - 740
+#    description: Ensure permissions on all logfiles are configured
   system_account_non_login:
     data:
       Ubuntu-16.04:

--- a/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-1-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1604-level-1-scored-v1-1-0.yaml
@@ -1159,15 +1159,15 @@ stat:
           user: root
     description: 'Ensure permissions on /etc/gshadow- are configured'
 misc:
-  check_log_files_permission:
-    data:
-      Ubuntu-16.04:
-       tag: CIS-4.2.4
-       function: check_directory_files_permission
-       args:
-        - /var/log
-        - 740
-    description: Ensure permissions on all logfiles are configured
+#  check_log_files_permission:
+#    data:
+#      Ubuntu-16.04:
+#       tag: CIS-4.2.4
+#       function: check_directory_files_permission
+#       args:
+#        - /var/log
+#        - 740
+#    description: Ensure permissions on all logfiles are configured
   system_account_non_login:
     data:
       Ubuntu-16.04:

--- a/hubblestack_nova_profiles/cis/ubuntu-1804-level-1-scored-v1-0-0.yaml
+++ b/hubblestack_nova_profiles/cis/ubuntu-1804-level-1-scored-v1-0-0.yaml
@@ -1199,15 +1199,15 @@ stat:
           user: root
     description: 'Ensure permissions on /etc/gshadow- are configured'
 misc:
-  check_log_files_permission:
-    data:
-      Ubuntu-18.04:
-       tag: CIS-4.2.4
-       function: check_directory_files_permission
-       args:
-        - /var/log
-        - 740
-    description: Ensure permissions on all logfiles are configured
+#  check_log_files_permission:
+#    data:
+#      Ubuntu-18.04:
+#       tag: CIS-4.2.4
+#       function: check_directory_files_permission
+#       args:
+#        - /var/log
+#        - 740
+#    description: Ensure permissions on all logfiles are configured
   system_account_non_login:
     data:
       Ubuntu-18.04:


### PR DESCRIPTION
This has had some edge case issues -- if you have many files under
/var/log then this `find` command can hobble your system. We need to
find a more safe way to do this check.