### PR TITLE
CIS 1.4.1 updated to match benchmark

### DIFF
--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-2-0.yaml
@@ -893,13 +893,21 @@ stat:
   grub_conf_own_perm:
     data:
       CentOS Linux-7:
-      - /etc/grub2.cfg:
+      - /boot/grub2/grub.cfg:
           gid: 0
           group: root
           mode: 600
           tag: CIS-1.4.1
           uid: 0
           user: root
+      - /boot/grub2/user.cfg:
+          gid: 0
+          group: root
+          mode: 600
+          tag: CIS-1.4.1
+          uid: 0
+          user: root
+          match_on_file_missing: True
     description: Ensure permissions on bootloader config are configured
   hosts_allow:
     data:


### PR DESCRIPTION
/etc/grub2.cfg is a symlink to /boot/grub2/grub.cfg because symlinks are always 777 checking the /etc/grub2.cfg will always fail. The CIS documentation is looking for permission on /boot/grub2/grub.cfg and /boot/grub2/user.cfg (if user.cfg exists).