### PR TITLE
/etc/gshadow should not have mode 000

### DIFF
--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-2-0.yaml
@@ -840,7 +840,7 @@ stat:
       - /etc/gshadow:
           gid: 0
           group: root
-          mode: '000'
+          mode: '600'
           tag: CIS-6.1.5
           uid: 0
           user: root
@@ -885,7 +885,7 @@ stat:
       - /etc/gshadow-:
           gid: 0
           group: root
-          mode: '000'
+          mode: '600'
           tag: CIS-6.1.9
           uid: 0
           user: root


### PR DESCRIPTION
Mudit found this. I'd have never noticed it myself. I set the PR against master because develop seems to be behind by a score of months and my patch was against master... I think this is a relatively low priority so I'll fix it later based on advices.